### PR TITLE
fix: clean logs and tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 out/
 bin/
 report/
+debug/
 logs/
 tmp/
 *.exe
@@ -26,3 +27,4 @@ config.yaml
 .claude/*.local.json
 # just in case
 *.local.json
+*.log

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,11 +1,11 @@
 # Olla Configuration (default)
 server:
-  host: "localhost"
-  port: 40114
+  host: "localhost" # Use 0.0.0.0 to bind to all interfaces (so it's accessible externally)
+  port: 40114 # default port for Olla - 4-OLLA
   read_timeout: 20s
   write_timeout: 0s # for LLMs streaming, leave this as 0s
-  shutdown_timeout: 10s
-  request_logging: true
+  shutdown_timeout: 10s # Graceful shutdown timeout, increase this for heavy sites that have long-running requests or lots of endpoints (30s is a good)
+  request_logging: true # logs Http Requests, may be useful for debugging, noise for other use cases
   request_limits:
     max_body_size: 52428800  # 50MB
     max_header_size: 524288  # 512KB
@@ -27,9 +27,9 @@ server:
 
 proxy:
   engine: "sherpa" # Available: sherpa, olla
-  connection_timeout: 40s
+  connection_timeout: 60s
   response_timeout: 900s
-  read_timeout: 300s
+  read_timeout: 600s
   max_retries: 3
   retry_backoff: 500ms
   load_balancer: "least-connections" # Available: round-robin, least-connections, priority

--- a/examples/ollama-openwebui/compose.yaml
+++ b/examples/ollama-openwebui/compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
       # Overide the default with our custom configuration
       - ./olla.yaml:/app/config.yaml:ro
-      - ./.container/olla/logs:/app/logs:ro
+      - ./.container/olla/logs:/app/logs
     healthcheck:
         test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:40114/internal/health"]
         timeout: 5s

--- a/internal/adapter/health/checker.go
+++ b/internal/adapter/health/checker.go
@@ -431,7 +431,7 @@ func (c *HTTPHealthChecker) logEndpointsTable(endpoints []*domain.Endpoint) {
 
 	// Build table
 	tableData := make([][]string, 0, len(entries)+1)
-	tableData = append(tableData, []string{"PRIORITY", "NAME", "TYPE", "URL", "HEALTH", "CHECK", "TIMEOUT"})
+	tableData = append(tableData, []string{"PRI", "NAME", "TYPE", "URL", "HEALTH", "CHECK", "TIMEOUT"})
 
 	for _, entry := range entries {
 		tableData = append(tableData, []string{

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1,0 +1,36 @@
+package container
+
+import (
+	"os"
+	"strings"
+)
+
+// IsContainerised returns true if the current process is likely running inside a container.
+// it checks for common container signals like /.dockerenv, container-related cgroup entries,
+// and Kubernetes environment variables.
+func IsContainerised() bool {
+	return hasDockerEnvFile() || isInContainerCGroup() || isInKubernetesPod()
+}
+
+// hasDockerEnvFile checks if the /.dockerenv file exists, which _should be_ present in most Docker containers.
+func hasDockerEnvFile() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}
+
+// isInContainerCGroup checks for container-related strings in /proc/1/cgroup (e.g. docker, containerd, kubepods).
+func isInContainerCGroup() bool {
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+	content := string(data)
+	return strings.Contains(content, "docker") ||
+		strings.Contains(content, "containerd") ||
+		strings.Contains(content, "kubepods")
+}
+
+// isInKubernetesPod checks for Kubernetes-specific environment variable.
+func isInKubernetesPod() bool {
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != ""
+}


### PR DESCRIPTION
This PR fixes a few things for Olla.

- Cleans up the JSON structured log output (in `./logs/olla.log`) and strips ANSI bits
- docker compose example contained `ro` for log output by mistake
- shows cleanup time and uptime in shutdonw
- minor UI tweak for tables in pretty output
- adds a few more comments for default config
- shows system config during startup too


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for containerised environments, improving system awareness.
  * Enhanced startup and shutdown logs with detailed timing and environment information.

* **Bug Fixes**
  * Log files are now written without ANSI escape codes, ensuring clean and parseable JSON output.

* **Chores**
  * Updated ignored files to include debug directories and log files.
  * Increased proxy timeout values in configuration for improved reliability.
  * Changed container log volume to allow write access.
  * Improved clarity of configuration comments and shortened a table header in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->