### PR TITLE
tweaks & bugfixes

### DIFF
--- a/internal/adapter/converter/openai_converter.go
+++ b/internal/adapter/converter/openai_converter.go
@@ -48,8 +48,16 @@ func (c *OpenAIConverter) ConvertToFormat(models []*domain.UnifiedModel, filters
 }
 
 func (c *OpenAIConverter) convertModel(model *domain.UnifiedModel) OpenAIModelData {
+	// OLLA-85: [Unification] Models with different digests fail to unify correctly.
+	// we need to use first alas as ID for routing compatibility
+	// to make sure the returned model ID can be used for requests
+	modelID := model.ID
+	if len(model.Aliases) > 0 {
+		modelID = model.Aliases[0].Name
+	}
+
 	return OpenAIModelData{
-		ID:      model.ID,
+		ID:      modelID,
 		Object:  "model",
 		Created: time.Now().Unix(),
 		OwnedBy: "olla",

--- a/internal/adapter/converter/openai_converter_test.go
+++ b/internal/adapter/converter/openai_converter_test.go
@@ -89,6 +89,6 @@ func TestOpenAIConverter_ConvertToFormat(t *testing.T) {
 		response, ok := result.(OpenAIModelResponse)
 		require.True(t, ok)
 		assert.Len(t, response.Data, 1)
-		assert.Equal(t, "phi/4:14.7b-q4km", response.Data[0].ID)
+		assert.Equal(t, "phi4:latest", response.Data[0].ID)
 	})
 }

--- a/internal/adapter/converter/unified_converter.go
+++ b/internal/adapter/converter/unified_converter.go
@@ -75,9 +75,16 @@ func (c *UnifiedConverter) convertModel(model *domain.UnifiedModel) UnifiedModel
 			State:    ep.State,
 		})
 	}
