### PR TITLE
feat: backend/vllm

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,6 +61,14 @@ discovery:
         health_check_url: "/"
         check_interval: 2s
         check_timeout: 1s
+      - url: "http://192.168.0.1:8000"
+        name: "local-vllm"
+        type: "vllm"
+        priority: 100
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
   model_discovery:
     enabled: true
     interval: 5m

--- a/config/profiles/vllm.yaml
+++ b/config/profiles/vllm.yaml
@@ -2,7 +2,7 @@
 name: vllm
 version: "1.0"
 display_name: "vLLM"
-description: "vLLM high-performance inference server"
+description: "vLLM high-performance inference server with PagedAttention"
 
 # Routing configuration
 routing:
@@ -13,12 +13,13 @@ routing:
 api:
   openai_compatible: true
   paths:
-    - /v1/models
-    - /v1/chat/completions
-    - /v1/completions
-    - /v1/embeddings
+    - /health          # 0: health check (vLLM-specific endpoint)
+    - /v1/models       # 1: list models
+    - /v1/chat/completions  # 2: chat completions
+    - /v1/completions  # 3: completions
+    - /v1/embeddings   # 4: embeddings
   model_discovery_path: /v1/models
-  health_check_path: /v1/models
+  health_check_path: /health
 
 # Platform characteristics
 characteristics:
@@ -31,14 +32,17 @@ characteristics:
 detection:
   path_indicators:
     - "/v1/models"
+    - "/health"
   default_ports:
     - 8000
+  response_headers:
+    - "X-vLLM-Version"  # vLLM may add this in future versions
 
 # Request/response handling
 request:
   model_field_paths:
     - "model"
-  response_format: "openai"
+  response_format: "vllm"
   parsing_rules:
     chat_completions_path: "/v1/chat/completions"
     completions_path: "/v1/completions"
@@ -48,16 +52,97 @@ request:
 # Path indices for specific functions
 path_indices:
   health: 0
-  models: 0
-  chat_completions: 1
-  completions: 2
-  embeddings: 3
+  models: 1
+  chat_completions: 2
+  completions: 3
+  embeddings: 4
 
-# Resource management - vLLM is optimized for high throughput
+# Model handling
+models:
+  name_format: "{{.Name}}"  # vLLM uses full model names like "meta-llama/Meta-Llama-3.1-8B-Instruct"
+  capability_patterns:
+    chat:
+      - "*-Chat-*"
+      - "*-Instruct*"
+      - "*-chat-*"
+    embeddings:
+      - "*embedding*"
+      - "*-embed-*"
+    vision:
+      - "*vision*"
+      - "*llava*"
+    code:
+      - "*code*"
+      - "*Code*"
+  # Context window patterns for common vLLM models
+  context_patterns:
+    - pattern: "*llama-3.1*"
+      context: 131072
+    - pattern: "*llama-3*"
+      context: 8192
+    - pattern: "*mistral*"
+      context: 32768
+    - pattern: "*mixtral*"
+      context: 32768
+    - pattern: "*gemma-2*"
+      context: 8192
+    - pattern: "*tinyllama*"
+      context: 2048
+
+# Resource management - vLLM is optimised for high throughput
 resources:
+  # Model size patterns for vLLM deployments
+  model_sizes:
+    - patterns: ["*70b*", "*72b*"]
+      min_memory_gb: 140  # vLLM requires more memory for KV cache
+      recommended_memory_gb: 160
+      min_gpu_memory_gb: 140
+      estimated_load_time_ms: 60000
+    - patterns: ["*34b*", "*33b*", "*30b*"]
+      min_memory_gb: 70
+      recommended_memory_gb: 80
+      min_gpu_memory_gb: 70
+      estimated_load_time_ms: 45000
+    - patterns: ["*13b*", "*14b*"]
+      min_memory_gb: 30
+      recommended_memory_gb: 40
+      min_gpu_memory_gb: 30
+      estimated_load_time_ms: 30000
+    - patterns: ["*7b*", "*8b*"]
+      min_memory_gb: 16
+      recommended_memory_gb: 24
+      min_gpu_memory_gb: 16
+      estimated_load_time_ms: 20000
+    - patterns: ["*3b*"]
+      min_memory_gb: 8
+      recommended_memory_gb: 12
+      min_gpu_memory_gb: 8
+      estimated_load_time_ms: 15000
+    - patterns: ["*1b*", "*1.1b*", "*1.5b*"]
+      min_memory_gb: 4
+      recommended_memory_gb: 8
+      min_gpu_memory_gb: 4
+      estimated_load_time_ms: 10000
+      
   defaults:
     min_memory_gb: 8
     recommended_memory_gb: 16
     min_gpu_memory_gb: 8
     requires_gpu: true
     estimated_load_time_ms: 30000
+    
+  # vLLM supports high concurrency with PagedAttention
+  concurrency_limits:
+    - min_memory_gb: 100  # 70B+ models
+      max_concurrent: 10
+    - min_memory_gb: 50   # 30B+ models
+      max_concurrent: 20
+    - min_memory_gb: 20   # 13B+ models
+      max_concurrent: 50
+    - min_memory_gb: 0    # smaller models
+      max_concurrent: 100
+      
+  # Timeout scaling for vLLM
+  timeout_scaling:
+    base_timeout_seconds: 120
+    load_time_buffer: true

--- a/internal/adapter/converter/factory.go
+++ b/internal/adapter/converter/factory.go
@@ -22,6 +22,7 @@ func NewConverterFactory() *ConverterFactory {
 	factory.RegisterConverter(NewOpenAIConverter())
 	factory.RegisterConverter(NewOllamaConverter())
 	factory.RegisterConverter(NewLMStudioConverter())
+	factory.RegisterConverter(NewVLLMConverter())
 
 	return factory
 }