+	// OLLA-85: [Unification] Models with different digests fail to unify correctly.
+	// we need to use first alas as ID for routing compatibility
+	// to make sure the returned model ID can be used for requests
+	modelID := model.ID
+	if len(model.Aliases) > 0 {
+		modelID = model.Aliases[0].Name
+	}
 
 	return UnifiedModelData{
-		ID:      model.ID,
+		ID:      modelID,
 		Object:  "model",
 		Created: time.Now().Unix(),
 		OwnedBy: "olla",

--- a/internal/adapter/converter/unified_converter_test.go
+++ b/internal/adapter/converter/unified_converter_test.go
@@ -84,8 +84,8 @@ func TestUnifiedConverter_ConvertToFormat(t *testing.T) {
 		assert.Equal(t, "list", response.Object)
 		assert.Len(t, response.Data, 2)
 
-		// Check first model
-		assert.Equal(t, "llama/3:70b-q4km", response.Data[0].ID)
+		// Check first model - ID should be first alias for routing compatibility
+		assert.Equal(t, "llama3:latest", response.Data[0].ID)
 		assert.Equal(t, "model", response.Data[0].Object)
 		assert.Equal(t, "olla", response.Data[0].OwnedBy)
 		assert.NotNil(t, response.Data[0].Olla)
@@ -112,7 +112,7 @@ func TestUnifiedConverter_ConvertToFormat(t *testing.T) {
 		response, ok := result.(UnifiedModelResponse)
 		require.True(t, ok)
 		assert.Len(t, response.Data, 1)
-		assert.Equal(t, "phi/4:14.7b-q4km", response.Data[0].ID)
+		assert.Equal(t, "phi4:latest", response.Data[0].ID)
 	})
 
 	t.Run("filter by availability", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestUnifiedConverter_ConvertToFormat(t *testing.T) {
 		response, ok := result.(UnifiedModelResponse)
 		require.True(t, ok)
 		assert.Len(t, response.Data, 1)
-		assert.Equal(t, "phi/4:14.7b-q4km", response.Data[0].ID)
+		assert.Equal(t, "phi4:latest", response.Data[0].ID)
 	})
 
 	t.Run("filter by type", func(t *testing.T) {

--- a/internal/adapter/discovery/errors_test.go
+++ b/internal/adapter/discovery/errors_test.go
@@ -1,0 +1,98 @@
+package discovery
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGetUserFriendlyMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name: "network error with connectex",
+			err: NewDiscoveryError(
+				"http://192.168.0.113:11434",
+				"ollama",
+				"http_request",
+				0,
+				1*time.Millisecond,
+				&NetworkError{
+					URL: "http://192.168.0.113:11434/api/tags",
+					Err: errors.New("dial tcp 192.168.0.113:11434: connectex: A socket operation was attempted to an unreachable host."),
+				},
+			),
+			expected: "endpoint unreachable",
+		},
+		{
+			name: "http 404 error",
+			err: NewDiscoveryError(
+				"http://localhost:11434",
+				"ollama",
+				"http_status",
+				404,
+				2*time.Millisecond,
+				errors.New("HTTP 404: Not Found"),
+			),
+			expected: "endpoint configuration issue (HTTP 404)",
+		},
+		{
+			name: "http 500 error",
+			err: NewDiscoveryError(
+				"http://localhost:11434",
+				"ollama",
+				"http_status",
+				500,
+				2*time.Millisecond,
+				errors.New("HTTP 500: Internal Server Error"),
+			),
+			expected: "endpoint server error (HTTP 500)",
+		},
+		{
+			name: "timeout error",
+			err: NewDiscoveryError(
+				"http://localhost:11434",
+				"ollama",
+				"http_request",
+				0,
+				5*time.Second,
+				errors.New("context deadline exceeded"),
+			),
+			expected: "connection timeout",
+		},
+		{
+			name: "parse error",
+			err: &ParseError{
+				Err:    errors.New("invalid character"),
+				Format: "json",
+				Data:   []byte("invalid json"),
+			},
+			expected: "invalid response format",
+		},
+		{
+			name: "generic network error",
+			err: &NetworkError{
+				URL: "http://test.com",
+				Err: errors.New("some network issue"),
+			},
+			expected: "network connection failed",
+		},
+		{
+			name:     "unknown error",
+			err:      errors.New("some unknown error"),
+			expected: "discovery failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetUserFriendlyMessage(tt.err)
+			if result != tt.expected {
+				t.Errorf("GetUserFriendlyMessage() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/adapter/proxy/sherpa/service.go
+++ b/internal/adapter/proxy/sherpa/service.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/thushan/olla/internal/adapter/proxy/common"
 	"github.com/thushan/olla/internal/adapter/proxy/core"
+	"github.com/thushan/olla/internal/app/middleware"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 	"github.com/thushan/olla/internal/logger"
@@ -211,15 +212,32 @@ func (s *Service) ProxyRequestToEndpoints(ctx context.Context, w http.ResponseWr
 
 	s.IncrementRequests()
 
-	rlog.Debug("proxy request started", "method", r.Method, "url", r.URL.String())
+	// Use context logger if available, fallback to provided logger
+	ctxLogger := middleware.GetLogger(ctx)
+	if ctxLogger != nil {
+		ctxLogger.Debug("Sherpa proxy request started",
+			"method", r.Method,
+			"url", r.URL.String(),
+			"endpoint_count", len(endpoints))
+	} else {
+		rlog.Debug("proxy request started", "method", r.Method, "url", r.URL.String())
+	}
 
 	if len(endpoints) == 0 {
-		rlog.Error("no healthy endpoints available")
+		if ctxLogger != nil {
+			ctxLogger.Error("No healthy endpoints available for request")
+		} else {
+			rlog.Error("no healthy endpoints available")
+		}
 		s.RecordFailure(ctx, nil, time.Since(stats.StartTime), common.ErrNoHealthyEndpoints)
 		return common.ErrNoHealthyEndpoints
 	}
 
-	rlog.Debug("using provided endpoints", "count", len(endpoints))
+	if ctxLogger != nil {
+		ctxLogger.Debug("Using provided endpoints", "count", len(endpoints))
+	} else {
+		rlog.Debug("using provided endpoints", "count", len(endpoints))
+	}
 
 	// Select endpoint
 	startSelect := time.Now()
@@ -234,7 +252,15 @@ func (s *Service) ProxyRequestToEndpoints(ctx context.Context, w http.ResponseWr
 
 	stats.EndpointName = endpoint.Name
 
-	rlog.Info("Request dispatching to endpoint", "endpoint", endpoint.Name, "target", stats.TargetUrl, "model", stats.Model)
+	if ctxLogger != nil {
+		ctxLogger.Info("Request dispatching to endpoint",
+			"endpoint", endpoint.Name,
+			"target", stats.TargetUrl,
+			"model", stats.Model,
+			"request_id", middleware.GetRequestID(ctx))
+	} else {
+		rlog.Info("Request dispatching to endpoint", "endpoint", endpoint.Name, "target", stats.TargetUrl, "model", stats.Model)
+	}
 
 	s.Selector.IncrementConnections(endpoint)
 	defer s.Selector.DecrementConnections(endpoint)
@@ -336,17 +362,33 @@ func (s *Service) ProxyRequestToEndpoints(ctx context.Context, w http.ResponseWr
 	stats.TotalBytes = bytesWritten
 
 	// Log detailed completion metrics
-	rlog.Debug("proxy request completed",
-		"endpoint", endpoint.Name,
-		"latency_ms", stats.Latency,
-		"processing_ms", stats.RequestProcessingMs,
-		"backend_ms", stats.BackendResponseMs,
-		"first_data_ms", stats.FirstDataMs,
-		"streaming_ms", stats.StreamingMs,
-		"selection_ms", stats.SelectionMs,
-		"header_ms", stats.HeaderProcessingMs,
-		"total_bytes", stats.TotalBytes,
-		"status", resp.StatusCode)
+	if ctxLogger != nil {
+		ctxLogger.Info("Sherpa proxy request completed",
+			"endpoint", endpoint.Name,
+			"latency_ms", stats.Latency,
+			"processing_ms", stats.RequestProcessingMs,
+			"backend_ms", stats.BackendResponseMs,
+			"first_data_ms", stats.FirstDataMs,
+			"streaming_ms", stats.StreamingMs,
+			"selection_ms", stats.SelectionMs,
+			"header_ms", stats.HeaderProcessingMs,
+			"total_bytes", stats.TotalBytes,
+			"bytes_formatted", middleware.FormatBytes(int64(stats.TotalBytes)),
+			"status", resp.StatusCode,
+			"request_id", middleware.GetRequestID(ctx))
+	} else {
+		rlog.Debug("proxy request completed",
+			"endpoint", endpoint.Name,
+			"latency_ms", stats.Latency,
+			"processing_ms", stats.RequestProcessingMs,
+			"backend_ms", stats.BackendResponseMs,
+			"first_data_ms", stats.FirstDataMs,
+			"streaming_ms", stats.StreamingMs,
+			"selection_ms", stats.SelectionMs,
+			"header_ms", stats.HeaderProcessingMs,
+			"total_bytes", stats.TotalBytes,
+			"status", resp.StatusCode)
+	}
 
 	return nil
 }

--- a/internal/app/middleware/logging.go
+++ b/internal/app/middleware/logging.go
@@ -2,12 +2,12 @@ package middleware
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/thushan/olla/internal/util"
 
 	"github.com/thushan/olla/internal/logger"
 )
@@ -38,13 +38,6 @@ func (rw *responseWriter) WriteHeader(s int) {
 	rw.ResponseWriter.WriteHeader(s)
 }
 
-// generateRequestID creates a unique request ID
-func generateRequestID() string {
-	bytes := make([]byte, 8)
-	rand.Read(bytes)
-	return hex.EncodeToString(bytes)
-}
-
 // GetLogger retrieves a logger with request ID from context
 func GetLogger(ctx context.Context) *slog.Logger {
 	if logger, ok := ctx.Value(LoggerKey).(*slog.Logger); ok {
@@ -70,7 +63,7 @@ func EnhancedLoggingMiddleware(styledLogger logger.StyledLogger) func(http.Handl
 			// Get or create request ID
 			requestID := r.Header.Get("X-Request-ID")
 			if requestID == "" {
-				requestID = generateRequestID()
+				requestID = util.GenerateRequestID()
 			}
 
 			// Calculate request size
@@ -128,7 +121,7 @@ func AccessLoggingMiddleware(styledLogger logger.StyledLogger) func(http.Handler
 			// Use existing request ID from context or create one
 			requestID := GetRequestID(r.Context())
 			if requestID == "" {
-				requestID = generateRequestID()
+				requestID = util.GenerateRequestID()
 				ctx := context.WithValue(r.Context(), RequestIDKey, requestID)
 				r = r.WithContext(ctx)
 			}

--- a/internal/app/middleware/logging_test.go
+++ b/internal/app/middleware/logging_test.go
@@ -1,0 +1,178 @@
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/logger"
+)
+
+func TestEnhancedLoggingMiddleware(t *testing.T) {
+	// Create a mock styled logger
+	mockLogger := &mockStyledLogger{}
+
+	// Create a test handler that uses the context logger
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Test that we can get the logger from context
+		ctxLogger := GetLogger(r.Context())
+		if ctxLogger == nil {
+			t.Error("Expected context logger to be available")
+			return
+		}
+
+		// Test that we can get the request ID from context
+		requestID := GetRequestID(r.Context())
+		if requestID == "" {
+			t.Error("Expected request ID to be available")
+			return
+		}
+
+		// Log something with the context logger
+		ctxLogger.Info("Test handler executed", "request_id", requestID)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test response"))
+	})
+
+	// Create the middleware
+	middleware := EnhancedLoggingMiddleware(mockLogger)
+	handler := middleware(testHandler)
+
+	// Create a test request
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Request-ID", "test-request-123")
+
+	// Create a response recorder
+	rr := httptest.NewRecorder()
+
+	// Execute the request
+	handler.ServeHTTP(rr, req)
+
+	// Verify response
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rr.Code)
+	}
+
+	// Verify that the request ID header was set
+	responseRequestID := rr.Header().Get("X-Olla-Request-ID")
+	if responseRequestID != "test-request-123" {
+		t.Errorf("Expected X-Olla-Request-ID header to be 'test-request-123', got '%s'", responseRequestID)
+	}
+
+	// Verify response body
+	expectedBody := "test response"
+	if rr.Body.String() != expectedBody {
+		t.Errorf("Expected body %q, got %q", expectedBody, rr.Body.String())
+	}
+}
+
+func TestAccessLoggingMiddleware(t *testing.T) {
+	// Create a mock styled logger
+	mockLogger := &mockStyledLogger{}
+
+	// Create a simple test handler
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("access log test"))
+	})
+
+	// Create the middleware
+	middleware := AccessLoggingMiddleware(mockLogger)
+	handler := middleware(testHandler)
+
+	// Create a test request
+	req := httptest.NewRequest("POST", "/api/test?param=value", strings.NewReader("test body"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "test-agent")
+	req.ContentLength = 9 // length of "test body"
+
+	// Create a response recorder
+	rr := httptest.NewRecorder()
+
+	// Execute the request
+	handler.ServeHTTP(rr, req)
+
+	// Verify response
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rr.Code)
+	}
+
+	expectedBody := "access log test"
+	if rr.Body.String() != expectedBody {
+		t.Errorf("Expected body %q, got %q", expectedBody, rr.Body.String())
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input    int64
+		expected string
+	}{
+		{0, "0B"},
+		{500, "500B"},
+		{1024, "1.0KB"},
+		{1536, "1.5KB"},
+		{1048576, "1.0MB"},
+		{1073741824, "1.0GB"},
+		{1099511627776, "1.0TB"},
+	}
+
+	for _, test := range tests {
+		result := FormatBytes(test.input)
+		if result != test.expected {
+			t.Errorf("FormatBytes(%d) = %s, want %s", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestGetLoggerWithoutContext(t *testing.T) {
+	ctx := context.Background()
+	logger := GetLogger(ctx)
+
+	// Should return the default logger when no logger is in context
+	if logger == nil {
+		t.Error("Expected default logger when no logger in context")
+	}
+}
+
+func TestGetRequestIDWithoutContext(t *testing.T) {
+	ctx := context.Background()
+	requestID := GetRequestID(ctx)
+
+	// Should return empty string when no request ID in context
+	if requestID != "" {
+		t.Errorf("Expected empty request ID when not in context, got %s", requestID)
+	}
+}
+
+// Mock styled logger for testing
+type mockStyledLogger struct{}
+
+func (m *mockStyledLogger) Debug(msg string, args ...any)                                {}
+func (m *mockStyledLogger) Info(msg string, args ...any)                                 {}
+func (m *mockStyledLogger) Warn(msg string, args ...any)                                 {}
+func (m *mockStyledLogger) Error(msg string, args ...any)                                {}
+func (m *mockStyledLogger) ResetLine()                                                   {}
+func (m *mockStyledLogger) InfoWithStatus(msg string, status string, args ...any)        {}
+func (m *mockStyledLogger) InfoWithCount(msg string, count int, args ...any)             {}
+func (m *mockStyledLogger) InfoWithEndpoint(msg string, endpoint string, args ...any)    {}
+func (m *mockStyledLogger) InfoWithHealthCheck(msg string, endpoint string, args ...any) {}
+func (m *mockStyledLogger) InfoWithNumbers(msg string, numbers ...int64)                 {}
+func (m *mockStyledLogger) WarnWithEndpoint(msg string, endpoint string, args ...any)    {}
+func (m *mockStyledLogger) ErrorWithEndpoint(msg string, endpoint string, args ...any)   {}
+func (m *mockStyledLogger) InfoHealthy(msg string, endpoint string, args ...any)         {}
+func (m *mockStyledLogger) InfoHealthStatus(msg string, name string, status domain.EndpointStatus, args ...any) {
+}
+func (m *mockStyledLogger) GetUnderlying() *slog.Logger                                         { return slog.Default() }
+func (m *mockStyledLogger) WithRequestID(requestID string) logger.StyledLogger                  { return m }
+func (m *mockStyledLogger) InfoConfigChange(oldName, newName string)                            {}
+func (m *mockStyledLogger) WithAttrs(attrs ...slog.Attr) logger.StyledLogger                    { return m }
+func (m *mockStyledLogger) With(args ...any) logger.StyledLogger                                { return m }
+func (m *mockStyledLogger) InfoWithContext(msg string, endpoint string, ctx logger.LogContext)  {}
+func (m *mockStyledLogger) WarnWithContext(msg string, endpoint string, ctx logger.LogContext)  {}
+func (m *mockStyledLogger) ErrorWithContext(msg string, endpoint string, ctx logger.LogContext) {}

--- a/internal/app/services/http.go
+++ b/internal/app/services/http.go
@@ -3,9 +3,10 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/thushan/olla/internal/util"
 	"net/http"
 	"time"
+
+	"github.com/thushan/olla/internal/util"
 
 	"github.com/thushan/olla/internal/app/handlers"
 	"github.com/thushan/olla/internal/config"

--- a/internal/app/services/http.go
+++ b/internal/app/services/http.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"github.com/thushan/olla/internal/util"
 	"net/http"
 	"time"
 
@@ -55,6 +56,10 @@ func (s *HTTPService) Name() string {
 // Start initialises and starts the HTTP server
 func (s *HTTPService) Start(ctx context.Context) error {
 	s.logger.Info("Initialising HTTP service")
+
+	if !util.IsPortAvailable(s.config.Host, s.config.Port) {
+		return fmt.Errorf("port %d is already in use on host %s", s.config.Port, s.config.Host)
+	}
 
 	// Resolve service dependencies now that all services are started
 	if s.statsService != nil {

--- a/internal/util/network.go
+++ b/internal/util/network.go
@@ -47,3 +47,13 @@ func NormaliseBaseURL(baseURL string) string {
 	}
 	return baseURL
 }
+
+// IsPortAvailable checks if a port is available by attempting to bind to it
+func IsPortAvailable(host string, port int) bool {
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	if err != nil {
+		return false
+	}
+	defer listener.Close()
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -39,11 +39,14 @@ const (
 var (
 	enableProfiling bool
 	showVersion     bool
+	configFile      string
 )
 
 func init() {
 	flag.BoolVar(&enableProfiling, "profile", false, "Enable pprof profiling server")
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
+	flag.StringVar(&configFile, "c", "", "Config file path")
+	flag.StringVar(&configFile, "config", "", "Config file path")
 
 	flag.Parse()
 
@@ -99,7 +102,7 @@ func main() {
 	}()
 
 	// Load configuration
-	cfg, err := config.Load()
+	cfg, err := config.Load(configFile)
 	if err != nil {
 		logger.FatalWithLogger(logInstance, "Failed to load configuration", "error", err)
 	}


### PR DESCRIPTION
This PR does some maintenance work:

- Added a new CLI flag (`-c` or `--config` so you can pass in a config file),
- Check on  startup if port is in use and bail if it is (especially problematic in Windows it seems)
- adds better logging with context-aware (`requestid` etc)
- Friendlier error  messages for discovery, similarly styled to Proxy now.

One important bugfix was to resolve model unification when the same model differs on servers (by digest). This is usually when a model is updated on one but not the other, we would get things like:

* `hf.co/unsloth/Qwen3-32B-GGUF:Q4_K_XL-75fb8ad3`
* `qwen3:32b-8ade7840`

And automation tools (mostly our suite) would fail to query those because they  dont exist - aren't routable. They now use the id properly.

* `hf.co/unsloth/Qwen3-32B-GGUF:Q4_K_XL`
* `qwen3:32b`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

**New Features**
  * Added command-line flags to specify a custom configuration file.
  * Enhanced HTTP service startup to check for port availability and prevent conflicts.
  * Introduced user-friendly error messages for discovery-related issues.
  * Integrated enhanced and access logging middleware for structured request logging.
  * Improved context-aware logging throughout proxy and discovery services.

**Improvements**
  * Model IDs now use the first alias for better routing compatibility and consistency.
  * Configuration loading now prioritises command-line flags, then environment variables, then defaults.
  * Security and rate limiting middleware chains now include enhanced and access logging layers.

**Bug Fixes**
  * Updated tests to reflect changes in model ID handling and logging behaviour.

**Tests**
  * Added comprehensive unit tests for new logging middleware and user-friendly error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->