--- a/internal/adapter/converter/factory_test.go
+++ b/internal/adapter/converter/factory_test.go
@@ -47,11 +47,12 @@ func TestConverterFactory(t *testing.T) {
 		assert.Contains(t, qpErr.Reason, "openai")
 		assert.Contains(t, qpErr.Reason, "ollama")
 		assert.Contains(t, qpErr.Reason, "lmstudio")
+		assert.Contains(t, qpErr.Reason, "vllm")
 	})
 
 	t.Run("GetSupportedFormats returns all formats", func(t *testing.T) {
 		formats := factory.GetSupportedFormats()
-		assert.Len(t, formats, 4)
+		assert.Len(t, formats, 5)
 
 		// Check all expected formats are present
 		formatMap := make(map[string]bool)
@@ -62,6 +63,7 @@ func TestConverterFactory(t *testing.T) {
 		assert.True(t, formatMap["unified"])
 		assert.True(t, formatMap["openai"])
 		assert.True(t, formatMap["ollama"])
+		assert.True(t, formatMap["vllm"])
 		assert.True(t, formatMap["lmstudio"])
 	})
 

--- a/internal/adapter/converter/lmstudio_converter.go
+++ b/internal/adapter/converter/lmstudio_converter.go
@@ -1,6 +1,7 @@
 package converter
 
 import (
+	"github.com/thushan/olla/internal/core/constants"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 )
@@ -32,7 +33,7 @@ func NewLMStudioConverter() ports.ModelResponseConverter {
 }
 
 func (c *LMStudioConverter) GetFormatName() string {
-	return "lmstudio"
+	return constants.ProviderPrefixLMStudio1
 }
 
 func (c *LMStudioConverter) ConvertToFormat(models []*domain.UnifiedModel, filters ports.ModelFilters) (interface{}, error) {
@@ -59,7 +60,7 @@ func (c *LMStudioConverter) convertModel(model *domain.UnifiedModel) *LMStudioMo
 
 	// First, look for an LM Studio source in aliases
 	for _, alias := range model.Aliases {
-		if alias.Source == "lmstudio" {
+		if alias.Source == constants.ProviderPrefixLMStudio1 {
 			lmstudioName = alias.Name
 			break
 		}

--- a/internal/adapter/converter/ollama_converter.go
+++ b/internal/adapter/converter/ollama_converter.go
@@ -3,6 +3,7 @@ package converter
 import (
 	"time"
 
+	"github.com/thushan/olla/internal/core/constants"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 )
@@ -38,7 +39,7 @@ func NewOllamaConverter() ports.ModelResponseConverter {
 }
 
 func (c *OllamaConverter) GetFormatName() string {
-	return "ollama"
+	return constants.ProviderTypeOllama
 }
 
 func (c *OllamaConverter) ConvertToFormat(models []*domain.UnifiedModel, filters ports.ModelFilters) (interface{}, error) {
@@ -65,7 +66,7 @@ func (c *OllamaConverter) convertModel(model *domain.UnifiedModel) *OllamaModelD
 
 	// First, look for an Ollama source in aliases
 	for _, alias := range model.Aliases {
-		if alias.Source == "ollama" {
+		if alias.Source == constants.ProviderTypeOllama {
 			ollamaName = alias.Name
 			break
 		}

--- a/internal/adapter/converter/vllm_converter.go
+++ b/internal/adapter/converter/vllm_converter.go
@@ -1,0 +1,147 @@
+package converter
+
+import (
+	"strings"
+	"time"
+
+	"github.com/thushan/olla/internal/core/constants"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+)
+
+// VLLMModelResponse represents the vLLM-specific format response
+type VLLMModelResponse struct {
+	Object string          `json:"object"`
+	Data   []VLLMModelData `json:"data"`
+}
+
+// VLLMModelData represents a single model in vLLM format with extended metadata
+type VLLMModelData struct {
+	MaxModelLen *int64                `json:"max_model_len,omitempty"` // vLLM-specific: maximum context length
+	Parent      *string               `json:"parent,omitempty"`        // vLLM-specific: parent model for fine-tuned models
+	ID          string                `json:"id"`
+	Object      string                `json:"object"`
+	OwnedBy     string                `json:"owned_by"`
+	Root        string                `json:"root,omitempty"`       // vLLM-specific: root model identifier
+	Permission  []VLLMModelPermission `json:"permission,omitempty"` // vLLM-specific: access permissions
+	Created     int64                 `json:"created"`
+}
+
+// VLLMModelPermission represents vLLM's granular permission system
+type VLLMModelPermission struct {
+	Group              *string `json:"group"`
+	ID                 string  `json:"id"`
+	Object             string  `json:"object"`
+	Organization       string  `json:"organization"`
+	Created            int64   `json:"created"`
+	AllowCreateEngine  bool    `json:"allow_create_engine"`
+	AllowSampling      bool    `json:"allow_sampling"`
+	AllowLogprobs      bool    `json:"allow_logprobs"`
+	AllowSearchIndices bool    `json:"allow_search_indices"`
+	AllowView          bool    `json:"allow_view"`
+	AllowFineTuning    bool    `json:"allow_fine_tuning"`
+	IsBlocking         bool    `json:"is_blocking"`
+}
+
+// VLLMConverter converts models to vLLM-compatible format with extended metadata
+type VLLMConverter struct{}
+
+// NewVLLMConverter creates a new vLLM format converter
+func NewVLLMConverter() ports.ModelResponseConverter {
+	return &VLLMConverter{}
+}
+
+func (c *VLLMConverter) GetFormatName() string {
+	return constants.ProviderTypeVLLM
+}
+
+func (c *VLLMConverter) ConvertToFormat(models []*domain.UnifiedModel, filters ports.ModelFilters) (interface{}, error) {
+	filtered := filterModels(models, filters)
+
+	data := make([]VLLMModelData, 0, len(filtered))
+	for _, model := range filtered {
+		vllmModel := c.convertModel(model)
+		if vllmModel != nil {
+			data = append(data, *vllmModel)
+		}
+	}
+
+	return VLLMModelResponse{
+		Object: "list",
+		Data:   data,
+	}, nil
+}
+
+func (c *VLLMConverter) convertModel(model *domain.UnifiedModel) *VLLMModelData {
+	// For vLLM, prefer the native vLLM name if available from source endpoints
+	modelID := c.findVLLMNativeName(model)
+	if modelID == "" {
+		// Fallback to first alias or unified ID
+		if len(model.Aliases) > 0 {
+			modelID = model.Aliases[0].Name
+		} else {
+			modelID = model.ID
+		}
+	}
+
+	vllmModel := &VLLMModelData{
+		ID:      modelID,
+		Object:  "model",
+		Created: time.Now().Unix(),
+		OwnedBy: c.determineOwner(modelID),
+		Root:    modelID, // vLLM typically sets root to the model ID
+	}
+
+	// Set max context length if available
+	if model.MaxContextLength != nil && *model.MaxContextLength > 0 {
+		vllmModel.MaxModelLen = model.MaxContextLength
+	}
+
+	// Generate default permissions that allow all operations
+	vllmModel.Permission = []VLLMModelPermission{
+		{
+			ID:                 "modelperm-olla-" + strings.ReplaceAll(modelID, "/", "-"),
+			Object:             "model_permission",
+			Created:            time.Now().Unix(),
+			AllowCreateEngine:  false, // Engine creation not applicable in proxy context
+			AllowSampling:      true,
+			AllowLogprobs:      true,
+			AllowSearchIndices: false,
+			AllowView:          true,
+			AllowFineTuning:    false,
+			Organization:       "*",
+			IsBlocking:         false,
+		},
+	}
+
+	return vllmModel
+}
+
+// findVLLMNativeName looks for the native vLLM name from source endpoints
+func (c *VLLMConverter) findVLLMNativeName(model *domain.UnifiedModel) string {
+	for _, endpoint := range model.SourceEndpoints {
+		// Check if this is from a vLLM endpoint based on the native name format
+		if strings.Contains(endpoint.NativeName, "/") {
+			// vLLM models typically use organisation/model-name format
+			return endpoint.NativeName
+		}
+	}
+
+	// Check aliases for vLLM source
+	for _, alias := range model.Aliases {
+		if alias.Source == constants.ProviderTypeVLLM {
+			return alias.Name
+		}
+	}
+
+	return ""
+}
+
+// determineOwner extracts the organisation from the model ID or defaults to "vllm"
+func (c *VLLMConverter) determineOwner(modelID string) string {
+	// vLLM models often follow organisation/model-name pattern
+	if parts := strings.SplitN(modelID, "/", 2); len(parts) == 2 {
+		return parts[0]
+	}
+	return constants.ProviderTypeVLLM
+}

--- a/internal/adapter/converter/vllm_converter_test.go
+++ b/internal/adapter/converter/vllm_converter_test.go
@@ -1,0 +1,289 @@
+package converter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+)
+
+func TestVLLMConverter_ConvertToFormat(t *testing.T) {
+	converter := NewVLLMConverter()
+
+	t.Run("converts unified models to vLLM format with extended metadata", func(t *testing.T) {
+		maxContext := int64(2048)
+		models := []*domain.UnifiedModel{
+			{
+				ID:               "tinyllama/1.1b:chat-v1.0",
+				Family:           "tinyllama",
+				Variant:          "1.1b",
+				ParameterSize:    "1.1b",
+				ParameterCount:   1100000000,
+				Format:           "safetensors",
+				MaxContextLength: &maxContext,
+				Aliases: []domain.AliasEntry{
+					{Name: "TinyLlama/TinyLlama-1.1B-Chat-v1.0", Source: "vllm"},
+				},
+				SourceEndpoints: []domain.SourceEndpoint{
+					{
+						EndpointURL:  "http://192.168.0.1:8000",
+						EndpointName: "vllm-server",
+						NativeName:   "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+						State:        "loaded",
+					},
+				},
+				Capabilities: []string{"chat"},
+			},
+			{
+				ID:               "llama/3.1:8b-instruct",
+				Family:           "llama",
+				Variant:          "3.1",
+				ParameterSize:    "8b",
+				ParameterCount:   8000000000,
+				Format:           "safetensors",
+				MaxContextLength: &[]int64{131072}[0],
+				Aliases: []domain.AliasEntry{
+					{Name: "meta-llama/Meta-Llama-3.1-8B-Instruct", Source: "vllm"},
+				},
+				SourceEndpoints: []domain.SourceEndpoint{
+					{
+						EndpointURL:  "http://192.168.0.1:8000",
+						EndpointName: "vllm-server",
+						NativeName:   "meta-llama/Meta-Llama-3.1-8B-Instruct",
+						State:        "available",
+					},
+				},
+				Capabilities: []string{"chat", "completion"},
+			},
+		}
+
+		filters := ports.ModelFilters{}
+		result, err := converter.ConvertToFormat(models, filters)
+		require.NoError(t, err)
+
+		response, ok := result.(VLLMModelResponse)
+		require.True(t, ok)
+		assert.Equal(t, "list", response.Object)
+		assert.Len(t, response.Data, 2)
+
+		// Check first model (TinyLlama)
+		tinyllama := response.Data[0]
+		assert.Equal(t, "TinyLlama/TinyLlama-1.1B-Chat-v1.0", tinyllama.ID)
+		assert.Equal(t, "model", tinyllama.Object)
+		assert.Equal(t, "TinyLlama", tinyllama.OwnedBy)
+		assert.Equal(t, "TinyLlama/TinyLlama-1.1B-Chat-v1.0", tinyllama.Root)
+		assert.NotNil(t, tinyllama.MaxModelLen)
+		assert.Equal(t, int64(2048), *tinyllama.MaxModelLen)
+
+		// Check permissions are generated
+		require.Len(t, tinyllama.Permission, 1)
+		perm := tinyllama.Permission[0]
+		assert.Equal(t, "model_permission", perm.Object)
+		assert.True(t, perm.AllowSampling)
+		assert.True(t, perm.AllowLogprobs)
+		assert.True(t, perm.AllowView)
+		assert.Equal(t, "*", perm.Organization)
+		assert.False(t, perm.IsBlocking)
+
+		// Check second model (Llama 3.1)
+		llama := response.Data[1]
+		assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct", llama.ID)
+		assert.Equal(t, "meta-llama", llama.OwnedBy)
+		assert.NotNil(t, llama.MaxModelLen)
+		assert.Equal(t, int64(131072), *llama.MaxModelLen)
+	})
+
+	t.Run("handles models without vLLM native names", func(t *testing.T) {
+		models := []*domain.UnifiedModel{
+			{
+				ID:             "phi/4:14.7b-q4km",
+				Family:         "phi",
+				Variant:        "4",
+				ParameterSize:  "14.7b",
+				ParameterCount: 14700000000,
+				Format:         "gguf",
+				Aliases: []domain.AliasEntry{
+					{Name: "phi4:latest", Source: "ollama"},
+				},
+				SourceEndpoints: []domain.SourceEndpoint{
+					{
+						EndpointURL: "http://localhost:11434",
+						NativeName:  "phi4:latest",
+						State:       "loaded",
+					},
+				},
+			},
+		}
+
+		filters := ports.ModelFilters{}
+		result, err := converter.ConvertToFormat(models, filters)
+		require.NoError(t, err)
+
+		response, ok := result.(VLLMModelResponse)
+		require.True(t, ok)
+		assert.Len(t, response.Data, 1)
+
+		// Should use first alias when no vLLM native name exists
+		model := response.Data[0]
+		assert.Equal(t, "phi4:latest", model.ID)
+		assert.Equal(t, "vllm", model.OwnedBy) // Default owner when no org in name
+		assert.Nil(t, model.MaxModelLen)       // No context length specified
+	})
+
+	t.Run("filters work correctly with vLLM format", func(t *testing.T) {
+		models := []*domain.UnifiedModel{
+			{
+				ID:            "tinyllama/1.1b:chat-v1.0",
+				Family:        "tinyllama",
+				Variant:       "1.1b",
+				ParameterSize: "1.1b",
+				Aliases: []domain.AliasEntry{
+					{Name: "TinyLlama/TinyLlama-1.1B-Chat-v1.0", Source: "vllm"},
+				},
+				SourceEndpoints: []domain.SourceEndpoint{
+					{NativeName: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"},
+				},
+			},
+			{
+				ID:            "llama/3.1:8b",
+				Family:        "llama",
+				Variant:       "3.1",
+				ParameterSize: "8b",
+				Aliases: []domain.AliasEntry{
+					{Name: "meta-llama/Meta-Llama-3.1-8B-Instruct", Source: "vllm"},
+				},
+				SourceEndpoints: []domain.SourceEndpoint{
+					{NativeName: "meta-llama/Meta-Llama-3.1-8B-Instruct"},
+				},
+			},
+		}
+
+		filters := ports.ModelFilters{
+			Family: "llama",
+		}
+
+		result, err := converter.ConvertToFormat(models, filters)
+		require.NoError(t, err)
+
+		response, ok := result.(VLLMModelResponse)
+		require.True(t, ok)
+		assert.Len(t, response.Data, 1)
+		assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct", response.Data[0].ID)
+	})
+
+	t.Run("generates consistent permissions for all models", func(t *testing.T) {
+		models := []*domain.UnifiedModel{
+			{
+				ID: "test/model",
+				Aliases: []domain.AliasEntry{
+					{Name: "org/test-model", Source: "vllm"},
+				},
+				SourceEndpoints: []domain.SourceEndpoint{
+					{NativeName: "org/test-model"},
+				},
+			},
+		}
+
+		result, err := converter.ConvertToFormat(models, ports.ModelFilters{})
+		require.NoError(t, err)
+
+		response := result.(VLLMModelResponse)
+		model := response.Data[0]
+
+		// Permission ID should be deterministic based on model ID
+		assert.Contains(t, model.Permission[0].ID, "modelperm-olla-org-test-model")
+
+		// Verify permission timestamp is recent
+		assert.WithinDuration(t, time.Now(), time.Unix(model.Permission[0].Created, 0), 5*time.Second)
+	})
+}
+
+func TestVLLMConverter_GetFormatName(t *testing.T) {
+	converter := NewVLLMConverter()
+	assert.Equal(t, "vllm", converter.GetFormatName())
+}
+
+func TestVLLMConverter_determineOwner(t *testing.T) {
+	converter := &VLLMConverter{}
+
+	tests := []struct {
+		name     string
+		modelID  string
+		expected string
+	}{
+		{
+			name:     "extracts organisation from slash-separated name",
+			modelID:  "meta-llama/Meta-Llama-3.1-8B-Instruct",
+			expected: "meta-llama",
+		},
+		{
+			name:     "handles TinyLlama format",
+			modelID:  "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+			expected: "TinyLlama",
+		},
+		{
+			name:     "defaults to vllm for non-slash names",
+			modelID:  "llama3:latest",
+			expected: "vllm",
+		},
+		{
+			name:     "handles single word models",
+			modelID:  "gpt4",
+			expected: "vllm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := converter.determineOwner(tt.modelID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestVLLMConverter_findVLLMNativeName(t *testing.T) {
+	converter := &VLLMConverter{}
+
+	t.Run("finds vLLM native name from source endpoints", func(t *testing.T) {
+		model := &domain.UnifiedModel{
+			ID: "tinyllama/1.1b",
+			SourceEndpoints: []domain.SourceEndpoint{
+				{NativeName: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"},
+			},
+		}
+
+		result := converter.findVLLMNativeName(model)
+		assert.Equal(t, "TinyLlama/TinyLlama-1.1B-Chat-v1.0", result)
+	})
+
+	t.Run("finds vLLM name from aliases when source is vllm", func(t *testing.T) {
+		model := &domain.UnifiedModel{
+			ID: "llama/3.1:8b",
+			Aliases: []domain.AliasEntry{
+				{Name: "llama3:latest", Source: "ollama"},
+				{Name: "meta-llama/Meta-Llama-3.1-8B-Instruct", Source: "vllm"},
+			},
+		}
+
+		result := converter.findVLLMNativeName(model)
+		assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct", result)
+	})
+
+	t.Run("returns empty string when no vLLM name found", func(t *testing.T) {
+		model := &domain.UnifiedModel{
+			ID: "phi/4:14b",
+			Aliases: []domain.AliasEntry{
+				{Name: "phi4:latest", Source: "ollama"},
+			},
+			SourceEndpoints: []domain.SourceEndpoint{
+				{NativeName: "phi4:latest"},
+			},
+		}
+
+		result := converter.findVLLMNativeName(model)
+		assert.Equal(t, "", result)
+	})
+}

--- a/internal/adapter/discovery/http_client.go
+++ b/internal/adapter/discovery/http_client.go
@@ -94,11 +94,12 @@ func (c *HTTPModelDiscoveryClient) DiscoverModels(ctx context.Context, endpoint 
 // discoverWithAutoDetection tries profiles in order until one succeeds
 func (c *HTTPModelDiscoveryClient) discoverWithAutoDetection(ctx context.Context, endpoint *domain.Endpoint, startTime time.Time) ([]*domain.ModelInfo, error) {
 	// We're going to try profiles in order:
-	//	Ollama → LM Studio → OpenAI Compatible (as a last resort)
+	//	Ollama → LM Studio → vLLM → OpenAI Compatible (as a last resort)
 	// Resolution for this may change in the future as more front-ends appear or are added.
 	profileTypes := []string{
 		domain.ProfileOllama,
 		domain.ProfileLmStudio,
+		domain.ProfileVLLM,
 		domain.ProfileOpenAICompatible, /* last ditch effort */
 	}
 

--- a/internal/adapter/registry/profile/parsers.go
+++ b/internal/adapter/registry/profile/parsers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/thushan/olla/internal/core/constants"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/util"
 )
@@ -17,11 +18,13 @@ type ModelResponseParser interface {
 
 func getParserForFormat(format string) ModelResponseParser {
 	switch format {
-	case "ollama":
+	case constants.ProviderTypeOllama:
 		return &ollamaParser{}
-	case "lmstudio":
+	case constants.ProviderPrefixLMStudio1:
 		return &lmStudioParser{}
-	case "openai":
+	case constants.ProviderTypeVLLM:
+		return &vllmParser{}
+	case constants.ProviderTypeOpenAI:
 		return &openAIParser{}
 	default:
 		// openai format is the de facto standard

--- a/internal/adapter/registry/profile/vllm.go
+++ b/internal/adapter/registry/profile/vllm.go
@@ -1,0 +1,35 @@
+package profile
+
+// VLLMResponse is the response structure from vLLM /v1/models endpoint
+type VLLMResponse struct {
+	Object string      `json:"object"`
+	Data   []VLLMModel `json:"data"`
+}
+
+// VLLMModel represents a model in vLLM response with extended metadata
+type VLLMModel struct {
+	MaxModelLen *int64                `json:"max_model_len,omitempty"` // vLLM-specific: max context length
+	Parent      *string               `json:"parent,omitempty"`        // vLLM-specific: parent for fine-tuned models
+	OwnedBy     string                `json:"owned_by"`
+	ID          string                `json:"id"`
+	Object      string                `json:"object"`
+	Root        string                `json:"root,omitempty"`       // vLLM-specific: root model ID
+	Permission  []VLLMModelPermission `json:"permission,omitempty"` // vLLM-specific: permissions array
+	Created     int64                 `json:"created"`
+}
+
+// VLLMModelPermission represents granular permissions in vLLM
+type VLLMModelPermission struct {
+	Group              *string `json:"group"`
+	ID                 string  `json:"id"`
+	Object             string  `json:"object"`
+	Organization       string  `json:"organization"`
+	Created            int64   `json:"created"`
+	AllowCreateEngine  bool    `json:"allow_create_engine"`
+	AllowSampling      bool    `json:"allow_sampling"`
+	AllowLogprobs      bool    `json:"allow_logprobs"`
+	AllowSearchIndices bool    `json:"allow_search_indices"`
+	AllowView          bool    `json:"allow_view"`
+	AllowFineTuning    bool    `json:"allow_fine_tuning"`
+	IsBlocking         bool    `json:"is_blocking"`
+}

--- a/internal/adapter/registry/profile/vllm_parser.go
+++ b/internal/adapter/registry/profile/vllm_parser.go
@@ -1,0 +1,73 @@
+package profile
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+type vllmParser struct{}
+
+func (p *vllmParser) Parse(data []byte) ([]*domain.ModelInfo, error) {
+	if len(data) == 0 {
+		return make([]*domain.ModelInfo, 0), nil
+	}
+
+	var response VLLMResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse vLLM response: %w", err)
+	}
+
+	models := make([]*domain.ModelInfo, 0, len(response.Data))
+	now := time.Now()
+
+	for _, model := range response.Data {
+		if model.ID == "" {
+			continue
+		}
+
+		modelInfo := &domain.ModelInfo{
+			Name:     model.ID,
+			Type:     "vllm", // Mark as vLLM model for proper handling
+			LastSeen: now,
+		}
+
+		// vLLM provides richer metadata than standard OpenAI
+		details := &domain.ModelDetails{}
+		hasDetails := false
+
+		// Extract max context length - crucial for vLLM models
+		if model.MaxModelLen != nil && *model.MaxModelLen > 0 {
+			details.MaxContextLength = model.MaxModelLen
+			hasDetails = true
+		}
+
+		// Set creation time if available
+		if model.Created > 0 {
+			createdTime := time.Unix(model.Created, 0)
+			details.ModifiedAt = &createdTime
+			hasDetails = true
+		}
+
+		// Extract publisher from OwnedBy field
+		if model.OwnedBy != "" && model.OwnedBy != "vllm" {
+			details.Publisher = &model.OwnedBy
+			hasDetails = true
+		}
+
+		// Set parent model if this is a fine-tuned model
+		if model.Parent != nil {
+			details.ParentModel = model.Parent
+			hasDetails = true
+		}
+
+		if hasDetails {
+			modelInfo.Details = details
+		}
+
+		models = append(models, modelInfo)
+	}
+
+	return models, nil
+}

--- a/internal/adapter/registry/profile/vllm_parser_test.go
+++ b/internal/adapter/registry/profile/vllm_parser_test.go
@@ -1,0 +1,463 @@
+package profile
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVLLMParser_Parse(t *testing.T) {
+	parser := &vllmParser{}
+
+	t.Run("parses valid vLLM response with full metadata", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+					"object": "model",
+					"created": 1754535984,
+					"owned_by": "vllm",
+					"root": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+					"parent": null,
+					"max_model_len": 2048,
+					"permission": [
+						{
+							"id": "modelperm-abc123",
+							"object": "model_permission",
+							"created": 1754535984,
+							"allow_create_engine": false,
+							"allow_sampling": true,
+							"allow_logprobs": true,
+							"allow_search_indices": false,
+							"allow_view": true,
+							"allow_fine_tuning": false,
+							"organization": "*",
+							"group": null,
+							"is_blocking": false
+						}
+					]
+				},
+				{
+					"id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+					"object": "model",
+					"created": 1754535985,
+					"owned_by": "meta-llama",
+					"root": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+					"parent": null,
+					"max_model_len": 131072,
+					"permission": []
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 2)
+
+		// Verify first model (TinyLlama)
+		tinyllama := models[0]
+		assert.Equal(t, "TinyLlama/TinyLlama-1.1B-Chat-v1.0", tinyllama.Name)
+		assert.Equal(t, "vllm", tinyllama.Type)
+		assert.NotNil(t, tinyllama.Details)
+
+		// Check max context length is captured
+		require.NotNil(t, tinyllama.Details.MaxContextLength)
+		assert.Equal(t, int64(2048), *tinyllama.Details.MaxContextLength)
+
+		// Check creation time is converted
+		require.NotNil(t, tinyllama.Details.ModifiedAt)
+		assert.Equal(t, time.Unix(1754535984, 0), *tinyllama.Details.ModifiedAt)
+
+		// Verify second model (Llama 3.1)
+		llama := models[1]
+		assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct", llama.Name)
+		assert.Equal(t, "vllm", llama.Type)
+		assert.NotNil(t, llama.Details)
+
+		// Check larger context length
+		require.NotNil(t, llama.Details.MaxContextLength)
+		assert.Equal(t, int64(131072), *llama.Details.MaxContextLength)
+
+		// Check publisher is extracted from owned_by when not "vllm"
+		require.NotNil(t, llama.Details.Publisher)
+		assert.Equal(t, "meta-llama", *llama.Details.Publisher)
+	})
+
+	t.Run("handles models with fine-tuning parent", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "custom/fine-tuned-model",
+					"object": "model",
+					"created": 1754535986,
+					"owned_by": "custom-org",
+					"root": "base-model",
+					"parent": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+					"max_model_len": 8192
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		assert.Equal(t, "custom/fine-tuned-model", model.Name)
+		assert.NotNil(t, model.Details)
+
+		// Check parent model is captured
+		require.NotNil(t, model.Details.ParentModel)
+		assert.Equal(t, "meta-llama/Meta-Llama-3.1-8B-Instruct", *model.Details.ParentModel)
+
+		// Check publisher
+		require.NotNil(t, model.Details.Publisher)
+		assert.Equal(t, "custom-org", *model.Details.Publisher)
+	})
+
+	t.Run("handles models without optional fields", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "simple-model",
+					"object": "model",
+					"created": 0,
+					"owned_by": "vllm"
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		assert.Equal(t, "simple-model", model.Name)
+		assert.Equal(t, "vllm", model.Type)
+
+		// Details should be nil when no metadata is present
+		assert.Nil(t, model.Details)
+	})
+
+	t.Run("skips models without ID", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"object": "model",
+					"created": 1754535987,
+					"owned_by": "test"
+				},
+				{
+					"id": "valid-model",
+					"object": "model",
+					"created": 1754535988,
+					"owned_by": "test"
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+		assert.Equal(t, "valid-model", models[0].Name)
+	})
+
+	t.Run("handles empty response", func(t *testing.T) {
+		models, err := parser.Parse([]byte{})
+		require.NoError(t, err)
+		assert.Empty(t, models)
+	})
+
+	t.Run("handles empty data array", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": []
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		assert.Empty(t, models)
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		invalidJSON := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "test-model",
+					"object": "model",
+					invalid json here
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(invalidJSON))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse vLLM response")
+		assert.Nil(t, models)
+	})
+
+	t.Run("handles zero max_model_len", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "model-with-zero-context",
+					"object": "model",
+					"created": 1754535989,
+					"owned_by": "test",
+					"max_model_len": 0
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		// Details should exist due to other metadata, but MaxContextLength should be nil when it's 0
+		assert.NotNil(t, model.Details)
+		assert.Nil(t, model.Details.MaxContextLength)
+	})
+
+	t.Run("handles negative max_model_len", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "model-with-negative-context",
+					"object": "model",
+					"created": 1754535990,
+					"owned_by": "test",
+					"max_model_len": -1
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		// Details should exist due to other metadata, but MaxContextLength should be nil when it's negative
+		assert.NotNil(t, model.Details)
+		assert.Nil(t, model.Details.MaxContextLength)
+	})
+
+	t.Run("preserves LastSeen timestamp", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "test-model",
+					"object": "model",
+					"created": 1754535991,
+					"owned_by": "test"
+				}
+			]
+		}`
+
+		beforeParse := time.Now()
+		models, err := parser.Parse([]byte(response))
+		afterParse := time.Now()
+
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		// LastSeen should be set to current time
+		assert.True(t, model.LastSeen.After(beforeParse) || model.LastSeen.Equal(beforeParse))
+		assert.True(t, model.LastSeen.Before(afterParse) || model.LastSeen.Equal(afterParse))
+	})
+
+	t.Run("handles real TinyLlama response from vLLM server", func(t *testing.T) {
+		// This is the actual response from the vLLM server at 192.168.0.1:8000
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+					"object": "model",
+					"created": 1754535984,
+					"owned_by": "vllm",
+					"root": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+					"parent": null,
+					"max_model_len": 2048,
+					"permission": [
+						{
+							"id": "modelperm-ca8a321b35824411baf0fbbe4719c498",
+							"object": "model_permission",
+							"created": 1754535984,
+							"allow_create_engine": false,
+							"allow_sampling": true,
+							"allow_logprobs": true,
+							"allow_search_indices": false,
+							"allow_view": true,
+							"allow_fine_tuning": false,
+							"organization": "*",
+							"group": null,
+							"is_blocking": false
+						}
+					]
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		assert.Equal(t, "TinyLlama/TinyLlama-1.1B-Chat-v1.0", model.Name)
+		assert.Equal(t, "vllm", model.Type)
+
+		// Verify all expected fields are parsed
+		require.NotNil(t, model.Details)
+		require.NotNil(t, model.Details.MaxContextLength)
+		assert.Equal(t, int64(2048), *model.Details.MaxContextLength)
+		require.NotNil(t, model.Details.ModifiedAt)
+		assert.Equal(t, int64(1754535984), model.Details.ModifiedAt.Unix())
+	})
+}
+
+func TestVLLMParser_EdgeCases(t *testing.T) {
+	parser := &vllmParser{}
+
+	t.Run("handles null parent field", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "model-with-null-parent",
+					"object": "model",
+					"created": 1754535992,
+					"owned_by": "test",
+					"parent": null
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		// ParentModel should not be set when parent is null
+		if model.Details != nil {
+			assert.Nil(t, model.Details.ParentModel)
+		}
+	})
+
+	t.Run("handles owned_by as vllm", func(t *testing.T) {
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "model-owned-by-vllm",
+					"object": "model",
+					"created": 1754535993,
+					"owned_by": "vllm",
+					"max_model_len": 4096
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		model := models[0]
+		assert.NotNil(t, model.Details)
+		// Publisher should not be set when owned_by is "vllm"
+		assert.Nil(t, model.Details.Publisher)
+	})
+
+	t.Run("handles various organisation formats", func(t *testing.T) {
+		testCases := []struct {
+			ownedBy           string
+			expectedPublisher string
+		}{
+			{"meta-llama", "meta-llama"},
+			{"TinyLlama", "TinyLlama"},
+			{"custom-org", "custom-org"},
+			{"", ""}, // Empty owned_by
+		}
+
+		for _, tc := range testCases {
+			response := fmt.Sprintf(`{
+				"object": "list",
+				"data": [
+					{
+						"id": "test-model",
+						"object": "model",
+						"created": 1754535994,
+						"owned_by": "%s",
+						"max_model_len": 1024
+					}
+				]
+			}`, tc.ownedBy)
+
+			models, err := parser.Parse([]byte(response))
+			require.NoError(t, err)
+			require.Len(t, models, 1)
+
+			model := models[0]
+			if tc.expectedPublisher != "" && tc.expectedPublisher != "vllm" {
+				require.NotNil(t, model.Details)
+				require.NotNil(t, model.Details.Publisher)
+				assert.Equal(t, tc.expectedPublisher, *model.Details.Publisher)
+			}
+		}
+	})
+}
+
+func TestVLLMParser_PerformanceConsiderations(t *testing.T) {
+	parser := &vllmParser{}
+
+	t.Run("handles large model list efficiently", func(t *testing.T) {
+		// Generate a response with many models
+		modelCount := 100
+		modelsJSON := ""
+		for i := 0; i < modelCount; i++ {
+			if i > 0 {
+				modelsJSON += ","
+			}
+			modelsJSON += fmt.Sprintf(`{
+				"id": "model-%d",
+				"object": "model",
+				"created": %d,
+				"owned_by": "test",
+				"max_model_len": %d
+			}`, i, 1754535995+i, 1024*(i+1))
+		}
+
+		response := fmt.Sprintf(`{
+			"object": "list",
+			"data": [%s]
+		}`, modelsJSON)
+
+		startTime := time.Now()
+		models, err := parser.Parse([]byte(response))
+		parseTime := time.Since(startTime)
+
+		require.NoError(t, err)
+		assert.Len(t, models, modelCount)
+
+		// Parsing should be fast even with many models
+		assert.Less(t, parseTime, 100*time.Millisecond)
+
+		// Verify a sample of models
+		assert.Equal(t, "model-0", models[0].Name)
+		assert.Equal(t, "model-99", models[99].Name)
+		assert.Equal(t, int64(1024), *models[0].Details.MaxContextLength)
+		assert.Equal(t, int64(102400), *models[99].Details.MaxContextLength)
+	})
+}

--- a/internal/core/domain/profile.go
+++ b/internal/core/domain/profile.go
@@ -3,6 +3,7 @@ package domain
 const (
 	ProfileOllama           = "ollama"
 	ProfileLmStudio         = "lm-studio"
+	ProfileVLLM             = "vllm"
 	ProfileOpenAICompatible = "openai-compatible"
 	ProfileAuto             = "auto"
 )

--- a/internal/integration/providers/vllm_integration_test.go
+++ b/internal/integration/providers/vllm_integration_test.go
@@ -1,0 +1,276 @@
+//go:build integration
+// +build integration
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/adapter/discovery"
+	"github.com/thushan/olla/internal/adapter/registry/profile"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// getVLLMTestServer returns the vLLM test server URL from environment variable
+func getVLLMTestServer(t *testing.T) string {
+	vllmServer := os.Getenv("OLLA_TEST_SERVER_VLLM")
+	if vllmServer == "" {
+		t.Skip("OLLA_TEST_SERVER_VLLM environment variable not set. " +
+			"Please set it to your vLLM server URL (e.g., http://192.168.0.1:8000) to run vLLM integration tests.")
+	}
+	
+	// Ensure the URL has a scheme
+	if !strings.HasPrefix(vllmServer, "http://") && !strings.HasPrefix(vllmServer, "https://") {
+		vllmServer = "http://" + vllmServer
+	}
+	
+	// Remove trailing slash if present
+	vllmServer = strings.TrimSuffix(vllmServer, "/")
+	
+	return vllmServer
+}
+
+// checkVLLMServerAvailable verifies the vLLM server is reachable
+func checkVLLMServerAvailable(t *testing.T, serverURL string) {
+	healthURL := serverURL + "/health"
+	
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(healthURL)
+	if err != nil {
+		t.Skipf("vLLM server not reachable at %s: %v\n"+
+			"Please ensure your vLLM server is running and accessible.", serverURL, err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		t.Skipf("vLLM server health check failed with status %d at %s\n"+
+			"Please ensure your vLLM server is healthy.", resp.StatusCode, serverURL)
+	}
+}
+
+func TestVLLMDiscovery_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	vllmServer := getVLLMTestServer(t)
+	checkVLLMServerAvailable(t, vllmServer)
+	
+	t.Logf("Running vLLM integration tests against: %s", vllmServer)
+
+	ctx := context.Background()
+	slogger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	testLogger := logger.NewPlainStyledLogger(slogger)
+	profileFactory, err := profile.NewFactory("../../../config/profiles")
+	require.NoError(t, err)
+
+	t.Run("discovers vLLM models with auto-detection", func(t *testing.T) {
+		client := discovery.NewHTTPModelDiscoveryClientWithDefaults(profileFactory, testLogger)
+
+		endpoint := &domain.Endpoint{
+			URLString: vllmServer,
+			Type:      domain.ProfileAuto, // Test auto-detection
+			Name:      "test-vllm",
+		}
+
+		models, err := client.DiscoverModels(ctx, endpoint)
+		require.NoError(t, err)
+		require.NotEmpty(t, models)
+
+		// Check that at least one model is discovered
+		// We don't assume a specific model since users may run different models
+		t.Logf("Discovered %d models from vLLM server", len(models))
+		
+		// Verify basic model properties
+		for _, model := range models {
+			assert.NotEmpty(t, model.Name, "Model name should not be empty")
+			assert.Equal(t, "vllm", model.Type, "Model type should be vllm")
+			
+			// Log discovered model for debugging
+			t.Logf("Found model: %s", model.Name)
+			
+			// vLLM typically provides max context length
+			if model.Details != nil && model.Details.MaxContextLength != nil {
+				t.Logf("  - Max context length: %d", *model.Details.MaxContextLength)
+			}
+		}
+	})
+
+	t.Run("discovers vLLM models with explicit profile", func(t *testing.T) {
+		client := discovery.NewHTTPModelDiscoveryClientWithDefaults(profileFactory, testLogger)
+
+		endpoint := &domain.Endpoint{
+			URLString: vllmServer,
+			Type:      domain.ProfileVLLM, // Explicit vLLM profile
+			Name:      "test-vllm-explicit",
+		}
+
+		models, err := client.DiscoverModels(ctx, endpoint)
+		require.NoError(t, err)
+		require.NotEmpty(t, models)
+
+		// Verify the first model has expected properties
+		model := models[0]
+		assert.NotEmpty(t, model.Name)
+		assert.Equal(t, "vllm", model.Type)
+		
+		t.Logf("Explicit vLLM profile discovered model: %s", model.Name)
+	})
+
+	t.Run("handles vLLM-specific response format", func(t *testing.T) {
+		client := &http.Client{Timeout: 10 * time.Second}
+
+		req, err := http.NewRequest("GET", vllmServer+"/v1/models", nil)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Parse response using vLLM profile
+		vllmProfile, err := profileFactory.GetProfile(domain.ProfileVLLM)
+		require.NoError(t, err)
+
+		// Read response body properly
+		buf := make([]byte, 10240)
+		n, err := resp.Body.Read(buf)
+		if err != nil && err.Error() != "EOF" && err.Error() != "unexpected EOF" {
+			require.NoError(t, err)
+		}
+
+		models, err := vllmProfile.ParseModelsResponse(buf[:n])
+		require.NoError(t, err)
+		require.NotEmpty(t, models)
+
+		// Verify vLLM-specific fields are captured
+		model := models[0]
+		assert.NotNil(t, model.Details)
+		
+		// Log what we found for debugging
+		t.Logf("Parsed vLLM model: %s", model.Name)
+		if model.Details != nil && model.Details.MaxContextLength != nil {
+			t.Logf("  - Max context length: %d", *model.Details.MaxContextLength)
+			assert.Greater(t, *model.Details.MaxContextLength, int64(0), "Max context length should be positive")
+		}
+	})
+}
+
+func TestVLLMHealthCheck_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	vllmServer := getVLLMTestServer(t)
+	
+	// Test vLLM health endpoint specifically
+	healthURL := vllmServer + "/health"
+	client := &http.Client{Timeout: 5 * time.Second}
+	
+	resp, err := client.Get(healthURL)
+	if err != nil {
+		t.Fatalf("Failed to reach vLLM health endpoint at %s: %v", healthURL, err)
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "vLLM health endpoint should return 200 OK")
+	t.Logf("vLLM health check successful at %s", healthURL)
+}
+
+// TestVLLMChatCompletion_Integration tests the chat completion endpoint if available
+func TestVLLMChatCompletion_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	vllmServer := getVLLMTestServer(t)
+	checkVLLMServerAvailable(t, vllmServer)
+	
+	// First, get available models
+	modelsURL := vllmServer + "/v1/models"
+	client := &http.Client{Timeout: 10 * time.Second}
+	
+	resp, err := client.Get(modelsURL)
+	if err != nil {
+		t.Fatalf("Failed to get models: %v", err)
+	}
+	defer resp.Body.Close()
+	
+	// Parse the response to get model name
+	var modelsResp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		t.Fatalf("Failed to parse models response: %v", err)
+	}
+	
+	if len(modelsResp.Data) == 0 {
+		t.Skip("No models available on vLLM server")
+	}
+	
+	modelName := modelsResp.Data[0].ID
+	t.Logf("Testing chat completion with model: %s", modelName)
+	
+	// Test chat completion
+	chatURL := vllmServer + "/v1/chat/completions"
+	chatRequest := fmt.Sprintf(`{
+		"model": "%s",
+		"messages": [{"role": "user", "content": "Say hello in one word"}],
+		"max_tokens": 10,
+		"temperature": 0.7
+	}`, modelName)
+	
+	req, err := http.NewRequest("POST", chatURL, strings.NewReader(chatRequest))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	
+	resp2, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send chat completion request: %v", err)
+	}
+	defer resp2.Body.Close()
+	
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "Chat completion should return 200 OK")
+	
+	// Parse response to verify it's valid
+	var chatResp struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Model   string `json:"model"`
+		Choices []struct {
+			Message struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	
+	if err := json.NewDecoder(resp2.Body).Decode(&chatResp); err != nil {
+		t.Fatalf("Failed to parse chat response: %v", err)
+	}
+	
+	assert.NotEmpty(t, chatResp.ID, "Response should have an ID")
+	assert.Equal(t, "chat.completion", chatResp.Object, "Response object should be chat.completion")
+	assert.Equal(t, modelName, chatResp.Model, "Response should echo the model name")
+	assert.NotEmpty(t, chatResp.Choices, "Response should have choices")
+	
+	if len(chatResp.Choices) > 0 {
+		t.Logf("vLLM response: %s", chatResp.Choices[0].Message.Content)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@
     <a href="https://github.com/thushan/olla/releases/latest"><img src="https://img.shields.io/github/release/thushan/olla" alt="Latest Release"></a> <br />
     <a href="https://ollama.com"><img src="https://img.shields.io/badge/Ollama-native-lightgreen.svg" alt="Ollama: Native Support"></a> 
     <a href="https://lmstudio.ai/"><img src="https://img.shields.io/badge/LM Studio-native-lightgreen.svg" alt="LM Studio: Native Support"></a> 
-    <a href="https://github.com/vllm-project/vllm"><img src="https://img.shields.io/badge/vLLM-openai-lightblue.svg" alt="vLLM: OpenAI Compatible"></a> 
+    <a href="https://github.com/vllm-project/vllm"><img src="https://img.shields.io/badge/vLLM-native-lightgreen.svg" alt="vLLM: Native Support"></a> 
     <a href="https://github.com/lemonade-sdk/lemonade"><img src="https://img.shields.io/badge/Lemonade-openai-lightblue.svg" alt="Lemonade AI: OpenAI Compatible"></a> 
     <a href="https://github.com/InternLM/lmdeploy"><img src="https://img.shields.io/badge/LM Deploy-openai-lightblue.svg" alt="Lemonade AI: OpenAI Compatible"></a> 
   </P>
@@ -40,10 +40,13 @@ In the above example, we configure [Jetbrains Junie](https://www.jetbrains.com/j
 
 ### Supported Backends
 
-* [Ollama](https://github.com/ollama/ollama) - full support for Ollama, including model unification. \
+* [Ollama](https://github.com/ollama/ollama) - native support for Ollama, including model unification. \
   Use: `/olla/ollama/`
-* [LM Studio](https://lmstudio.ai/) - full support for LMStudio, including model unification. \
+* [LM Studio](https://lmstudio.ai/) - native support for LMStudio, including model unification. \
   Use: `/olla/lmstudio/` || `/olla/lm-studio/` || `/olla/lm_studio/`
+* [vLLM](https://github.com/vllm-project/vllm) - native support for vllm, including model unification. \
+  Use: `/olla/vllm/` \
+  Models from vLLM will be available under `/olla/models` and `/olla/vllm/v1/models`
 * [OpenAI](https://platform.openai.com/docs/overview) - You can use OpenAI API that provides a unified query API across all providers. \
   Use: `/olla/openai/`
 
@@ -53,7 +56,6 @@ In the above example, we configure [Jetbrains Junie](https://www.jetbrains.com/j
 
 Coming soon - but you can use the OpenAI compatibility in the interim:
 
-* [vLLM](https://github.com/vllm-project/vllm)
 * [LMDeploy](https://github.com/InternLM/lmdeploy)
 * [Lemonade](https://github.com/lemonade-sdk/lemonade)
 

--- a/test/scripts/logic/test-model-routing-provider.py
+++ b/test/scripts/logic/test-model-routing-provider.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Olla Provider-Specific Model Routing Test Script
-Tests model routing with different provider formats (OpenAI, Ollama, LM Studio)
+Tests model routing with different provider formats (OpenAI, Ollama, LM Studio, vLLM)
 """
 
 import sys
@@ -35,7 +35,8 @@ class ProviderTester:
         self.provider_models = {
             'openai': [],
             'ollama': [],
-            'lmstudio': []
+            'lmstudio': [],
+            'vllm': []
         }
         self.endpoint_usage = defaultdict(int)
         self.endpoint_success = defaultdict(int)
@@ -113,7 +114,7 @@ class ProviderTester:
             
         # Now fetch provider-specific models
         self.print_color(YELLOW, "Fetching provider-specific models...")
-        for provider in ['openai', 'ollama', 'lmstudio']:
+        for provider in ['openai', 'ollama', 'lmstudio', 'vllm']:
             try:
                 response = requests.get(f"{self.base_url}/olla/models?format={provider}", timeout=TIMEOUT)
                 if response.status_code == 200:
@@ -143,7 +144,7 @@ class ProviderTester:
         self.print_color(CYAN, f"Total models available: {len(self.all_models)}")
         
         # Show models per provider
-        for provider in ['openai', 'ollama', 'lmstudio']:
+        for provider in ['openai', 'ollama', 'lmstudio', 'vllm']:
             if self.provider_models[provider]:
                 print()
                 self.print_color(YELLOW, f"{provider.upper()} models ({len(self.provider_models[provider])}):")
@@ -226,6 +227,13 @@ class ProviderTester:
             self.test_endpoint(
                 "LM Studio Enhanced Models (/olla/lm-studio/api/v0/models)",
                 f"{self.base_url}/olla/lm-studio/api/v0/models",
+                method="GET"
+            )
+            
+        if 'vllm' in providers:
+            self.test_endpoint(
+                "vLLM Models (/olla/vllm/v1/models)",
+                f"{self.base_url}/olla/vllm/v1/models",
                 method="GET"
             )
             
@@ -335,6 +343,38 @@ class ProviderTester:
                         }
                     )
                     
+                elif provider == 'vllm':
+                    if 'embed' not in model:
+                        self.test_endpoint(
+                            "  Chat Completions (/v1/chat/completions)",
+                            f"{self.base_url}/olla/vllm/v1/chat/completions",
+                            {
+                                "model": model,
+                                "messages": [{"role": "user", "content": "Hello"}],
+                                "max_tokens": 10,
+                                "stream": False
+                            }
+                        )
+                        self.test_endpoint(
+                            "  Completions (/v1/completions)",
+                            f"{self.base_url}/olla/vllm/v1/completions",
+                            {
+                                "model": model,
+                                "prompt": "Hello",
+                                "max_tokens": 10,
+                                "stream": False
+                            }
+                        )
+                    else:
+                        self.test_endpoint(
+                            "  Embeddings (/v1/embeddings)",
+                            f"{self.base_url}/olla/vllm/v1/embeddings",
+                            {
+                                "model": model,
+                                "input": "Test text"
+                            }
+                        )
+                    
                 tested_per_provider[provider] += 1
             
     def print_summary(self):
@@ -374,6 +414,7 @@ def main():
     parser.add_argument('--openai', action='store_true', help='Test OpenAI format')
     parser.add_argument('--ollama', action='store_true', help='Test Ollama format')
     parser.add_argument('--lmstudio', '--lm-studio', action='store_true', help='Test LM Studio format')
+    parser.add_argument('--vllm', action='store_true', help='Test vLLM format')
     parser.add_argument('--all', action='store_true', help='Test all models (default: 3 per provider)')
     parser.add_argument('--url', default=TARGET_URL, help='Olla base URL')
     
@@ -387,9 +428,11 @@ def main():
         providers.append('ollama')
     if args.lmstudio:
         providers.append('lmstudio')
+    if args.vllm:
+        providers.append('vllm')
         
     if not providers:
-        providers = ['openai', 'ollama', 'lmstudio']
+        providers = ['openai', 'ollama', 'lmstudio', 'vllm']
         
     tester = ProviderTester(args.url)
     tester.print_header()

--- a/test/scripts/logic/test-model-routing.sh
+++ b/test/scripts/logic/test-model-routing.sh
@@ -74,7 +74,7 @@ usage() {
     echo
     echo -e "${YELLOW}Environment Variables:${RESET}"
     echo -e "  TARGET_URL      Olla proxy URL (default: http://localhost:40114)"
-    echo -e "  PROVIDER        Provider to test (default: ollama) - ollama, lmstudio, openai, vllm"
+    echo -e "  PROVIDER        Provider to test (default: openai) - ollama, lmstudio, openai, vllm"
     echo -e "  VERBOSE         Show detailed request/response info (default: false)"
     echo
     echo -e "${YELLOW}Description:${RESET}"
@@ -92,9 +92,10 @@ usage() {
     echo -e "  • X-Served-By - Server identification"
     echo
     echo -e "${YELLOW}Examples:${RESET}"
-    echo -e "  $0                               # Test only discovered models (Ollama)"
+    echo -e "  $0                               # Test only discovered models (OpenAI)"
+    echo -e "  PROVIDER=ollama $0               # Test Ollama endpoints"
     echo -e "  PROVIDER=lmstudio $0             # Test LM Studio endpoints"
-    echo -e "  PROVIDER=openai $0               # Test OpenAI-compatible endpoints"
+    echo -e "  PROVIDER=vllm $0                 # Test vLLM endpoints"
     echo -e "  $0 gpt-4-turbo claude-3-sonnet   # Test discovered + additional models"
     echo -e "  VERBOSE=true $0                  # Show detailed debug information"
     echo


### PR DESCRIPTION
This PR implements the backend provider type for [vllm](https://github.com/vllm-project/vllm).

You can configure a vLLM endpoint like this in the configuration (also in the default `config.yaml` as an example):

```yaml
      - url: "http://192.168.0.1:8000"
        name: "local-vllm"
        type: "vllm"
        priority: 100
        model_url: "/v1/models"
        health_check_url: "/health"
        check_interval: 5s
        check_timeout: 2s
```

Features supported:

- Healthcheck
- Model unification across vllm instances
- Supports native and openai methods

TODO:
- Determine how to handle model swaps (process starts with `tinyllama` shutdown, server comes back up with `llama4`, Olla thinks it's still okay to have / route to `tinyllama`).