### PR TITLE
feat: Improved health recovery

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,10 @@ proxy:
   response_timeout: 900s
   read_timeout: 600s
   
+  # DEPRECATED as of v0.0.16 - These fields are no longer used
+  # max_retries: 3        # Replaced by retry.max_attempts
+  # retry_backoff: 500ms  # Now uses intelligent exponential backoff
+  
   # Connection failure retry settings (applies to both Sherpa and Olla engines)
   # When enabled, the proxy will automatically retry failed requests on other healthy endpoints
   retry:
@@ -101,10 +105,23 @@ discovery:
 model_registry:
   type: "memory"
   enable_unifier: true
+
   unification:
     enabled: true
     stale_threshold: 24h  # How long to keep models in memory after last seen
     cleanup_interval: 10m  # How often to check for stale models
+  
+  # Model routing strategy (v0.0.16+)
+  # Controls how requests are routed when models aren't available on all endpoints
+  routing_strategy:
+    type: "strict"  # Options: strict, optimistic, discovery
+    options:
+      # Fallback behavior when model not found (optimistic mode)
+      fallback_behavior: "compatible_only"  # Options: compatible_only, all, none
+      
+      # Discovery mode settings
+      discovery_timeout: 2s  # Timeout for discovery refresh
+      discovery_refresh_on_miss: false  # Refresh discovery when model not found
 
 logging:
   level: "info"  # debug, info, warn, error

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -37,12 +37,33 @@ proxy:
   connection_timeout: 60s
   response_timeout: 900s
   read_timeout: 600s
-  max_retries: 3
-  retry_backoff: 500ms
+  
+  # Connection failure retry settings (applies to both Sherpa and Olla engines)
+  # When enabled, the proxy will automatically retry failed requests on other healthy endpoints
+  retry:
+    enabled: true # Enable automatic retry on connection failures
+    on_connection_failure: true # Retry when connection to backend fails (connection refused, reset, timeout)
+    max_attempts: 0 # Maximum retry attempts (0 = try all available endpoints once)
+    # Connection errors that trigger retry:
+    # - Connection refused (backend is down)
+    # - Connection reset (backend crashed)
+    # - Connection timeout (backend is overloaded)
+    # - Network unreachable (network issues)
+    # Failed endpoints are immediately marked as unhealthy and removed from the retry pool
 
 discovery:
   type: "static"
   refresh_interval: 30s
+  
+  # Health check and recovery settings
+  health_check:
+    initial_delay: 1s # Delay before first health check
+    # When an endpoint fails during request processing:
+    # - It's immediately marked as unhealthy
+    # - Consecutive failures increment, causing exponential backoff
+    # - Next check time = now + (consecutive_failures * 2) seconds (max 60s)
+    # - Health checker will automatically recover endpoints when they're back online
+  
   static:
     endpoints:
       - url: "http://localhost:11434"
@@ -51,7 +72,7 @@ discovery:
         priority: 100
         model_url: "/api/tags"
         health_check_url: "/"
-        check_interval: 2s
+        check_interval: 2s # How often to check when healthy
         check_timeout: 1s
       - url: "http://localhost:11234"
         name: "local-lm-studio"

--- a/docs/content/concepts/health-checking.md
+++ b/docs/content/concepts/health-checking.md
@@ -128,12 +128,13 @@ endpoints:
 
 When an endpoint fails, Olla implements exponential backoff:
 
-1. **First failure**: Check again after `check_interval`
+1. **First failure**: Check again after `check_interval` (no backoff)
 2. **Second failure**: Wait `check_interval * 2`
 3. **Third failure**: Wait `check_interval * 4`
-4. **Max backoff**: Capped at 60 seconds
+4. **Fourth failure**: Wait `check_interval * 8`
+5. **Max backoff**: Capped at `check_interval * 12` or 60 seconds (whichever is lower)
 
-This reduces load on failing endpoints while still detecting recovery.
+This reduces load on failing endpoints while still detecting recovery quickly on the first failure.
 
 ### Fast Recovery Detection
 

--- a/docs/content/concepts/model-routing.md
+++ b/docs/content/concepts/model-routing.md
@@ -1,0 +1,146 @@
+---
+title: Model Routing - Intelligent Request Routing in Olla
+description: Understanding Olla's model routing strategies for handling requests when models aren't available on all endpoints.
+keywords: model routing, routing strategy, fallback behavior, request routing, model availability
+---
+
+# Model Routing
+
+Olla implements intelligent model routing strategies to handle scenarios where requested models aren't available on all endpoints.
+
+## Overview
+
+When a request specifies a model (e.g., `phi3.5:latest`), Olla needs to determine which endpoints can handle that request. Not all endpoints have all models, and endpoints can become unhealthy during operation.
+
+## Routing Strategies
+
+### Strict Mode (Default)
+
+Only routes requests to endpoints known to have the model.
+
+**Characteristics:**
+- High reliability - requests only go to endpoints with the model
+- Fails fast when model unavailable
+- Returns 404 when model not found anywhere
+- Returns 503 when model only on unhealthy endpoints
+
+**Use Case:** Production environments where predictability is critical.
+
+```yaml
+routing:
+  model_routing:
+    type: strict
+```
+
+### Optimistic Mode
+
+Attempts to route to any healthy endpoint when the model isn't found.
+
+**Characteristics:**
+- Higher availability - tries all healthy endpoints
+- May route to endpoints without the model
+- Configurable fallback behavior
+- Best effort approach
+
+**Use Case:** Development environments or when models might be pulled on-demand.
+
+```yaml
+routing:
+  model_routing:
+    type: optimistic
+    options:
+      fallback_behavior: compatible_only  # or "all", "none"
+```
+
+### Discovery Mode
+
+Refreshes model discovery before making routing decisions.
+
+**Characteristics:**
+- Most accurate model availability
+- Adds latency for discovery refresh
+- Configurable timeout
+- Falls back to strict behavior after refresh
+
+**Use Case:** When models are frequently added/removed from endpoints.
+
+```yaml
+routing:
+  model_routing:
+    type: discovery
+    options:
+      discovery_refresh_on_miss: true
+      discovery_timeout: 2s
+```
+
+## Fallback Behavior
+
+Controls what happens when the requested model isn't available:
+
+- **`compatible_only`**: Route to endpoints of compatible type (e.g., Ollama to Ollama)
+- **`all`**: Route to any healthy endpoint regardless of type
+- **`none`**: Never fall back, always reject if model not found
+
+## Response Headers
+
+Routing decisions are exposed via HTTP headers for observability:
+
+```http
+X-Olla-Routing-Strategy: strict
+X-Olla-Routing-Decision: routed
+X-Olla-Routing-Reason: model_found
+```
+
+## Status Codes
+
+Different routing decisions result in appropriate HTTP status codes:
+
+- **200 OK**: Request successfully routed
+- **404 Not Found**: Model doesn't exist on any endpoint
+- **503 Service Unavailable**: Model exists but no healthy endpoints available
+
+## Configuration Example
+
+Complete routing configuration:
+
+```yaml
+# Strict mode for production
+routing:
+  model_routing:
+    type: strict
+    
+# Optimistic with compatible fallback
+routing:
+  model_routing:
+    type: optimistic
+    options:
+      fallback_behavior: compatible_only
+      
+# Discovery with timeout
+routing:
+  model_routing:
+    type: discovery
+    options:
+      discovery_refresh_on_miss: true
+      discovery_timeout: 2s
+      fallback_behavior: none
+```
+
+## Metrics and Monitoring
+
+Routing decisions are tracked in metrics:
+
+- Total routing decisions by strategy
+- Success/failure rates per strategy
+- Fallback usage statistics
+- Discovery refresh latency
+
+Access metrics via `/internal/status` endpoint.
+
+## Best Practices
+
+1. **Use strict mode in production** for predictable behavior
+2. **Enable discovery mode** when models change frequently
+3. **Monitor routing headers** to understand request flow
+4. **Set appropriate timeouts** for discovery mode
+5. **Use compatible_only fallback** to maintain API compatibility

--- a/docs/content/concepts/model-routing.md
+++ b/docs/content/concepts/model-routing.md
@@ -27,8 +27,8 @@ Only routes requests to endpoints known to have the model.
 **Use Case:** Production environments where predictability is critical.
 
 ```yaml
-routing:
-  model_routing:
+model_registry:
+  routing_strategy:
     type: strict
 ```
 
@@ -45,8 +45,8 @@ Attempts to route to any healthy endpoint when the model isn't found.
 **Use Case:** Development environments or when models might be pulled on-demand.
 
 ```yaml
-routing:
-  model_routing:
+model_registry:
+  routing_strategy:
     type: optimistic
     options:
       fallback_behavior: compatible_only  # or "all", "none"
@@ -65,8 +65,8 @@ Refreshes model discovery before making routing decisions.
 **Use Case:** When models are frequently added/removed from endpoints.
 
 ```yaml
-routing:
-  model_routing:
+model_registry:
+  routing_strategy:
     type: discovery
     options:
       discovery_refresh_on_miss: true
@@ -104,21 +104,27 @@ Different routing decisions result in appropriate HTTP status codes:
 Complete routing configuration:
 
 ```yaml
-# Strict mode for production
-routing:
-  model_routing:
+# Strict mode for production (default)
+model_registry:
+  type: "memory"
+  enable_unifier: true
+  routing_strategy:
     type: strict
     
 # Optimistic with compatible fallback
-routing:
-  model_routing:
+model_registry:
+  type: "memory"
+  enable_unifier: true
+  routing_strategy:
     type: optimistic
     options:
       fallback_behavior: compatible_only
       
 # Discovery with timeout
-routing:
-  model_routing:
+model_registry:
+  type: "memory"
+  enable_unifier: true
+  routing_strategy:
     type: discovery
     options:
       discovery_refresh_on_miss: true

--- a/docs/content/concepts/overview.md
+++ b/docs/content/concepts/overview.md
@@ -45,6 +45,15 @@ Standardised model discovery and management:
 
 Model unification simplifies working with heterogeneous LLM infrastructure.
 
+### [Model Routing](model-routing.md)
+Intelligent routing strategies for model availability:
+
+- **Strict**: Only route to endpoints with the model (default)
+- **Optimistic**: Try any healthy endpoint with fallback
+- **Discovery**: Refresh model catalog before routing
+
+Model routing ensures requests reach appropriate endpoints based on model availability.
+
 ### [Proxy Profiles](proxy-profiles.md)
 Response handling strategies for different use cases:
 

--- a/docs/content/concepts/proxy-engines.md
+++ b/docs/content/concepts/proxy-engines.md
@@ -48,6 +48,8 @@ Olla ships with the default setting of using the `Sherpa` engine for a wide vari
 | **Performance** | Good for moderate loads | Excellent for high loads |
 | **Memory Usage** | Lower memory footprint | Higher due to pooling |
 | **Connection Handling** | Shared transport with keep-alive | Per-endpoint connection pools |
+| **Circuit Breaker** | Basic failure detection | Advanced circuit breaker per endpoint |
+| **Retry Logic** | Shared retry handler | Shared retry handler with circuit breaker integration |
 | **Streaming** | Standard HTTP streaming (8KB buffer) | Optimised for LLM streaming (64KB buffer) |
 | **Best For** | Development, small deployments | Production, enterprise use |
 
@@ -135,6 +137,7 @@ No other changes are needed. Both engines:
 - Work with all [proxy profiles](proxy-profiles.md)
 - Are compatible with all backends
 - Provide identical functionality
+- Share the same retry and recovery mechanisms
 
 ## Stream Buffer Size
 

--- a/docs/content/configuration/examples.md
+++ b/docs/content/configuration/examples.md
@@ -321,7 +321,11 @@ proxy:
   profile: "standard"  # No streaming for public API
   load_balancer: "least-connections"
   connection_timeout: 20s
-  max_retries: 2
+  # Automatic retry with failover to other endpoints
+  retry:
+    enabled: true
+    on_connection_failure: true
+    max_attempts: 2  # Limit retries for public API
 
 discovery:
   type: "static"

--- a/docs/content/configuration/overview.md
+++ b/docs/content/configuration/overview.md
@@ -120,9 +120,13 @@ proxy:
   connection_timeout: 30s     # Timeout for establishing connections
   response_timeout: 600s      # Timeout for complete response (10 minutes)
   read_timeout: 120s         # Timeout for reading response chunks
-  max_retries: 3             # Maximum retry attempts on failure
-  retry_backoff: 500ms       # Delay between retries
   stream_buffer_size: 8192   # Buffer size for streaming responses (8KB)
+  
+  # Automatic retry on connection failures (v0.0.16+)
+  retry:
+    enabled: true             # Enable automatic retry
+    on_connection_failure: true  # Retry on connection errors
+    max_attempts: 0           # 0 = try all available endpoints
 ```
 
 ### Proxy Settings

--- a/docs/content/configuration/practices/overview.md
+++ b/docs/content/configuration/practices/overview.md
@@ -229,7 +229,7 @@ Multi-region deployment:
 ```yaml
 proxy:
   load_balancer: "priority"
-  max_retries: 3
+  # Automatic failover between regions
 
 discovery:
   static:
@@ -398,12 +398,21 @@ proxy:
 
 ### Retry Strategy
 
-Configure retries appropriately:
+Automatic retry is enabled by default for connection failures:
 
 ```yaml
 proxy:
-  max_retries: 3  # Balance reliability vs latency
+  retry:
+    enabled: true  # Automatic failover
+    on_connection_failure: true
+    max_attempts: 0  # Try all endpoints (or set limit)
 ```
+
+The retry mechanism intelligently:
+- Only retries connection failures (not application errors)
+- Automatically tries different endpoints
+- Marks failed endpoints as unhealthy
+- Uses exponential backoff for health checks
 
 ### Model Discovery
 

--- a/docs/content/configuration/practices/performance.md
+++ b/docs/content/configuration/practices/performance.md
@@ -359,7 +359,10 @@ proxy:
   profile: "auto"              # Dynamic selection
   load_balancer: "least-connections"
   connection_timeout: 60s      # Long connection reuse
-  max_retries: 2               # Limit retries
+  retry:
+    enabled: true
+    on_connection_failure: true
+    max_attempts: 2           # Limit retries for performance
 
 discovery:
   model_discovery:
@@ -385,7 +388,10 @@ proxy:
   profile: "streaming"         # Optimise for streaming
   load_balancer: "priority"    # Fastest decisions
   connection_timeout: 120s     # Reuse connections
-  max_retries: 1               # Fast failure
+  retry:
+    enabled: true
+    on_connection_failure: true
+    max_attempts: 1           # Fast failure
 
 discovery:
   static:

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -331,6 +331,47 @@ model_registry:
           "llama3": "meta-llama"
 ```
 
+## Routing Configuration
+
+Model routing strategy settings for handling requests when models aren't available on all endpoints.
+
+### Model Routing Strategy
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `routing.model_routing.type` | string | `"strict"` | Routing strategy (`strict`, `optimistic`, `discovery`) |
+| `routing.model_routing.options.fallback_behavior` | string | `"compatible_only"` | Fallback behavior (`compatible_only`, `all`, `none`) |
+| `routing.model_routing.options.discovery_refresh_on_miss` | bool | `false` | Refresh discovery when model not found |
+| `routing.model_routing.options.discovery_timeout` | duration | `2s` | Discovery refresh timeout |
+
+#### Strategy Types
+
+- **`strict`**: Only routes to endpoints known to have the model
+- **`optimistic`**: Falls back to healthy endpoints when model not found
+- **`discovery`**: Refreshes model discovery before routing decisions
+
+Example:
+
+```yaml
+routing:
+  model_routing:
+    type: strict
+    options:
+      fallback_behavior: compatible_only
+      discovery_refresh_on_miss: false
+      discovery_timeout: 2s
+```
+
+### Response Headers
+
+Routing decisions are exposed via response headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-Olla-Routing-Strategy` | Strategy used (strict/optimistic/discovery) |
+| `X-Olla-Routing-Decision` | Action taken (routed/fallback/rejected) |
+| `X-Olla-Routing-Reason` | Human-readable reason for decision |
+
 ## Logging Configuration
 
 Application logging settings.

--- a/docs/content/getting-started/quickstart.md
+++ b/docs/content/getting-started/quickstart.md
@@ -180,7 +180,11 @@ proxy:
   engine: "olla"  # High-performance engine
   load_balancer: "least-connections"
   connection_timeout: 30s
-  max_retries: 3
+  # Automatic retry on connection failures is enabled by default
+  retry:
+    enabled: true
+    on_connection_failure: true
+    max_attempts: 0  # Try all available endpoints
 ```
 
 ### Rate Limiting

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -39,7 +39,9 @@ It intelligently routes LLM requests across local and remote inference nodes - i
 Understand these key concepts to get the most from Olla:
 
 - **[Proxy Engines](concepts/proxy-engines.md)** - Choose between Sherpa (simple) or Olla (high-performance) engines
-- **[Load Balancing](concepts/load-balancing.md)** - Distribute requests across multiple endpoints with priority, round-robin, or least-connections
+- **[Proxy Profiles](concepts/proxy-profiles.md)** - Learn about different proxy behaviours for streaming or buffering
+- **[Load Balancing](concepts/load-balancing.md)** - Distribute requests across multiple endpoints
+- **[Model Routing](concepts/model-routing.md)** - Different ways Olla routes traffic based on model availability & health
 - **[Model Unification](concepts/model-unification.md)** - Single catalogue of models across all your backends
 - **[Health Checking](concepts/health-checking.md)** - Automatic endpoint monitoring and intelligent failover
 - **[Profile System](concepts/profile-system.md)** - Customise backend behaviour without writing code
@@ -50,6 +52,11 @@ Understand these key concepts to get the most from Olla:
 
 Get up and running with Olla in minutes:
 
+=== "Installer"    
+    ```bash
+    # Linux/macOS
+    bash <(curl -s https://raw.githubusercontent.com/thushan/olla/main/install.sh)
+    ```
 === "Using Docker"
     ```bash
     # If you have ollama or lmstudio locally
@@ -62,6 +69,10 @@ Get up and running with Olla in minutes:
     go install github.com/thushan/olla@latest
     olla
     ```
+
+=== "From Binaries"
+
+    <small>Visit [Github Releases](https://github.com/thushan/olla/releases/latest)</small>
 
 === "From Source"
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -78,7 +78,7 @@ Mission-critical AI infrastructure at scale:
 # Enterprise config - high performance, observability
 proxy:
   engine: "olla"  # High-performance engine
-  max_retries: 3
+  # Automatic retry is enabled by default for connection failures
 server:
   request_logging: true
   rate_limits:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - Proxy Engines: concepts/proxy-engines.md
       - Proxy Profiles: concepts/proxy-profiles.md
       - Load Balancing: concepts/load-balancing.md
+      - Model Routing: concepts/model-routing.md
       - Model Unification: concepts/model-unification.md
       - Health Checking: concepts/health-checking.md
       - Profile System: concepts/profile-system.md

--- a/internal/adapter/discovery/repository.go
+++ b/internal/adapter/discovery/repository.go
@@ -110,6 +110,15 @@ func (r *StaticEndpointRepository) Exists(ctx context.Context, endpointURL *url.
 	return exists
 }
 
+// AddTestEndpoint adds an endpoint directly for testing purposes
+func (r *StaticEndpointRepository) AddTestEndpoint(endpoint *domain.Endpoint) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := endpoint.URL.String()
+	r.endpoints[key] = endpoint
+}
+
 func (r *StaticEndpointRepository) LoadFromConfig(ctx context.Context, configs []config.EndpointConfig) error {
 	if len(configs) == 0 {
 		r.mu.Lock()

--- a/internal/adapter/discovery/repository.go
+++ b/internal/adapter/discovery/repository.go
@@ -110,15 +110,6 @@ func (r *StaticEndpointRepository) Exists(ctx context.Context, endpointURL *url.
 	return exists
 }
 
-// AddTestEndpoint adds an endpoint directly for testing purposes
-func (r *StaticEndpointRepository) AddTestEndpoint(endpoint *domain.Endpoint) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	key := endpoint.URL.String()
-	r.endpoints[key] = endpoint
-}
-
 func (r *StaticEndpointRepository) LoadFromConfig(ctx context.Context, configs []config.EndpointConfig) error {
 	if len(configs) == 0 {
 		r.mu.Lock()

--- a/internal/adapter/discovery/repository_test_helpers.go
+++ b/internal/adapter/discovery/repository_test_helpers.go
@@ -1,0 +1,24 @@
+package discovery
+
+import "github.com/thushan/olla/internal/core/domain"
+
+// TestStaticEndpointRepository provides test-specific repository extensions
+type TestStaticEndpointRepository struct {
+	*StaticEndpointRepository
+}
+
+// NewTestStaticEndpointRepository creates a repository with test helpers
+func NewTestStaticEndpointRepository() *TestStaticEndpointRepository {
+	return &TestStaticEndpointRepository{
+		StaticEndpointRepository: NewStaticEndpointRepository(),
+	}
+}
+
+// AddTestEndpoint bypasses normal validation for test fixture creation
+func (r *TestStaticEndpointRepository) AddTestEndpoint(endpoint *domain.Endpoint) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	key := endpoint.URL.String()
+	r.endpoints[key] = endpoint
+}

--- a/internal/adapter/discovery/service_test.go
+++ b/internal/adapter/discovery/service_test.go
@@ -479,6 +479,15 @@ type mockModelRegistry struct {
 	mu                sync.Mutex
 }
 
+// GetRoutableEndpointsForModel
+func (m *mockModelRegistry) GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	return healthyEndpoints, &domain.ModelRoutingDecision{
+		Strategy: "mock",
+		Action:   "routed",
+		Reason:   "mock routing",
+	}, nil
+}
+
 func (m *mockModelRegistry) RegisterModel(ctx context.Context, endpointURL string, model *domain.ModelInfo) error {
 	return nil
 }

--- a/internal/adapter/health/checker.go
+++ b/internal/adapter/health/checker.go
@@ -279,11 +279,12 @@ func (c *HTTPHealthChecker) logHealthCheckResult(
 
 		case oldStatus == domain.StatusUnknown:
 			// Initial discovery of unhealthy endpoint
-			detailedArgs := []interface{}{
+			detailedArgs := make([]interface{}, 0, 8)
+			detailedArgs = append(detailedArgs,
 				"endpoint_url", endpoint.GetURLString(),
 				"status_code", result.StatusCode,
 				"error_type", result.ErrorType,
-			}
+			)
 			if checkErr != nil {
 				var healthCheckErr *domain.HealthCheckError
 				if errors.As(checkErr, &healthCheckErr) {
@@ -311,11 +312,12 @@ func (c *HTTPHealthChecker) logHealthCheckResult(
 
 		default:
 			// Status changed to unhealthy
-			detailedArgs := []interface{}{
+			detailedArgs := make([]interface{}, 0, 8)
+			detailedArgs = append(detailedArgs,
 				"endpoint_url", endpoint.GetURLString(),
 				"status_code", result.StatusCode,
 				"error_type", result.ErrorType,
-			}
+			)
 			if checkErr != nil {
 				var healthCheckErr *domain.HealthCheckError
 				if errors.As(checkErr, &healthCheckErr) {
@@ -338,11 +340,13 @@ func (c *HTTPHealthChecker) logHealthCheckResult(
 
 	case checkErr != nil && endpoint.ConsecutiveFailures > 0 && endpoint.ConsecutiveFailures%5 == 0:
 		// Log ongoing issues every 5th consecutive failure instead of time-based throttling
-		detailedArgs := []interface{}{
+		// Pre-allocate with capacity for all fields including error
+		detailedArgs := make([]interface{}, 0, 8)
+		detailedArgs = append(detailedArgs,
 			"endpoint_url", endpoint.GetURLString(),
 			"status_code", result.StatusCode,
 			"error_type", result.ErrorType,
-		}
+		)
 		var healthCheckErr *domain.HealthCheckError
 		if errors.As(checkErr, &healthCheckErr) {
 			detailedArgs = append(detailedArgs, "check_error", healthCheckErr.Error())

--- a/internal/adapter/health/client_backoff_test.go
+++ b/internal/adapter/health/client_backoff_test.go
@@ -1,0 +1,174 @@
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+func TestCalculateBackoff(t *testing.T) {
+	tests := []struct {
+		name               string
+		endpoint           *domain.Endpoint
+		success            bool
+		expectedInterval   time.Duration
+		expectedMultiplier int
+		description        string
+	}{
+		{
+			name: "success_resets_backoff",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     5 * time.Second,
+				BackoffMultiplier: 8,
+			},
+			success:            true,
+			expectedInterval:   5 * time.Second,
+			expectedMultiplier: 1,
+			description:        "Successful check should reset backoff to normal interval",
+		},
+		{
+			name: "first_failure_keeps_normal_interval",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     5 * time.Second,
+				BackoffMultiplier: 1,
+			},
+			success:            false,
+			expectedInterval:   5 * time.Second, // First failure uses normal interval
+			expectedMultiplier: 2,
+			description:        "First failure should keep normal interval but set multiplier to 2",
+		},
+		{
+			name: "second_failure_doubles_interval",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     5 * time.Second,
+				BackoffMultiplier: 2,
+			},
+			success:            false,
+			expectedInterval:   10 * time.Second, // Uses current multiplier (2)
+			expectedMultiplier: 4,
+			description:        "Second failure should double the interval (using multiplier 2)",
+		},
+		{
+			name: "third_failure_exponential_growth",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     5 * time.Second,
+				BackoffMultiplier: 4,
+			},
+			success:            false,
+			expectedInterval:   20 * time.Second, // Uses current multiplier (4)
+			expectedMultiplier: 8,
+			description:        "Third failure uses multiplier 4 (20s interval)",
+		},
+		{
+			name: "backoff_capped_at_max_multiplier",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     5 * time.Second,
+				BackoffMultiplier: 8,
+			},
+			success:            false,
+			expectedInterval:   40 * time.Second, // Uses current multiplier (8)
+			expectedMultiplier: 12,               // Next multiplier capped at 12
+			description:        "Fourth failure uses multiplier 8, next capped at 12",
+		},
+		{
+			name: "backoff_capped_at_max_seconds",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     10 * time.Second,
+				BackoffMultiplier: 6,
+			},
+			success:            false,
+			expectedInterval:   60 * time.Second, // 10s * 6 = 60s
+			expectedMultiplier: 12,
+			description:        "Interval should be capped at MaxBackoffSeconds",
+		},
+		{
+			name: "already_at_max_multiplier_stays_at_max",
+			endpoint: &domain.Endpoint{
+				CheckInterval:     5 * time.Second,
+				BackoffMultiplier: 12,
+			},
+			success:            false,
+			expectedInterval:   60 * time.Second,
+			expectedMultiplier: 12,
+			description:        "Once at max multiplier, should stay at max",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interval, multiplier := calculateBackoff(tt.endpoint, tt.success)
+
+			assert.Equal(t, tt.expectedInterval, interval,
+				"Interval mismatch: %s", tt.description)
+			assert.Equal(t, tt.expectedMultiplier, multiplier,
+				"Multiplier mismatch: %s", tt.description)
+		})
+	}
+}
+
+// TestBackoffProgressionSequence verifies the complete exponential backoff sequence
+func TestBackoffProgressionSequence(t *testing.T) {
+	endpoint := &domain.Endpoint{
+		CheckInterval:       5 * time.Second,
+		BackoffMultiplier:   1,
+		ConsecutiveFailures: 0,
+	}
+
+	// Expected exponential progression
+	expectedSequence := []struct {
+		interval   time.Duration
+		multiplier int
+	}{
+		{5 * time.Second, 2},   // First failure - normal interval
+		{10 * time.Second, 4},  // Second failure - 2x interval
+		{20 * time.Second, 8},  // Third failure - 4x interval
+		{40 * time.Second, 12}, // Fourth failure - 8x interval (next multiplier capped)
+		{60 * time.Second, 12}, // Fifth failure - capped at 60s
+	}
+
+	for i, expected := range expectedSequence {
+		interval, multiplier := calculateBackoff(endpoint, false)
+
+		assert.Equal(t, expected.interval, interval,
+			"Failure %d: Expected interval %v, got %v", i+1, expected.interval, interval)
+		assert.Equal(t, expected.multiplier, multiplier,
+			"Failure %d: Expected multiplier %d, got %d", i+1, expected.multiplier, multiplier)
+
+		// Update endpoint for next iteration
+		endpoint.BackoffMultiplier = multiplier
+		endpoint.ConsecutiveFailures++
+	}
+
+	// Verify recovery resets backoff
+	interval, multiplier := calculateBackoff(endpoint, true)
+	assert.Equal(t, 5*time.Second, interval, "Success should reset to original interval")
+	assert.Equal(t, 1, multiplier, "Success should reset multiplier to 1")
+}
+
+// TestBackoffDoesNotUseConsecutiveFailures ensures we don't accidentally use ConsecutiveFailures
+// instead of BackoffMultiplier for the calculation (this was the bug we fixed)
+func TestBackoffDoesNotUseConsecutiveFailures(t *testing.T) {
+	// This test specifically guards against the regression where we used
+	// ConsecutiveFailures instead of BackoffMultiplier
+
+	endpoint := &domain.Endpoint{
+		CheckInterval:       5 * time.Second,
+		BackoffMultiplier:   2,  // Exponential multiplier
+		ConsecutiveFailures: 10, // This should NOT affect the calculation
+	}
+
+	interval, multiplier := calculateBackoff(endpoint, false)
+
+	// With BackoffMultiplier=2, we use current multiplier for interval, next will be 4
+	assert.Equal(t, 10*time.Second, interval,
+		"Backoff should use current BackoffMultiplier (2), not ConsecutiveFailures (10)")
+	assert.Equal(t, 4, multiplier,
+		"Multiplier should double from 2 to 4, not be affected by ConsecutiveFailures")
+
+	// If we were incorrectly using ConsecutiveFailures, we'd get:
+	// interval = 5s * (10 * 2) = 100s (wrong!)
+	assert.NotEqual(t, 100*time.Second, interval,
+		"Interval should NOT be based on ConsecutiveFailures")
+}

--- a/internal/adapter/health/recovery_callback.go
+++ b/internal/adapter/health/recovery_callback.go
@@ -1,0 +1,26 @@
+package health
+
+import (
+	"context"
+
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+// RecoveryCallback is called when an endpoint recovers from unhealthy to healthy state
+type RecoveryCallback interface {
+	OnEndpointRecovered(ctx context.Context, endpoint *domain.Endpoint) error
+}
+
+// RecoveryCallbackFunc is a function adapter for RecoveryCallback
+type RecoveryCallbackFunc func(ctx context.Context, endpoint *domain.Endpoint) error
+
+func (f RecoveryCallbackFunc) OnEndpointRecovered(ctx context.Context, endpoint *domain.Endpoint) error {
+	return f(ctx, endpoint)
+}
+
+// NoOpRecoveryCallback is a no-op implementation of RecoveryCallback
+type NoOpRecoveryCallback struct{}
+
+func (n NoOpRecoveryCallback) OnEndpointRecovered(ctx context.Context, endpoint *domain.Endpoint) error {
+	return nil
+}

--- a/internal/adapter/health/recovery_callback_test.go
+++ b/internal/adapter/health/recovery_callback_test.go
@@ -1,0 +1,139 @@
+package health
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thushan/olla/internal/adapter/discovery"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/logger"
+)
+
+type testRecoveryCallback struct {
+	called   bool
+	endpoint *domain.Endpoint
+}
+
+func (t *testRecoveryCallback) OnEndpointRecovered(ctx context.Context, endpoint *domain.Endpoint) error {
+	t.called = true
+	t.endpoint = endpoint
+	return nil
+}
+
+func TestHealthCheckerRecoveryCallback(t *testing.T) {
+	// Create a test server that will be "down" initially then come back up
+	serverIsHealthy := false
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if serverIsHealthy {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer testServer.Close()
+
+	// Create test endpoint
+	endpointURL, _ := url.Parse(testServer.URL)
+	endpoint := &domain.Endpoint{
+		Name:                 "test-endpoint",
+		URL:                  endpointURL,
+		URLString:            testServer.URL,
+		HealthCheckURL:       endpointURL,
+		HealthCheckURLString: testServer.URL,
+		Status:               domain.StatusUnknown, // Start as unknown
+		CheckInterval:        100 * time.Millisecond,
+		CheckTimeout:         50 * time.Millisecond,
+	}
+
+	// Create repository and add endpoint directly
+	repo := discovery.NewStaticEndpointRepository()
+	// Add the endpoint to the repository (for testing)
+	repo.AddTestEndpoint(endpoint)
+
+	// Create logger
+	logCfg := &logger.Config{Level: "error"}
+	log, _, _ := logger.New(logCfg)
+	testLogger := logger.NewPlainStyledLogger(log)
+
+	// Create health checker with callback
+	checker := NewHTTPHealthCheckerWithDefaults(repo, testLogger)
+
+	// Set up recovery callback
+	recoveryCallback := &testRecoveryCallback{}
+	checker.SetRecoveryCallback(recoveryCallback)
+
+	ctx := context.Background()
+
+	// Start health checking
+	err := checker.StartChecking(ctx)
+	assert.NoError(t, err)
+	defer checker.StopChecking(ctx)
+
+	// Initial check - endpoint should be unhealthy
+	// Get endpoint from repo to ensure we have the latest state
+	endpoints, _ := repo.GetAll(ctx)
+	checker.checkEndpoint(ctx, endpoints[0])
+
+	// Wait for status to be updated in repository
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify endpoint is now unhealthy (or offline)
+	endpoints, _ = repo.GetAll(ctx)
+	assert.True(t, endpoints[0].Status == domain.StatusUnhealthy || endpoints[0].Status == domain.StatusOffline)
+
+	// Verify callback was not called (no recovery yet)
+	assert.False(t, recoveryCallback.called)
+
+	// Make server healthy
+	serverIsHealthy = true
+
+	// Check again - endpoint should recover
+	endpoints, _ = repo.GetAll(ctx)
+	checker.checkEndpoint(ctx, endpoints[0])
+
+	// Give it a moment to process
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify callback was called
+	assert.True(t, recoveryCallback.called)
+	assert.NotNil(t, recoveryCallback.endpoint)
+	assert.Equal(t, "test-endpoint", recoveryCallback.endpoint.Name)
+	assert.Equal(t, domain.StatusHealthy, recoveryCallback.endpoint.Status)
+}
+
+func TestRecoveryCallbackFunc(t *testing.T) {
+	called := false
+	var capturedEndpoint *domain.Endpoint
+
+	callbackFunc := RecoveryCallbackFunc(func(ctx context.Context, endpoint *domain.Endpoint) error {
+		called = true
+		capturedEndpoint = endpoint
+		return nil
+	})
+
+	testEndpoint := &domain.Endpoint{
+		Name:   "test",
+		Status: domain.StatusHealthy,
+	}
+
+	err := callbackFunc.OnEndpointRecovered(context.Background(), testEndpoint)
+
+	assert.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, testEndpoint, capturedEndpoint)
+}
+
+func TestNoOpRecoveryCallback(t *testing.T) {
+	callback := NoOpRecoveryCallback{}
+
+	err := callback.OnEndpointRecovered(context.Background(), &domain.Endpoint{
+		Name: "test",
+	})
+
+	assert.NoError(t, err)
+}

--- a/internal/adapter/health/recovery_callback_test.go
+++ b/internal/adapter/health/recovery_callback_test.go
@@ -50,8 +50,8 @@ func TestHealthCheckerRecoveryCallback(t *testing.T) {
 		CheckTimeout:         50 * time.Millisecond,
 	}
 
-	// Create repository and add endpoint directly
-	repo := discovery.NewStaticEndpointRepository()
+	// Create test repository and add endpoint directly
+	repo := discovery.NewTestStaticEndpointRepository()
 	// Add the endpoint to the repository (for testing)
 	repo.AddTestEndpoint(endpoint)
 
@@ -60,8 +60,8 @@ func TestHealthCheckerRecoveryCallback(t *testing.T) {
 	log, _, _ := logger.New(logCfg)
 	testLogger := logger.NewPlainStyledLogger(log)
 
-	// Create health checker with callback
-	checker := NewHTTPHealthCheckerWithDefaults(repo, testLogger)
+	// Create health checker with callback (using the embedded repository)
+	checker := NewHTTPHealthCheckerWithDefaults(repo.StaticEndpointRepository, testLogger)
 
 	// Set up recovery callback
 	recoveryCallback := &testRecoveryCallback{}

--- a/internal/adapter/health/types.go
+++ b/internal/adapter/health/types.go
@@ -13,4 +13,5 @@ const (
 	DefaultCircuitBreakerTimeout   = 30 * time.Second
 
 	MaxBackoffMultiplier = 12
+	MaxBackoffSeconds    = 60 * time.Second
 )

--- a/internal/adapter/proxy/core/common.go
+++ b/internal/adapter/proxy/core/common.go
@@ -13,15 +13,6 @@ import (
 	"github.com/thushan/olla/internal/version"
 )
 
-// Deprecated: Use constants from internal/core/constants/content.go instead
-const (
-	HeaderRequestID    = constants.HeaderXOllaRequestID
-	HeaderEndpoint     = constants.HeaderXOllaEndpoint
-	HeaderBackendType  = constants.HeaderXOllaBackendType
-	HeaderModel        = constants.HeaderXOllaModel
-	HeaderResponseTime = constants.HeaderXOllaResponseTime
-)
-
 var (
 	proxiedByHeader string
 	viaHeader       string
@@ -179,13 +170,13 @@ func SetResponseHeaders(w http.ResponseWriter, stats *ports.RequestStats, endpoi
 	// Set request tracking headers
 	if stats != nil {
 		if stats.RequestID != "" {
-			h.Set(HeaderRequestID, stats.RequestID)
+			h.Set(constants.HeaderXOllaRequestID, stats.RequestID)
 		}
 
 		// Calculate and set response time if we have timing information
 		if !stats.StartTime.IsZero() {
 			responseTime := time.Since(stats.StartTime)
-			h.Set(HeaderResponseTime, responseTime.String())
+			h.Set(constants.HeaderXOllaResponseTime, responseTime.String())
 		}
 
 		// set routing decision headers if available
@@ -200,12 +191,12 @@ func SetResponseHeaders(w http.ResponseWriter, stats *ports.RequestStats, endpoi
 
 	// Set endpoint information
 	if endpoint != nil {
-		h.Set(HeaderEndpoint, endpoint.Name)
-		h.Set(HeaderBackendType, endpoint.Type)
+		h.Set(constants.HeaderXOllaEndpoint, endpoint.Name)
+		h.Set(constants.HeaderXOllaBackendType, endpoint.Type)
 
 		// Set model header if available
 		if stats != nil && stats.Model != "" {
-			h.Set(HeaderModel, stats.Model)
+			h.Set(constants.HeaderXOllaModel, stats.Model)
 		}
 	}
 }

--- a/internal/adapter/proxy/core/common.go
+++ b/internal/adapter/proxy/core/common.go
@@ -187,6 +187,15 @@ func SetResponseHeaders(w http.ResponseWriter, stats *ports.RequestStats, endpoi
 			responseTime := time.Since(stats.StartTime)
 			h.Set(HeaderResponseTime, responseTime.String())
 		}
+
+		// set routing decision headers if available
+		if stats.RoutingDecision != nil {
+			h.Set(constants.HeaderXOllaRoutingStrategy, stats.RoutingDecision.Strategy)
+			h.Set(constants.HeaderXOllaRoutingDecision, stats.RoutingDecision.Action)
+			if stats.RoutingDecision.Reason != "" {
+				h.Set(constants.HeaderXOllaRoutingReason, stats.RoutingDecision.Reason)
+			}
+		}
 	}
 
 	// Set endpoint information

--- a/internal/adapter/proxy/core/common_test.go
+++ b/internal/adapter/proxy/core/common_test.go
@@ -465,9 +465,9 @@ func TestProxyHeaderConstants(t *testing.T) {
 
 func TestHeaderConstants(t *testing.T) {
 	// Test that header constants are defined
-	assert.Equal(t, "X-Olla-Request-ID", HeaderRequestID)
-	assert.Equal(t, "X-Olla-Endpoint", HeaderEndpoint)
-	assert.Equal(t, "X-Olla-Backend-Type", HeaderBackendType)
-	assert.Equal(t, "X-Olla-Model", HeaderModel)
-	assert.Equal(t, "X-Olla-Response-Time", HeaderResponseTime)
+	assert.Equal(t, "X-Olla-Request-ID", constants.HeaderXOllaRequestID)
+	assert.Equal(t, "X-Olla-Endpoint", constants.HeaderXOllaEndpoint)
+	assert.Equal(t, "X-Olla-Backend-Type", constants.HeaderXOllaBackendType)
+	assert.Equal(t, "X-Olla-Model", constants.HeaderXOllaModel)
+	assert.Equal(t, "X-Olla-Response-Time", constants.HeaderXOllaResponseTime)
 }

--- a/internal/adapter/proxy/core/retry.go
+++ b/internal/adapter/proxy/core/retry.go
@@ -1,0 +1,205 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// RetryHandler provides connection failure retry logic for proxy implementations
+type RetryHandler struct {
+	logger           logger.StyledLogger
+	discoveryService ports.DiscoveryService
+}
+
+// NewRetryHandler creates a new retry handler
+func NewRetryHandler(discoveryService ports.DiscoveryService, logger logger.StyledLogger) *RetryHandler {
+	return &RetryHandler{
+		discoveryService: discoveryService,
+		logger:           logger,
+	}
+}
+
+// ProxyFunc is the function signature for proxying to a single endpoint
+type ProxyFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats) error
+
+// ExecuteWithRetry executes a proxy request with retry logic on connection failures
+func (h *RetryHandler) ExecuteWithRetry(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	endpoints []*domain.Endpoint,
+	selector domain.EndpointSelector,
+	stats *ports.RequestStats,
+	proxyFunc ProxyFunc,
+) error {
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no endpoints available")
+	}
+
+	// Create a copy of endpoints for retry logic
+	availableEndpoints := make([]*domain.Endpoint, len(endpoints))
+	copy(availableEndpoints, endpoints)
+
+	var lastErr error
+	maxRetries := len(endpoints) // Try each endpoint once
+	retryCount := 0
+
+	// Save the original request body for retry
+	var bodyBytes []byte
+	if r.Body != nil && r.Body != http.NoBody {
+		bodyBytes, _ = io.ReadAll(r.Body)
+		r.Body.Close()
+	}
+
+	for retryCount <= maxRetries && len(availableEndpoints) > 0 {
+		// Restore request body for retry
+		if bodyBytes != nil {
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		// Select endpoint
+		endpoint, err := selector.Select(ctx, availableEndpoints)
+		if err != nil {
+			return fmt.Errorf("endpoint selection failed: %w", err)
+		}
+
+		// Try proxying to this endpoint
+		err = proxyFunc(ctx, w, r, endpoint, stats)
+
+		if err == nil {
+			// Success!
+			return nil
+		}
+
+		lastErr = err
+
+		// Check if this is a connection error
+		if IsConnectionError(err) {
+			h.logger.Warn("Connection failed to endpoint, marking as unhealthy",
+				"endpoint", endpoint.Name,
+				"error", err,
+				"retry", retryCount+1,
+				"remaining_endpoints", len(availableEndpoints)-1)
+
+			// Mark endpoint as unhealthy
+			h.markEndpointUnhealthy(ctx, endpoint)
+
+			// Remove this endpoint from available list
+			newAvailable := make([]*domain.Endpoint, 0, len(availableEndpoints)-1)
+			for _, ep := range availableEndpoints {
+				if ep.Name != endpoint.Name {
+					newAvailable = append(newAvailable, ep)
+				}
+			}
+			availableEndpoints = newAvailable
+
+			retryCount++
+
+			// Continue to next endpoint
+			if len(availableEndpoints) > 0 {
+				h.logger.Info("Retrying request with different endpoint",
+					"available_endpoints", len(availableEndpoints))
+				continue
+			}
+		} else {
+			// Non-connection error, don't retry
+			return err
+		}
+	}
+
+	if len(availableEndpoints) == 0 {
+		return fmt.Errorf("all endpoints failed with connection errors: %w", lastErr)
+	}
+
+	return fmt.Errorf("max retries (%d) exceeded: %w", maxRetries, lastErr)
+}
+
+// IsConnectionError determines if an error is a connection failure that warrants retry
+func IsConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for network errors
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// Check for specific syscall errors
+	var syscallErr syscall.Errno
+	if errors.As(err, &syscallErr) {
+		switch syscallErr {
+		case syscall.ECONNREFUSED, syscall.ECONNRESET, syscall.ECONNABORTED:
+			return true
+		default:
+			// Other syscall errors are not connection errors
+		}
+	}
+
+	// Check for common connection error messages
+	errStr := err.Error()
+	connectionErrors := []string{
+		"connection refused",
+		"connection reset",
+		"no such host",
+		"network is unreachable",
+		"no route to host",
+		"connection timed out",
+		"i/o timeout",
+		"dial tcp",
+		"connectex:",
+	}
+
+	for _, pattern := range connectionErrors {
+		if strings.Contains(strings.ToLower(errStr), pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// markEndpointUnhealthy marks an endpoint as unhealthy
+func (h *RetryHandler) markEndpointUnhealthy(ctx context.Context, endpoint *domain.Endpoint) {
+	if endpoint == nil {
+		return
+	}
+
+	// Create a copy to avoid modifying the original
+	endpointCopy := *endpoint
+	endpointCopy.Status = domain.StatusOffline
+	endpointCopy.ConsecutiveFailures++
+	endpointCopy.LastChecked = time.Now()
+
+	// Calculate backoff for next check
+	backoffSeconds := endpointCopy.ConsecutiveFailures * 2
+	if backoffSeconds > 60 {
+		backoffSeconds = 60
+	}
+	endpointCopy.NextCheckTime = time.Now().Add(time.Duration(backoffSeconds) * time.Second)
+
+	h.logger.Warn("Marking endpoint as unhealthy due to connection failure",
+		"endpoint", endpoint.Name,
+		"consecutive_failures", endpointCopy.ConsecutiveFailures,
+		"next_check", endpointCopy.NextCheckTime.Format(time.RFC3339))
+
+	// Try to update endpoint status in repository through discovery service
+	if discoveryService, ok := h.discoveryService.(ports.DiscoveryServiceWithEndpointUpdate); ok {
+		if err := discoveryService.UpdateEndpointStatus(ctx, &endpointCopy); err != nil {
+			h.logger.Debug("Failed to update endpoint status in repository", "error", err)
+		}
+	}
+}

--- a/internal/adapter/proxy/core/retry.go
+++ b/internal/adapter/proxy/core/retry.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/thushan/olla/internal/adapter/health"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 	"github.com/thushan/olla/internal/logger"
@@ -201,13 +202,13 @@ func (h *RetryHandler) markEndpointUnhealthy(ctx context.Context, endpoint *doma
 
 		// Calculate next multiplier for future failures
 		endpointCopy.BackoffMultiplier *= 2
-		if endpointCopy.BackoffMultiplier > 12 {
-			endpointCopy.BackoffMultiplier = 12
+		if endpointCopy.BackoffMultiplier > health.MaxBackoffMultiplier {
+			endpointCopy.BackoffMultiplier = health.MaxBackoffMultiplier
 		}
 	}
 
-	if backoffInterval > 60*time.Second {
-		backoffInterval = 60 * time.Second
+	if backoffInterval > health.MaxBackoffSeconds {
+		backoffInterval = health.MaxBackoffSeconds
 	}
 	endpointCopy.NextCheckTime = now.Add(backoffInterval)
 

--- a/internal/adapter/proxy/core/retry.go
+++ b/internal/adapter/proxy/core/retry.go
@@ -178,11 +178,13 @@ func (h *RetryHandler) markEndpointUnhealthy(ctx context.Context, endpoint *doma
 		return
 	}
 
+	now := time.Now()
+
 	// Work with copy to preserve original state
 	endpointCopy := *endpoint
 	endpointCopy.Status = domain.StatusOffline
 	endpointCopy.ConsecutiveFailures++
-	endpointCopy.LastChecked = time.Now()
+	endpointCopy.LastChecked = now
 
 	// Calculate proper exponential backoff multiplier
 	// First failure: keep default interval from the endpoint but set multiplier to 2
@@ -207,7 +209,7 @@ func (h *RetryHandler) markEndpointUnhealthy(ctx context.Context, endpoint *doma
 	if backoffInterval > 60*time.Second {
 		backoffInterval = 60 * time.Second
 	}
-	endpointCopy.NextCheckTime = time.Now().Add(backoffInterval)
+	endpointCopy.NextCheckTime = now.Add(backoffInterval)
 
 	h.logger.Warn("Marking endpoint as unhealthy due to connection failure",
 		"endpoint", endpoint.Name,

--- a/internal/adapter/proxy/core/retry_test.go
+++ b/internal/adapter/proxy/core/retry_test.go
@@ -1,0 +1,142 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// testDiscoveryService for testing
+type testDiscoveryService struct {
+	updatedEndpoint *domain.Endpoint
+}
+
+func (t *testDiscoveryService) GetEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
+	return nil, nil
+}
+
+func (t *testDiscoveryService) GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
+	return nil, nil
+}
+
+func (t *testDiscoveryService) RefreshEndpoints(ctx context.Context) error {
+	return nil
+}
+
+func (t *testDiscoveryService) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	// Capture the endpoint for verification
+	t.updatedEndpoint = &domain.Endpoint{}
+	*t.updatedEndpoint = *endpoint
+	return nil
+}
+
+func TestMarkEndpointUnhealthyBackoffProgression(t *testing.T) {
+	tests := []struct {
+		name                       string
+		initialBackoffMultiplier   int
+		initialConsecutiveFailures int
+		expectedBackoffMultiplier  int
+		expectedBackoffInterval    time.Duration
+	}{
+		{
+			name:                       "first_failure",
+			initialBackoffMultiplier:   0, // uninitialized
+			initialConsecutiveFailures: 0,
+			expectedBackoffMultiplier:  2,
+			expectedBackoffInterval:    5 * time.Second, // First failure uses normal interval
+		},
+		{
+			name:                       "second_failure",
+			initialBackoffMultiplier:   2,
+			initialConsecutiveFailures: 1,
+			expectedBackoffMultiplier:  4,
+			expectedBackoffInterval:    10 * time.Second, // 5s * 2
+		},
+		{
+			name:                       "third_failure",
+			initialBackoffMultiplier:   4,
+			initialConsecutiveFailures: 2,
+			expectedBackoffMultiplier:  8,
+			expectedBackoffInterval:    20 * time.Second, // 5s * 4
+		},
+		{
+			name:                       "fourth_failure_capped",
+			initialBackoffMultiplier:   8,
+			initialConsecutiveFailures: 3,
+			expectedBackoffMultiplier:  12,               // capped at 12
+			expectedBackoffInterval:    40 * time.Second, // 5s * 8
+		},
+		{
+			name:                       "already_at_max",
+			initialBackoffMultiplier:   12,
+			initialConsecutiveFailures: 4,
+			expectedBackoffMultiplier:  12,               // stays at 12
+			expectedBackoffInterval:    60 * time.Second, // stays at 60s
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test discovery service
+			testDiscovery := &testDiscoveryService{}
+
+			// Create test logger
+			logConfig := &logger.Config{Level: "error"}
+			log, _, _ := logger.New(logConfig)
+			testLogger := logger.NewPlainStyledLogger(log)
+
+			// Create retry handler
+			handler := NewRetryHandler(testDiscovery, testLogger)
+
+			// Create test endpoint
+			endpoint := &domain.Endpoint{
+				Name:                "test-endpoint",
+				CheckInterval:       5 * time.Second,
+				BackoffMultiplier:   tt.initialBackoffMultiplier,
+				ConsecutiveFailures: tt.initialConsecutiveFailures,
+			}
+
+			// Mark endpoint as unhealthy
+			handler.markEndpointUnhealthy(context.Background(), endpoint)
+
+			// Verify the updated endpoint has correct values
+			assert.NotNil(t, testDiscovery.updatedEndpoint)
+			assert.Equal(t, tt.expectedBackoffMultiplier, testDiscovery.updatedEndpoint.BackoffMultiplier,
+				"BackoffMultiplier should be %d", tt.expectedBackoffMultiplier)
+			assert.Equal(t, tt.initialConsecutiveFailures+1, testDiscovery.updatedEndpoint.ConsecutiveFailures,
+				"ConsecutiveFailures should increment")
+			assert.Equal(t, domain.StatusOffline, testDiscovery.updatedEndpoint.Status,
+				"Status should be Offline")
+
+			// Verify NextCheckTime is set correctly
+			actualBackoffInterval := testDiscovery.updatedEndpoint.NextCheckTime.Sub(time.Now())
+
+			// Allow 1 second tolerance for test execution time
+			assert.InDelta(t, tt.expectedBackoffInterval.Seconds(), actualBackoffInterval.Seconds(), 1,
+				"Expected backoff interval ~%v, got %v", tt.expectedBackoffInterval, actualBackoffInterval)
+		})
+	}
+}
+
+func TestMarkEndpointUnhealthyNilEndpoint(t *testing.T) {
+	// Create test discovery service
+	testDiscovery := &testDiscoveryService{}
+
+	// Create test logger
+	logConfig := &logger.Config{Level: "error"}
+	log, _, _ := logger.New(logConfig)
+	testLogger := logger.NewPlainStyledLogger(log)
+
+	// Create retry handler
+	handler := NewRetryHandler(testDiscovery, testLogger)
+
+	// Should not panic or call UpdateEndpointStatus with nil endpoint
+	handler.markEndpointUnhealthy(context.Background(), nil)
+
+	// Verify no update was made
+	assert.Nil(t, testDiscovery.updatedEndpoint, "Should not update nil endpoint")
+}

--- a/internal/adapter/proxy/olla/service_leak_test.go
+++ b/internal/adapter/proxy/olla/service_leak_test.go
@@ -320,6 +320,10 @@ func (m *mockDiscoveryService) RefreshEndpoints(ctx context.Context) error {
 	return nil
 }
 
+func (m *mockDiscoveryService) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	return nil
+}
+
 type mockEndpointSelector struct{}
 
 func (m *mockEndpointSelector) Select(ctx context.Context, endpoints []*domain.Endpoint) (*domain.Endpoint, error) {

--- a/internal/adapter/proxy/proxy_test.go
+++ b/internal/adapter/proxy/proxy_test.go
@@ -105,6 +105,17 @@ func (m *mockDiscoveryService) RefreshEndpoints(ctx context.Context) error {
 	return m.err
 }
 
+func (m *mockDiscoveryService) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	// Find and update the endpoint in our mock list
+	for i, ep := range m.endpoints {
+		if ep.URLString == endpoint.URLString {
+			m.endpoints[i] = endpoint
+			return nil
+		}
+	}
+	return nil
+}
+
 type mockEndpointSelector struct {
 	endpoint  *domain.Endpoint
 	err       error

--- a/internal/adapter/proxy/sherpa/service.go
+++ b/internal/adapter/proxy/sherpa/service.go
@@ -30,22 +30,15 @@ package sherpa
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"time"
 
-	"github.com/thushan/olla/internal/core/constants"
-
-	"github.com/thushan/olla/internal/adapter/proxy/common"
 	"github.com/thushan/olla/internal/adapter/proxy/core"
-	"github.com/thushan/olla/internal/app/middleware"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 	"github.com/thushan/olla/internal/logger"
-	"github.com/thushan/olla/internal/util"
 	"github.com/thushan/olla/pkg/pool"
 )
 
@@ -140,214 +133,12 @@ func (s *Service) ProxyRequest(ctx context.Context, w http.ResponseWriter, r *ht
 		return err
 	}
 
-	return s.ProxyRequestToEndpoints(ctx, w, r, endpoints, stats, rlog)
-}
-
-// ProxyRequestToEndpoints proxies the request to the provided endpoints
-func (s *Service) ProxyRequestToEndpoints(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoints []*domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) error {
 	return s.ProxyRequestToEndpointsWithRetry(ctx, w, r, endpoints, stats, rlog)
 }
 
-// ProxyRequestToEndpointsLegacy is the original implementation without retry logic
-func (s *Service) ProxyRequestToEndpointsLegacy(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoints []*domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) (err error) {
-	// Panic recovery
-	defer func() {
-		if rec := recover(); rec != nil {
-			s.RecordFailure(ctx, nil, time.Since(stats.StartTime), fmt.Errorf("panic: %v", rec))
-
-			err = fmt.Errorf("proxy panic recovered after %.1fs: %v (this is a bug, please report)",
-				time.Since(stats.StartTime).Seconds(), rec)
-			rlog.Error("proxy request panic recovered",
-				"panic", rec,
-				"method", r.Method,
-				"path", r.URL.Path)
-
-			if w.Header().Get(constants.HeaderContentType) == "" {
-				http.Error(w, "Internal server error", http.StatusInternalServerError)
-			}
-		}
-	}()
-
-	s.IncrementRequests()
-
-	// Use context logger if available, fallback to provided logger
-	ctxLogger := middleware.GetLogger(ctx)
-	if ctxLogger != nil {
-		ctxLogger.Debug("Sherpa proxy request started",
-			"method", r.Method,
-			"url", r.URL.String(),
-			"endpoint_count", len(endpoints))
-	} else {
-		rlog.Debug("proxy request started", "method", r.Method, "url", r.URL.String())
-	}
-
-	if len(endpoints) == 0 {
-		if ctxLogger != nil {
-			ctxLogger.Error("No healthy endpoints available for request")
-		} else {
-			rlog.Error("no healthy endpoints available")
-		}
-		s.RecordFailure(ctx, nil, time.Since(stats.StartTime), common.ErrNoHealthyEndpoints)
-		return common.ErrNoHealthyEndpoints
-	}
-
-	if ctxLogger != nil {
-		ctxLogger.Debug("Using provided endpoints", "count", len(endpoints))
-	} else {
-		rlog.Debug("using provided endpoints", "count", len(endpoints))
-	}
-
-	// Select endpoint
-	startSelect := time.Now()
-	endpoint, err := s.Selector.Select(ctx, endpoints)
-	stats.SelectionMs = time.Since(startSelect).Milliseconds()
-
-	if err != nil {
-		rlog.Error("failed to select endpoint", "error", err)
-		s.RecordFailure(ctx, nil, time.Since(stats.StartTime), err)
-		return fmt.Errorf("endpoint selection failed: %w", err)
-	}
-
-	stats.EndpointName = endpoint.Name
-
-	if ctxLogger != nil {
-		ctxLogger.Info("Request dispatching",
-			"endpoint", endpoint.Name,
-			"target", stats.TargetUrl,
-			"model", stats.Model)
-	} else {
-		rlog.Info("Request dispatching", "endpoint", endpoint.Name, "target", stats.TargetUrl, "model", stats.Model)
-	}
-
-	s.Selector.IncrementConnections(endpoint)
-	defer s.Selector.DecrementConnections(endpoint)
-
-	// Strip route prefix from request path for upstream
-	targetPath := util.StripPrefix(r.URL.Path, s.configuration.GetProxyPrefix())
-	targetURL := endpoint.URL.ResolveReference(&url.URL{Path: targetPath})
-	if r.URL.RawQuery != "" {
-		targetURL.RawQuery = r.URL.RawQuery
-	}
-
-	stats.TargetUrl = targetURL.String()
-
-	proxyReq, err := http.NewRequestWithContext(ctx, r.Method, targetURL.String(), r.Body)
-	if err != nil {
-		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), err)
-		return fmt.Errorf("failed to create proxy request: %w", err)
-	}
-
-	rlog.Debug("created proxy request")
-
-	headerStart := time.Now()
-	core.CopyHeaders(proxyReq, r)
-	stats.HeaderProcessingMs = time.Since(headerStart).Milliseconds()
-
-	// Add model header if available
-	if model, ok := ctx.Value("model").(string); ok && model != "" {
-		proxyReq.Header.Set("X-Model", model)
-		stats.Model = model
-	}
-
-	// we mark the request processing as complete here
-	stats.RequestProcessingMs = time.Since(stats.StartTime).Milliseconds()
-
-	rlog.Debug("making round-trip request", "target", targetURL.String())
-	backendStart := time.Now()
-	resp, err := s.transport.RoundTrip(proxyReq)
-	stats.BackendResponseMs = time.Since(backendStart).Milliseconds()
-
-	if err != nil {
-		rlog.Error("round-trip failed", "error", err)
-		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), err)
-		duration := time.Since(stats.StartTime)
-		return common.MakeUserFriendlyError(err, duration, "backend", s.configuration.GetResponseTimeout())
-	}
-	defer resp.Body.Close()
-
-	rlog.Debug("round-trip success", "status", resp.StatusCode)
-
-	core.SetResponseHeaders(w, stats, endpoint)
-
-	// Copy response headers
-	for key, values := range resp.Header {
-		for _, value := range values {
-			w.Header().Add(key, value)
-		}
-	}
-
-	w.WriteHeader(resp.StatusCode)
-
-	// stream the response through
-	rlog.Debug("starting response stream")
-	streamStart := time.Now()
-	stats.FirstDataMs = time.Since(stats.StartTime).Milliseconds()
-
-	buffer := s.bufferPool.Get()
-	defer s.bufferPool.Put(buffer)
-
-	// Stream with timeout protection - don't let slow clients hang forever
-	bytesWritten, streamErr := s.streamResponseWithTimeout(ctx, ctx, w, resp, *buffer, rlog)
-	stats.StreamingMs = time.Since(streamStart).Milliseconds()
-	stats.TotalBytes = bytesWritten
-
-	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
-		rlog.Error("streaming failed", "error", streamErr)
-		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), streamErr)
-		return common.MakeUserFriendlyError(streamErr, time.Since(stats.StartTime), "streaming", s.configuration.GetResponseTimeout())
-	}
-
-	// we've successfully written the response
-	duration := time.Since(stats.StartTime)
-	s.RecordSuccess(endpoint, duration.Milliseconds(), int64(bytesWritten))
-
-	s.PublishEvent(core.ProxyEvent{
-		Type:      core.EventTypeProxySuccess,
-		RequestID: stats.RequestID,
-		Endpoint:  endpoint.Name,
-		Duration:  duration,
-		Metadata: core.ProxyEventMetadata{
-			BytesSent:  int64(bytesWritten),
-			StatusCode: resp.StatusCode,
-			Model:      stats.Model,
-		},
-	})
-
-	// stats update
-	stats.EndTime = time.Now()
-	stats.Latency = stats.EndTime.Sub(stats.StartTime).Milliseconds()
-	stats.TotalBytes = bytesWritten
-
-	// Log detailed completion metrics at Debug level to reduce redundancy
-	if ctxLogger != nil {
-		ctxLogger.Debug("Sherpa proxy metrics",
-			"endpoint", endpoint.Name,
-			"latency_ms", stats.Latency,
-			"processing_ms", stats.RequestProcessingMs,
-			"backend_ms", stats.BackendResponseMs,
-			"first_data_ms", stats.FirstDataMs,
-			"streaming_ms", stats.StreamingMs,
-			"selection_ms", stats.SelectionMs,
-			"header_ms", stats.HeaderProcessingMs,
-			"total_bytes", stats.TotalBytes,
-			"bytes_formatted", middleware.FormatBytes(int64(stats.TotalBytes)),
-			"status", resp.StatusCode,
-			"request_id", middleware.GetRequestID(ctx))
-	} else {
-		rlog.Debug("proxy request completed",
-			"endpoint", endpoint.Name,
-			"latency_ms", stats.Latency,
-			"processing_ms", stats.RequestProcessingMs,
-			"backend_ms", stats.BackendResponseMs,
-			"first_data_ms", stats.FirstDataMs,
-			"streaming_ms", stats.StreamingMs,
-			"selection_ms", stats.SelectionMs,
-			"header_ms", stats.HeaderProcessingMs,
-			"total_bytes", stats.TotalBytes,
-			"status", resp.StatusCode)
-	}
-
-	return nil
+// ProxyRequestToEndpoints proxies the request to the provided endpoints with automatic retry on connection failures
+func (s *Service) ProxyRequestToEndpoints(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoints []*domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) error {
+	return s.ProxyRequestToEndpointsWithRetry(ctx, w, r, endpoints, stats, rlog)
 }
 
 // GetStats returns current proxy statistics

--- a/internal/adapter/proxy/sherpa/service_retry.go
+++ b/internal/adapter/proxy/sherpa/service_retry.go
@@ -1,0 +1,190 @@
+package sherpa
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/thushan/olla/internal/adapter/proxy/common"
+	"github.com/thushan/olla/internal/adapter/proxy/core"
+	"github.com/thushan/olla/internal/app/middleware"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+	"github.com/thushan/olla/internal/util"
+)
+
+// ProxyRequestToEndpointsWithRetry proxies the request with retry logic for connection failures
+func (s *Service) ProxyRequestToEndpointsWithRetry(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoints []*domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) error {
+	s.IncrementRequests()
+
+	// Use context logger if available, fallback to provided logger
+	ctxLogger := middleware.GetLogger(ctx)
+	if ctxLogger != nil {
+		ctxLogger.Debug("Sherpa proxy request started",
+			"method", r.Method,
+			"url", r.URL.String(),
+			"endpoint_count", len(endpoints))
+	} else {
+		rlog.Debug("proxy request started", "method", r.Method, "url", r.URL.String())
+	}
+
+	if len(endpoints) == 0 {
+		if ctxLogger != nil {
+			ctxLogger.Error("No healthy endpoints available for request")
+		} else {
+			rlog.Error("no healthy endpoints available")
+		}
+		s.RecordFailure(ctx, nil, time.Since(stats.StartTime), common.ErrNoHealthyEndpoints)
+		return common.ErrNoHealthyEndpoints
+	}
+
+	// Define the proxy function for a single endpoint
+	proxyFunc := func(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats) error {
+		return s.proxyToSingleEndpoint(ctx, w, r, endpoint, stats, rlog)
+	}
+
+	// Use the shared retry handler
+	return s.retryHandler.ExecuteWithRetry(ctx, w, r, endpoints, s.Selector, stats, proxyFunc)
+}
+
+// proxyToSingleEndpoint handles proxying to a single endpoint
+func (s *Service) proxyToSingleEndpoint(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) error {
+	stats.EndpointName = endpoint.Name
+
+	ctxLogger := middleware.GetLogger(ctx)
+	if ctxLogger != nil {
+		ctxLogger.Info("Request dispatching",
+			"endpoint", endpoint.Name,
+			"target", stats.TargetUrl,
+			"model", stats.Model)
+	} else {
+		rlog.Info("Request dispatching", "endpoint", endpoint.Name, "target", stats.TargetUrl, "model", stats.Model)
+	}
+
+	s.Selector.IncrementConnections(endpoint)
+	defer s.Selector.DecrementConnections(endpoint)
+
+	// Strip route prefix from request path for upstream
+	targetPath := util.StripPrefix(r.URL.Path, s.configuration.GetProxyPrefix())
+	targetURL := endpoint.URL.ResolveReference(&url.URL{Path: targetPath})
+	if r.URL.RawQuery != "" {
+		targetURL.RawQuery = r.URL.RawQuery
+	}
+
+	stats.TargetUrl = targetURL.String()
+
+	proxyReq, err := http.NewRequestWithContext(ctx, r.Method, targetURL.String(), r.Body)
+	if err != nil {
+		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), err)
+		return fmt.Errorf("failed to create proxy request: %w", err)
+	}
+
+	rlog.Debug("created proxy request")
+
+	headerStart := time.Now()
+	core.CopyHeaders(proxyReq, r)
+	stats.HeaderProcessingMs = time.Since(headerStart).Milliseconds()
+
+	// Add model header if available
+	if model, ok := ctx.Value("model").(string); ok && model != "" {
+		proxyReq.Header.Set("X-Model", model)
+		stats.Model = model
+	}
+
+	// We mark the request processing as complete here
+	stats.RequestProcessingMs = time.Since(stats.StartTime).Milliseconds()
+
+	rlog.Debug("making round-trip request", "target", targetURL.String())
+	backendStart := time.Now()
+	resp, err := s.transport.RoundTrip(proxyReq)
+	stats.BackendResponseMs = time.Since(backendStart).Milliseconds()
+
+	if err != nil {
+		// Don't log as error if it's a connection failure - the retry handler will handle it
+		if core.IsConnectionError(err) {
+			rlog.Debug("round-trip connection failed", "error", err)
+		} else {
+			rlog.Error("round-trip failed", "error", err)
+		}
+		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), err)
+		duration := time.Since(stats.StartTime)
+		return common.MakeUserFriendlyError(err, duration, "backend", s.configuration.GetResponseTimeout())
+	}
+	defer resp.Body.Close()
+
+	rlog.Debug("round-trip success", "status", resp.StatusCode)
+
+	core.SetResponseHeaders(w, stats, endpoint)
+
+	// Copy response headers
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	// Stream the response through
+	rlog.Debug("starting response stream")
+	streamStart := time.Now()
+	stats.FirstDataMs = time.Since(stats.StartTime).Milliseconds()
+
+	buffer := s.bufferPool.Get()
+	defer s.bufferPool.Put(buffer)
+
+	// Stream with timeout protection - don't let slow clients hang forever
+	bytesWritten, streamErr := s.streamResponseWithTimeout(ctx, ctx, w, resp, *buffer, rlog)
+	stats.StreamingMs = time.Since(streamStart).Milliseconds()
+	stats.TotalBytes = bytesWritten
+
+	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
+		rlog.Error("streaming failed", "error", streamErr)
+		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), streamErr)
+		return common.MakeUserFriendlyError(streamErr, time.Since(stats.StartTime), "streaming", s.configuration.GetResponseTimeout())
+	}
+
+	// We've successfully written the response
+	duration := time.Since(stats.StartTime)
+	s.RecordSuccess(endpoint, duration.Milliseconds(), int64(bytesWritten))
+
+	s.PublishEvent(core.ProxyEvent{
+		Type:      core.EventTypeProxySuccess,
+		RequestID: stats.RequestID,
+		Endpoint:  endpoint.Name,
+		Duration:  duration,
+		Metadata: core.ProxyEventMetadata{
+			BytesSent:  int64(bytesWritten),
+			StatusCode: resp.StatusCode,
+			Model:      stats.Model,
+		},
+	})
+
+	// Stats update
+	stats.EndTime = time.Now()
+	stats.Latency = stats.EndTime.Sub(stats.StartTime).Milliseconds()
+	stats.TotalBytes = bytesWritten
+
+	// Log detailed completion metrics at Debug level
+	if ctxLogger != nil {
+		ctxLogger.Debug("Sherpa proxy metrics",
+			"endpoint", endpoint.Name,
+			"latency_ms", stats.Latency,
+			"processing_ms", stats.RequestProcessingMs,
+			"backend_ms", stats.BackendResponseMs,
+			"first_data_ms", stats.FirstDataMs,
+			"streaming_ms", stats.StreamingMs,
+			"selection_ms", stats.SelectionMs,
+			"header_ms", stats.HeaderProcessingMs,
+			"total_bytes", stats.TotalBytes,
+			"bytes_formatted", middleware.FormatBytes(int64(stats.TotalBytes)),
+			"status", resp.StatusCode,
+			"request_id", middleware.GetRequestID(ctx))
+	}
+
+	return nil
+}

--- a/internal/adapter/proxy/sherpa/service_retry.go
+++ b/internal/adapter/proxy/sherpa/service_retry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thushan/olla/internal/adapter/proxy/common"
 	"github.com/thushan/olla/internal/adapter/proxy/core"
 	"github.com/thushan/olla/internal/app/middleware"
+	"github.com/thushan/olla/internal/core/constants"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 	"github.com/thushan/olla/internal/logger"
@@ -90,7 +91,7 @@ func (s *Service) proxyToSingleEndpoint(ctx context.Context, w http.ResponseWrit
 
 	// Add model header if available
 	if model, ok := ctx.Value("model").(string); ok && model != "" {
-		proxyReq.Header.Set("X-Model", model)
+		proxyReq.Header.Set(constants.HeaderXModel, model)
 		stats.Model = model
 	}
 

--- a/internal/adapter/proxy/sherpa/service_retry_test.go
+++ b/internal/adapter/proxy/sherpa/service_retry_test.go
@@ -1,0 +1,389 @@
+package sherpa
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thushan/olla/internal/adapter/proxy/core"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// Simple test implementation of DiscoveryServiceWithEndpointUpdate
+type testDiscoveryService struct {
+	endpoints         []*domain.Endpoint
+	updateStatusCalls []string
+}
+
+func (t *testDiscoveryService) GetEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
+	return t.endpoints, nil
+}
+
+func (t *testDiscoveryService) GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
+	return t.endpoints, nil
+}
+
+func (t *testDiscoveryService) RefreshEndpoints(ctx context.Context) error {
+	return nil
+}
+
+func (t *testDiscoveryService) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	t.updateStatusCalls = append(t.updateStatusCalls, endpoint.Name)
+	return nil
+}
+
+// Simple test implementation of EndpointSelector
+type testSelector struct {
+	selectCount int
+	selectIndex int
+	endpoints   []*domain.Endpoint
+}
+
+func (t *testSelector) Select(ctx context.Context, endpoints []*domain.Endpoint) (*domain.Endpoint, error) {
+	if len(endpoints) == 0 {
+		return nil, errors.New("no endpoints")
+	}
+
+	// For testing retry logic, return endpoints in order
+	if t.selectIndex < len(endpoints) {
+		ep := endpoints[t.selectIndex]
+		t.selectIndex++
+		t.selectCount++
+		return ep, nil
+	}
+	return endpoints[0], nil
+}
+
+func (t *testSelector) Name() string {
+	return "test"
+}
+
+func (t *testSelector) IncrementConnections(endpoint *domain.Endpoint) {}
+func (t *testSelector) DecrementConnections(endpoint *domain.Endpoint) {}
+
+func createRetryTestLogger() logger.StyledLogger {
+	loggerCfg := &logger.Config{Level: "error", Theme: "default"}
+	log, _, _ := logger.New(loggerCfg)
+	return logger.NewPlainStyledLogger(log)
+}
+
+func TestRetryOnConnectionFailure(t *testing.T) {
+	mockLogger := createRetryTestLogger()
+
+	// Create test configuration
+	config := &Configuration{
+		ProxyPrefix:         "/olla/",
+		ConnectionTimeout:   time.Second,
+		ConnectionKeepAlive: time.Second,
+		ResponseTimeout:     time.Second,
+		ReadTimeout:         time.Second,
+		StreamBufferSize:    8192,
+	}
+
+	// Create test endpoints - first will fail with connection error, second will succeed
+	failingEndpoint := &domain.Endpoint{
+		Name:   "failing",
+		URL:    &url.URL{Scheme: "http", Host: "localhost:9999"}, // Non-existent port
+		Status: domain.StatusHealthy,
+	}
+
+	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+	defer successServer.Close()
+
+	successURL, _ := url.Parse(successServer.URL)
+	successEndpoint := &domain.Endpoint{
+		Name:   "success",
+		URL:    successURL,
+		Status: domain.StatusHealthy,
+	}
+
+	// Create test discovery service
+	discoveryService := &testDiscoveryService{
+		endpoints: []*domain.Endpoint{failingEndpoint, successEndpoint},
+	}
+
+	// Create test selector that returns endpoints in order
+	selector := &testSelector{}
+
+	// Create service (not used in this test, but verifies it can be created)
+	_, err := NewService(discoveryService, selector, config, nil, mockLogger)
+	assert.NoError(t, err)
+
+	// Create test request
+	reqBody := bytes.NewBufferString("test body")
+	req := httptest.NewRequest("POST", "/olla/test", reqBody)
+	w := httptest.NewRecorder()
+
+	stats := &ports.RequestStats{
+		StartTime: time.Now(),
+	}
+
+	// Create retry handler
+	retryHandler := core.NewRetryHandler(discoveryService, mockLogger)
+
+	// Define proxy function
+	proxyFunc := func(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats) error {
+		if endpoint.Name == "failing" {
+			// Simulate connection error
+			return errors.New("dial tcp 127.0.0.1:9999: connect: connection refused")
+		}
+		// Success case
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+		return nil
+	}
+
+	// Execute with retry
+	err = retryHandler.ExecuteWithRetry(
+		context.Background(),
+		w,
+		req,
+		[]*domain.Endpoint{failingEndpoint, successEndpoint},
+		selector,
+		stats,
+		proxyFunc,
+	)
+
+	// Verify
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "success", w.Body.String())
+
+	// Verify that UpdateEndpointStatus was called for the failing endpoint
+	assert.Contains(t, discoveryService.updateStatusCalls, "failing")
+}
+
+func TestIsConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("dial tcp 127.0.0.1:9999: connect: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("read tcp 127.0.0.1:1234->127.0.0.1:5678: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "timeout",
+			err:      errors.New("dial tcp 127.0.0.1:9999: i/o timeout"),
+			expected: true,
+		},
+		{
+			name:     "no such host",
+			err:      errors.New("dial tcp: lookup invalid.host: no such host"),
+			expected: true,
+		},
+		{
+			name:     "non-connection error",
+			err:      errors.New("invalid request"),
+			expected: false,
+		},
+		{
+			name:     "EOF error",
+			err:      io.EOF,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := core.IsConnectionError(tt.err)
+			assert.Equal(t, tt.expected, result, "IsConnectionError(%v) = %v, want %v", tt.err, result, tt.expected)
+		})
+	}
+}
+
+func TestRetryExhaustsAllEndpoints(t *testing.T) {
+	mockLogger := createRetryTestLogger()
+
+	// Create test configuration
+	config := &Configuration{
+		ProxyPrefix:         "/olla/",
+		ConnectionTimeout:   100 * time.Millisecond,
+		ConnectionKeepAlive: time.Second,
+		ResponseTimeout:     100 * time.Millisecond,
+		ReadTimeout:         100 * time.Millisecond,
+		StreamBufferSize:    8192,
+	}
+
+	// Create test endpoints - all will fail with connection errors
+	endpoint1 := &domain.Endpoint{
+		Name:   "endpoint1",
+		URL:    &url.URL{Scheme: "http", Host: "localhost:9991"},
+		Status: domain.StatusHealthy,
+	}
+
+	endpoint2 := &domain.Endpoint{
+		Name:   "endpoint2",
+		URL:    &url.URL{Scheme: "http", Host: "localhost:9992"},
+		Status: domain.StatusHealthy,
+	}
+
+	endpoint3 := &domain.Endpoint{
+		Name:   "endpoint3",
+		URL:    &url.URL{Scheme: "http", Host: "localhost:9993"},
+		Status: domain.StatusHealthy,
+	}
+
+	discoveryService := &testDiscoveryService{
+		endpoints: []*domain.Endpoint{endpoint1, endpoint2, endpoint3},
+	}
+
+	selector := &testSelector{}
+
+	// Create service (not used in this test, but verifies it can be created)
+	_, err := NewService(discoveryService, selector, config, nil, mockLogger)
+	assert.NoError(t, err)
+
+	// Create test request
+	req := httptest.NewRequest("GET", "/olla/test", nil)
+	w := httptest.NewRecorder()
+
+	stats := &ports.RequestStats{
+		StartTime: time.Now(),
+	}
+
+	// Create retry handler
+	retryHandler := core.NewRetryHandler(discoveryService, mockLogger)
+
+	// Define proxy function that always fails with connection error
+	proxyFunc := func(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats) error {
+		return fmt.Errorf("dial tcp %s: connect: connection refused", endpoint.URL.Host)
+	}
+
+	// Execute with retry
+	err = retryHandler.ExecuteWithRetry(
+		context.Background(),
+		w,
+		req,
+		[]*domain.Endpoint{endpoint1, endpoint2, endpoint3},
+		selector,
+		stats,
+		proxyFunc,
+	)
+
+	// Verify that all endpoints were tried and failed
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all endpoints failed")
+
+	// Verify that all endpoints were marked as unhealthy
+	assert.Len(t, discoveryService.updateStatusCalls, 3)
+}
+
+func TestRetryPreservesRequestBody(t *testing.T) {
+	mockLogger := createRetryTestLogger()
+
+	// Create test configuration
+	config := &Configuration{
+		ProxyPrefix:         "/olla/",
+		ConnectionTimeout:   time.Second,
+		ConnectionKeepAlive: time.Second,
+		ResponseTimeout:     time.Second,
+		ReadTimeout:         time.Second,
+		StreamBufferSize:    8192,
+	}
+
+	// Track request bodies received
+	var receivedBodies []string
+
+	// Create endpoints
+	failingEndpoint := &domain.Endpoint{
+		Name:   "failing",
+		URL:    &url.URL{Scheme: "http", Host: "localhost:9999"},
+		Status: domain.StatusHealthy,
+	}
+
+	successEndpoint := &domain.Endpoint{
+		Name:   "success",
+		URL:    &url.URL{Scheme: "http", Host: "localhost:8888"},
+		Status: domain.StatusHealthy,
+	}
+
+	discoveryService := &testDiscoveryService{
+		endpoints: []*domain.Endpoint{failingEndpoint, successEndpoint},
+	}
+
+	selector := &testSelector{}
+
+	// Create service (not used in this test, but verifies it can be created)
+	_, err := NewService(discoveryService, selector, config, nil, mockLogger)
+	assert.NoError(t, err)
+
+	// Create test request with body
+	testBody := "test request body content"
+	req := httptest.NewRequest("POST", "/olla/test", strings.NewReader(testBody))
+	w := httptest.NewRecorder()
+
+	stats := &ports.RequestStats{
+		StartTime: time.Now(),
+	}
+
+	// Create retry handler
+	retryHandler := core.NewRetryHandler(discoveryService, mockLogger)
+
+	attemptCount := 0
+	// Define proxy function that fails first, then succeeds
+	proxyFunc := func(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats) error {
+		// Read the body to verify it's preserved
+		if r.Body != nil {
+			body, _ := io.ReadAll(r.Body)
+			receivedBodies = append(receivedBodies, string(body))
+		}
+
+		attemptCount++
+		if attemptCount == 1 {
+			// First attempt fails
+			return errors.New("dial tcp 127.0.0.1:9999: connect: connection refused")
+		}
+		// Second attempt succeeds
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "success")
+		return nil
+	}
+
+	// Execute with retry
+	err = retryHandler.ExecuteWithRetry(
+		context.Background(),
+		w,
+		req,
+		[]*domain.Endpoint{failingEndpoint, successEndpoint},
+		selector,
+		stats,
+		proxyFunc,
+	)
+
+	// Verify
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "success", w.Body.String())
+
+	// Verify that the request body was preserved through the retry
+	assert.Len(t, receivedBodies, 2)
+	assert.Equal(t, testBody, receivedBodies[0])
+	assert.Equal(t, testBody, receivedBodies[1])
+}

--- a/internal/adapter/registry/factory.go
+++ b/internal/adapter/registry/factory.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thushan/olla/internal/logger"
@@ -10,18 +11,28 @@ import (
 )
 
 type RegistryConfig struct {
-	UnificationConf *config.UnificationConfig `yaml:"unification"`
-	Type            string                    `yaml:"type"`
-	EnableUnifier   bool                      `yaml:"enable_unifier"`
+	Discovery       DiscoveryService             // injected dependency for discovery strategy
+	UnificationConf *config.UnificationConfig    `yaml:"unification"`
+	RoutingStrategy *config.ModelRoutingStrategy `yaml:"routing_strategy"`
+	Type            string                       `yaml:"type"`
+	EnableUnifier   bool                         `yaml:"enable_unifier"`
+}
+
+// DiscoveryService interface for discovery operations
+type DiscoveryService interface {
+	RefreshEndpoints(ctx context.Context) error
+	GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error)
 }
 
 func NewModelRegistry(regConfig RegistryConfig, logger logger.StyledLogger) (domain.ModelRegistry, error) {
 	switch regConfig.Type {
 	case "memory", "":
 		if regConfig.EnableUnifier {
-			return NewUnifiedMemoryModelRegistry(logger, regConfig.UnificationConf), nil
+			return NewUnifiedMemoryModelRegistry(logger, regConfig.UnificationConf, regConfig.RoutingStrategy, regConfig.Discovery), nil
 		}
-		return NewMemoryModelRegistry(logger), nil
+		// for non-unified registry, wrap with routing support
+		baseRegistry := NewMemoryModelRegistry(logger)
+		return NewRoutingRegistry(baseRegistry, regConfig.RoutingStrategy, regConfig.Discovery, logger), nil
 	default:
 		return nil, fmt.Errorf("unsupported registry type: %s", regConfig.Type)
 	}

--- a/internal/adapter/registry/routing/discovery_strategy.go
+++ b/internal/adapter/registry/routing/discovery_strategy.go
@@ -1,0 +1,176 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// DiscoveryStrategy refreshes model discovery before deciding
+type DiscoveryStrategy struct {
+	discovery      ports.DiscoveryService
+	logger         logger.StyledLogger
+	strictFallback *StrictStrategy // use strict strategy after discovery
+	options        config.ModelRoutingStrategyOptions
+}
+
+// NewDiscoveryStrategy creates a new discovery routing strategy
+func NewDiscoveryStrategy(discovery ports.DiscoveryService, options config.ModelRoutingStrategyOptions, logger logger.StyledLogger) *DiscoveryStrategy {
+	return &DiscoveryStrategy{
+		discovery:      discovery,
+		options:        options,
+		logger:         logger,
+		strictFallback: NewStrictStrategy(logger),
+	}
+}
+
+// Name returns the strategy name
+func (s *DiscoveryStrategy) Name() string {
+	return StrategyDiscovery
+}
+
+// GetRoutableEndpoints refreshes discovery then routes based on updated model information
+func (s *DiscoveryStrategy) GetRoutableEndpoints(
+	ctx context.Context,
+	modelName string,
+	healthyEndpoints []*domain.Endpoint,
+	modelEndpoints []string,
+) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// first check if we already have healthy endpoints with the model
+	modelEndpointMap := make(map[string]bool)
+	for _, url := range modelEndpoints {
+		modelEndpointMap[url] = true
+	}
+
+	var currentlyRoutable []*domain.Endpoint
+	for _, endpoint := range healthyEndpoints {
+		if modelEndpointMap[endpoint.URLString] {
+			currentlyRoutable = append(currentlyRoutable, endpoint)
+		}
+	}
+
+	// if we already have routable endpoints, use them
+	if len(currentlyRoutable) > 0 {
+		s.logger.Debug("Discovery strategy found existing endpoints with model",
+			"model", modelName,
+			"routable", len(currentlyRoutable))
+
+		return currentlyRoutable, ports.NewRoutingDecision(
+			s.Name(),
+			ports.RoutingActionRouted,
+			"model_found_no_refresh",
+		), nil
+	}
+
+	// no healthy endpoints have the model - trigger discovery refresh if configured
+	if !s.options.DiscoveryRefreshOnMiss {
+		s.logger.Debug("Discovery refresh disabled, rejecting request",
+			"model", modelName)
+
+		return nil, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"model_unavailable_no_refresh",
+			), domain.NewModelRoutingError(
+				modelName,
+				s.Name(),
+				"rejected",
+				len(healthyEndpoints),
+				modelEndpoints,
+				fmt.Errorf("model %s not available and discovery refresh disabled", modelName),
+			)
+	}
+
+	s.logger.Info("Triggering discovery refresh for model",
+		"model", modelName,
+		"timeout", s.options.DiscoveryTimeout)
+
+	// create timeout context for discovery
+	discoveryCtx, cancel := context.WithTimeout(ctx, s.options.DiscoveryTimeout)
+	defer cancel()
+
+	// trigger discovery refresh
+	startTime := time.Now()
+	if err := s.discovery.RefreshEndpoints(discoveryCtx); err != nil {
+		s.logger.Warn("Discovery refresh failed",
+			"model", modelName,
+			"error", err,
+			"duration", time.Since(startTime))
+
+		// fallback based on configuration
+		if s.options.FallbackBehavior == "compatible_only" {
+			return healthyEndpoints, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionFallback,
+				"discovery_failed_fallback",
+			), nil
+		}
+
+		return nil, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"discovery_failed",
+			), domain.NewModelRoutingError(
+				modelName,
+				s.Name(),
+				"rejected",
+				len(healthyEndpoints),
+				modelEndpoints,
+				fmt.Errorf("discovery refresh failed: %w", err),
+			)
+	}
+
+	s.logger.Debug("Discovery refresh completed",
+		"model", modelName,
+		"duration", time.Since(startTime))
+
+	// get updated endpoints after discovery
+	updatedHealthy, err := s.discovery.GetHealthyEndpoints(ctx)
+	if err != nil {
+		s.logger.Error("Failed to get endpoints after discovery",
+			"model", modelName,
+			"error", err)
+
+		// use original endpoints as fallback
+		return healthyEndpoints, ports.NewRoutingDecision(
+			s.Name(),
+			ports.RoutingActionFallback,
+			"discovery_error_fallback",
+		), nil
+	}
+
+	// note: we can't get updated model endpoints here without registry access
+	// in practice, the registry would need to be updated during discovery
+	// for now, fall back to all healthy endpoints after refresh
+	s.logger.Info("Discovery refresh completed, using updated endpoints",
+		"model", modelName,
+		"updated_healthy", len(updatedHealthy),
+		"original_healthy", len(healthyEndpoints))
+
+	if len(updatedHealthy) == 0 {
+		return nil, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"no_healthy_after_discovery",
+			), domain.NewModelRoutingError(
+				modelName,
+				s.Name(),
+				"rejected",
+				0,
+				modelEndpoints,
+				fmt.Errorf("no healthy endpoints after discovery refresh"),
+			)
+	}
+
+	// return all updated healthy endpoints as discovery may have found the model
+	return updatedHealthy, ports.NewRoutingDecision(
+		s.Name(),
+		ports.RoutingActionFallback,
+		"discovery_complete_fallback",
+	), nil
+}

--- a/internal/adapter/registry/routing/factory.go
+++ b/internal/adapter/registry/routing/factory.go
@@ -1,0 +1,79 @@
+package routing
+
+import (
+	"sync"
+
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+const (
+	StrategyStrict     = "strict"
+	StrategyOptimistic = "optimistic"
+	StrategyDiscovery  = "discovery"
+)
+
+// Factory creates model routing strategy instances
+type Factory struct {
+	creators map[string]func(config.ModelRoutingStrategyOptions, ports.DiscoveryService, logger.StyledLogger) ports.ModelRoutingStrategy
+	logger   logger.StyledLogger
+	mu       sync.RWMutex
+}
+
+// NewFactory creates a new routing strategy factory with default registrations
+func NewFactory(log logger.StyledLogger) *Factory {
+	factory := &Factory{
+		creators: make(map[string]func(config.ModelRoutingStrategyOptions, ports.DiscoveryService, logger.StyledLogger) ports.ModelRoutingStrategy),
+		logger:   log,
+	}
+
+	// register default strategies
+	factory.Register(StrategyStrict, func(opts config.ModelRoutingStrategyOptions, discovery ports.DiscoveryService, log logger.StyledLogger) ports.ModelRoutingStrategy {
+		return NewStrictStrategy(log)
+	})
+
+	factory.Register(StrategyOptimistic, func(opts config.ModelRoutingStrategyOptions, discovery ports.DiscoveryService, log logger.StyledLogger) ports.ModelRoutingStrategy {
+		return NewOptimisticStrategy(opts.FallbackBehavior, log)
+	})
+
+	factory.Register(StrategyDiscovery, func(opts config.ModelRoutingStrategyOptions, discovery ports.DiscoveryService, log logger.StyledLogger) ports.ModelRoutingStrategy {
+		return NewDiscoveryStrategy(discovery, opts, log)
+	})
+
+	return factory
+}
+
+// Register adds a new strategy type to the factory
+func (f *Factory) Register(name string, creator func(config.ModelRoutingStrategyOptions, ports.DiscoveryService, logger.StyledLogger) ports.ModelRoutingStrategy) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.creators[name] = creator
+}
+
+// Create instantiates a strategy of the specified type
+func (f *Factory) Create(strategyConfig config.ModelRoutingStrategy, discovery ports.DiscoveryService) (ports.ModelRoutingStrategy, error) {
+	f.mu.RLock()
+	creator, exists := f.creators[strategyConfig.Type]
+	f.mu.RUnlock()
+
+	if !exists {
+		// default to strict if unknown
+		f.logger.Warn("Unknown routing strategy type, defaulting to strict", "type", strategyConfig.Type)
+		return NewStrictStrategy(f.logger), nil
+	}
+
+	return creator(strategyConfig.Options, discovery, f.logger), nil
+}
+
+// GetAvailableStrategies returns all registered strategy types
+func (f *Factory) GetAvailableStrategies() []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	strategies := make([]string, 0, len(f.creators))
+	for name := range f.creators {
+		strategies = append(strategies, name)
+	}
+	return strategies
+}

--- a/internal/adapter/registry/routing/optimistic_strategy.go
+++ b/internal/adapter/registry/routing/optimistic_strategy.go
@@ -1,0 +1,109 @@
+package routing
+
+import (
+	"context"
+
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// OptimisticStrategy falls back to healthy endpoints when model not found
+type OptimisticStrategy struct {
+	logger           logger.StyledLogger
+	fallbackBehavior string
+}
+
+// NewOptimisticStrategy creates a new optimistic routing strategy
+func NewOptimisticStrategy(fallbackBehavior string, logger logger.StyledLogger) *OptimisticStrategy {
+	if fallbackBehavior == "" {
+		fallbackBehavior = "compatible_only"
+	}
+	return &OptimisticStrategy{
+		fallbackBehavior: fallbackBehavior,
+		logger:           logger,
+	}
+}
+
+// Name returns the strategy name
+func (s *OptimisticStrategy) Name() string {
+	return StrategyOptimistic
+}
+
+// GetRoutableEndpoints returns healthy endpoints that have the model, or falls back to all healthy endpoints
+func (s *OptimisticStrategy) GetRoutableEndpoints(
+	ctx context.Context,
+	modelName string,
+	healthyEndpoints []*domain.Endpoint,
+	modelEndpoints []string,
+) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// no endpoints have the model - fall back to all healthy
+	if len(modelEndpoints) == 0 {
+		s.logger.Debug("Model not found, using all healthy endpoints",
+			"model", modelName,
+			"healthy_endpoints", len(healthyEndpoints),
+			"fallback", s.fallbackBehavior)
+
+		if s.fallbackBehavior == "none" {
+			return []*domain.Endpoint{}, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"model_not_found_no_fallback",
+			), nil
+		}
+
+		return healthyEndpoints, ports.NewRoutingDecision(
+			s.Name(),
+			ports.RoutingActionFallback,
+			"model_not_found_fallback",
+		), nil
+	}
+
+	// create map for fast lookup
+	modelEndpointMap := make(map[string]bool)
+	for _, url := range modelEndpoints {
+		modelEndpointMap[url] = true
+	}
+
+	// filter healthy endpoints to those that have the model
+	var routable []*domain.Endpoint
+	for _, endpoint := range healthyEndpoints {
+		if modelEndpointMap[endpoint.URLString] {
+			routable = append(routable, endpoint)
+		}
+	}
+
+	// no healthy endpoints have the model - fall back
+	if len(routable) == 0 {
+		s.logger.Warn("Model only on unhealthy endpoints, falling back to all healthy",
+			"model", modelName,
+			"model_endpoints", len(modelEndpoints),
+			"healthy_endpoints", len(healthyEndpoints),
+			"fallback", s.fallbackBehavior)
+
+		if s.fallbackBehavior == "none" {
+			return []*domain.Endpoint{}, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"model_unavailable_no_fallback",
+			), nil
+		}
+
+		return healthyEndpoints, ports.NewRoutingDecision(
+			s.Name(),
+			ports.RoutingActionFallback,
+			"model_unavailable_fallback",
+		), nil
+	}
+
+	s.logger.Debug("Optimistic routing found endpoints with model",
+		"model", modelName,
+		"routable", len(routable),
+		"total_healthy", len(healthyEndpoints))
+
+	return routable, ports.NewRoutingDecision(
+		s.Name(),
+		ports.RoutingActionRouted,
+		"model_found",
+	), nil
+}

--- a/internal/adapter/registry/routing/strict_strategy.go
+++ b/internal/adapter/registry/routing/strict_strategy.go
@@ -1,0 +1,101 @@
+package routing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// StrictStrategy only routes to endpoints that have the model
+type StrictStrategy struct {
+	logger logger.StyledLogger
+}
+
+// NewStrictStrategy creates a new strict routing strategy
+func NewStrictStrategy(logger logger.StyledLogger) *StrictStrategy {
+	return &StrictStrategy{
+		logger: logger,
+	}
+}
+
+// Name returns the strategy name
+func (s *StrictStrategy) Name() string {
+	return StrategyStrict
+}
+
+// GetRoutableEndpoints returns only healthy endpoints that have the model
+func (s *StrictStrategy) GetRoutableEndpoints(
+	ctx context.Context,
+	modelName string,
+	healthyEndpoints []*domain.Endpoint,
+	modelEndpoints []string,
+) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// no endpoints have the model
+	if len(modelEndpoints) == 0 {
+		s.logger.Debug("Model not found in any endpoint",
+			"model", modelName,
+			"healthy_endpoints", len(healthyEndpoints))
+
+		return nil, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"model_not_found",
+			), domain.NewModelRoutingError(
+				modelName,
+				s.Name(),
+				"rejected",
+				len(healthyEndpoints),
+				modelEndpoints,
+				fmt.Errorf("model %s not found on any endpoint", modelName),
+			)
+	}
+
+	// create map for fast lookup
+	modelEndpointMap := make(map[string]bool)
+	for _, url := range modelEndpoints {
+		modelEndpointMap[url] = true
+	}
+
+	// filter healthy endpoints to those that have the model
+	var routable []*domain.Endpoint
+	for _, endpoint := range healthyEndpoints {
+		if modelEndpointMap[endpoint.URLString] {
+			routable = append(routable, endpoint)
+		}
+	}
+
+	// no healthy endpoints have the model
+	if len(routable) == 0 {
+		s.logger.Info("Model only available on unhealthy endpoints",
+			"model", modelName,
+			"model_endpoints", len(modelEndpoints),
+			"healthy_endpoints", len(healthyEndpoints))
+
+		return nil, ports.NewRoutingDecision(
+				s.Name(),
+				ports.RoutingActionRejected,
+				"model_unavailable",
+			), domain.NewModelRoutingError(
+				modelName,
+				s.Name(),
+				"rejected",
+				len(healthyEndpoints),
+				modelEndpoints,
+				fmt.Errorf("model %s only available on unhealthy endpoints", modelName),
+			)
+	}
+
+	s.logger.Debug("Strict routing found endpoints with model",
+		"model", modelName,
+		"routable", len(routable),
+		"total_healthy", len(healthyEndpoints))
+
+	return routable, ports.NewRoutingDecision(
+		s.Name(),
+		ports.RoutingActionRouted,
+		"model_found",
+	), nil
+}

--- a/internal/adapter/registry/routing_registry.go
+++ b/internal/adapter/registry/routing_registry.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/thushan/olla/internal/adapter/registry/routing"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// RoutingRegistry wraps a base registry with routing strategy support
+type RoutingRegistry struct {
+	domain.ModelRegistry
+	routingStrategy ports.ModelRoutingStrategy
+	logger          logger.StyledLogger
+}
+
+// NewRoutingRegistry creates a registry wrapper with routing support
+func NewRoutingRegistry(base domain.ModelRegistry, routingConfig *config.ModelRoutingStrategy,
+	discovery DiscoveryService, logger logger.StyledLogger) *RoutingRegistry {
+
+	// create routing strategy
+	var routingStrategy ports.ModelRoutingStrategy
+	if routingConfig != nil {
+		factory := routing.NewFactory(logger)
+		// adapt discovery interface if provided
+		var discoveryAdapter ports.DiscoveryService
+		if discovery != nil {
+			discoveryAdapter = &discoveryServiceAdapter{discovery: discovery}
+		}
+		routingStrategy, _ = factory.Create(*routingConfig, discoveryAdapter)
+	} else {
+		// default to strict strategy
+		routingStrategy = routing.NewStrictStrategy(logger)
+	}
+
+	return &RoutingRegistry{
+		ModelRegistry:   base,
+		routingStrategy: routingStrategy,
+		logger:          logger,
+	}
+}
+
+// GetRoutableEndpointsForModel implements model routing strategy
+func (r *RoutingRegistry) GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// get endpoints that have this model
+	modelEndpoints, err := r.GetEndpointsForModel(ctx, modelName)
+	if err != nil {
+		r.logger.Error("Failed to get endpoints for model", "model", modelName, "error", err)
+		modelEndpoints = []string{} // treat error as model not found
+	}
+
+	// delegate to routing strategy
+	return r.routingStrategy.GetRoutableEndpoints(ctx, modelName, healthyEndpoints, modelEndpoints)
+}

--- a/internal/adapter/registry/unified_memory_registry.go
+++ b/internal/adapter/registry/unified_memory_registry.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/thushan/olla/internal/adapter/registry/routing"
 	"github.com/thushan/olla/internal/adapter/unifier"
 	"github.com/thushan/olla/internal/config"
 	"github.com/thushan/olla/internal/core/domain"
@@ -16,7 +17,8 @@ import (
 
 // UnifiedMemoryModelRegistry extends MemoryModelRegistry with model unification
 type UnifiedMemoryModelRegistry struct {
-	unifier ports.ModelUnifier
+	unifier         ports.ModelUnifier
+	routingStrategy ports.ModelRoutingStrategy
 	*MemoryModelRegistry
 	unifiedModels    *xsync.Map[string, *domain.UnifiedModel] // Endpoint -> []UnifiedModel
 	globalUnified    *xsync.Map[string, *domain.UnifiedModel] // UnifiedID -> UnifiedModel (merged across endpoints)
@@ -25,7 +27,8 @@ type UnifiedMemoryModelRegistry struct {
 }
 
 // NewUnifiedMemoryModelRegistry creates a new registry with unification support
-func NewUnifiedMemoryModelRegistry(logger logger.StyledLogger, unificationConfig *config.UnificationConfig) *UnifiedMemoryModelRegistry {
+func NewUnifiedMemoryModelRegistry(logger logger.StyledLogger, unificationConfig *config.UnificationConfig,
+	routingConfig *config.ModelRoutingStrategy, discovery DiscoveryService) *UnifiedMemoryModelRegistry {
 	// Create unifier with config
 	unifierFactory := unifier.NewFactory(logger)
 	var modelUnifier ports.ModelUnifier
@@ -43,9 +46,25 @@ func NewUnifiedMemoryModelRegistry(logger logger.StyledLogger, unificationConfig
 		modelUnifier, _ = unifierFactory.Create(unifier.DefaultUnifierType)
 	}
 
+	// create routing strategy
+	var routingStrategy ports.ModelRoutingStrategy
+	if routingConfig != nil {
+		factory := routing.NewFactory(logger)
+		// adapt discovery interface if provided
+		var discoveryAdapter ports.DiscoveryService
+		if discovery != nil {
+			discoveryAdapter = &discoveryServiceAdapter{discovery: discovery}
+		}
+		routingStrategy, _ = factory.Create(*routingConfig, discoveryAdapter)
+	} else {
+		// default to strict strategy
+		routingStrategy = routing.NewStrictStrategy(logger)
+	}
+
 	return &UnifiedMemoryModelRegistry{
 		MemoryModelRegistry: NewMemoryModelRegistry(logger),
 		unifier:             modelUnifier,
+		routingStrategy:     routingStrategy,
 		unifiedModels:       xsync.NewMap[string, *domain.UnifiedModel](),
 		globalUnified:       xsync.NewMap[string, *domain.UnifiedModel](),
 		endpoints:           xsync.NewMap[string, *domain.Endpoint](),
@@ -357,4 +376,34 @@ type UnifiedRegistryStats struct {
 	domain.RegistryStats
 	domain.UnificationStats
 	TotalUnifiedModels int `json:"total_unified_models"`
+}
+
+// GetRoutableEndpointsForModel implements model routing strategy
+func (r *UnifiedMemoryModelRegistry) GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// get endpoints that have this model
+	modelEndpoints, err := r.GetEndpointsForModel(ctx, modelName)
+	if err != nil {
+		r.logger.Error("Failed to get endpoints for model", "model", modelName, "error", err)
+		modelEndpoints = []string{} // treat error as model not found
+	}
+
+	// delegate to routing strategy
+	return r.routingStrategy.GetRoutableEndpoints(ctx, modelName, healthyEndpoints, modelEndpoints)
+}
+
+// discoveryServiceAdapter adapts our DiscoveryService to ports.DiscoveryService
+type discoveryServiceAdapter struct {
+	discovery DiscoveryService
+}
+
+func (a *discoveryServiceAdapter) RefreshEndpoints(ctx context.Context) error {
+	return a.discovery.RefreshEndpoints(ctx)
+}
+
+func (a *discoveryServiceAdapter) GetEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
+	return a.discovery.GetHealthyEndpoints(ctx)
+}
+
+func (a *discoveryServiceAdapter) GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
+	return a.discovery.GetHealthyEndpoints(ctx)
 }

--- a/internal/adapter/registry/unified_memory_registry.go
+++ b/internal/adapter/registry/unified_memory_registry.go
@@ -407,3 +407,8 @@ func (a *discoveryServiceAdapter) GetEndpoints(ctx context.Context) ([]*domain.E
 func (a *discoveryServiceAdapter) GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error) {
 	return a.discovery.GetHealthyEndpoints(ctx)
 }
+
+func (a *discoveryServiceAdapter) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	// This is a no-op for the registry adapter as it doesn't manage endpoint status
+	return nil
+}

--- a/internal/adapter/registry/unified_memory_registry_test.go
+++ b/internal/adapter/registry/unified_memory_registry_test.go
@@ -52,7 +52,7 @@ func (m *mockEndpointRepository) Exists(ctx context.Context, endpointURL *url.UR
 }
 
 func createTestUnifiedRegistry() *UnifiedMemoryModelRegistry {
-	return NewUnifiedMemoryModelRegistry(createTestLogger(), nil)
+	return NewUnifiedMemoryModelRegistry(createTestLogger(), nil, nil, nil)
 }
 
 func TestGetHealthyEndpointsForModel(t *testing.T) {

--- a/internal/adapter/unifier/integration_test.go
+++ b/internal/adapter/unifier/integration_test.go
@@ -33,7 +33,7 @@ func TestUnifierIntegrationWithRegistry(t *testing.T) {
 	ctx := context.Background()
 
 	// Create unified registry
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(log, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(log, nil, nil, nil)
 
 	// Test data - models from different endpoints
 	ollamaEndpoint := "http://localhost:11434"
@@ -182,7 +182,7 @@ func TestUnifierIntegrationEdgeCases(t *testing.T) {
 	ctx := context.Background()
 
 	// Create unified registry
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(log, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(log, nil, nil, nil)
 
 	t.Run("empty model list", func(t *testing.T) {
 		err := unifiedRegistry.RegisterModels(ctx, "http://localhost:11434", []*domain.ModelInfo{})
@@ -266,7 +266,7 @@ func TestUnifierIntegrationEdgeCases(t *testing.T) {
 func TestUnifierWithRealWorldScenarios(t *testing.T) {
 	log := createTestLogger()
 	ctx := context.Background()
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(log, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(log, nil, nil, nil)
 
 	// Scenario 1: Model migration between endpoints
 	t.Run("model migration", func(t *testing.T) {

--- a/internal/adapter/unifier/model_builder.go
+++ b/internal/adapter/unifier/model_builder.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/thushan/olla/internal/core/constants"
 	"github.com/thushan/olla/internal/core/domain"
 )
 
@@ -224,10 +225,10 @@ func (e *ModelExtractor) DetectPlatform(format string, metadata map[string]inter
 			return strings.ToLower(platform)
 		}
 		if _, ok := metadata["ollama.version"]; ok {
-			return "ollama"
+			return constants.ProviderTypeOllama
 		}
 		if _, ok := metadata["lmstudio.version"]; ok {
-			return "lmstudio"
+			return constants.ProviderTypeLMStudio
 		}
 	}
 
@@ -242,11 +243,11 @@ func (e *ModelExtractor) DetectPlatform(format string, metadata map[string]inter
 
 	// Check format
 	if format != "" && strings.Contains(strings.ToLower(format), "gguf") {
-		return "ollama"
+		return constants.ProviderTypeOllama
 	}
 
 	// Default to openai-compatible
-	return "openai"
+	return constants.ProviderTypeOpenAI
 }
 
 // MapModelState maps model properties to a state string

--- a/internal/adapter/unifier/model_builder_test.go
+++ b/internal/adapter/unifier/model_builder_test.go
@@ -2,6 +2,8 @@ package unifier
 
 import (
 	"testing"
+
+	"github.com/thushan/olla/internal/core/constants"
 )
 
 func TestDetectPlatform(t *testing.T) {
@@ -22,13 +24,13 @@ func TestDetectPlatform(t *testing.T) {
 			name:         "ollama version in metadata",
 			metadata:     map[string]interface{}{"ollama.version": "0.1.0"},
 			endpointType: "lmstudio",
-			want:         "ollama",
+			want:         constants.ProviderTypeOllama,
 		},
 		{
 			name:         "lmstudio version in metadata",
 			metadata:     map[string]interface{}{"lmstudio.version": "1.0.0"},
 			endpointType: "openai",
-			want:         "lmstudio",
+			want:         constants.ProviderTypeLMStudio,
 		},
 		{
 			name:         "endpoint type used when no metadata hints",
@@ -59,7 +61,7 @@ func TestDetectPlatform(t *testing.T) {
 			format:       "gguf",
 			metadata:     map[string]interface{}{},
 			endpointType: "",
-			want:         "ollama",
+			want:         constants.ProviderTypeOllama,
 		},
 		{
 			name:         "endpoint type overrides gguf format",
@@ -73,7 +75,7 @@ func TestDetectPlatform(t *testing.T) {
 			format:       "",
 			metadata:     map[string]interface{}{},
 			endpointType: "",
-			want:         "openai",
+			want:         constants.ProviderTypeOpenAI,
 		},
 	}
 

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -73,7 +73,7 @@ func (a *Application) providerProxyHandler(w http.ResponseWriter, r *http.Reques
 	// Provider type must flow through the entire request lifecycle to ensure
 	// consistent routing decisions
 	ctx := r.Context()
-	ctx = context.WithValue(ctx, "provider_type", providerType)
+	ctx = context.WithValue(ctx, constants.ContextProviderTypeKey, providerType)
 
 	// The proxy needs to know which prefix to strip before forwarding.
 	// This mimics the behaviour of the main router for consistency.

--- a/internal/app/handlers/handler_provider_models_test.go
+++ b/internal/app/handlers/handler_provider_models_test.go
@@ -63,7 +63,7 @@ func TestProviderSpecificModelEndpoints(t *testing.T) {
 	}
 
 	// Create registry and register models
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
 	ctx := context.Background()
 
 	// Register endpoints
@@ -253,7 +253,7 @@ func TestProviderModelFiltering(t *testing.T) {
 	}
 
 	// Create registry
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
 	ctx := context.Background()
 
 	// Register endpoints
@@ -336,7 +336,7 @@ func TestUnifiedModelsFormatFiltering(t *testing.T) {
 	}
 
 	// Create registry
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
 	ctx := context.Background()
 
 	// Register endpoints

--- a/internal/app/handlers/handler_provider_test.go
+++ b/internal/app/handlers/handler_provider_test.go
@@ -28,6 +28,10 @@ func (m *mockDiscoveryService) RefreshEndpoints(ctx context.Context) error {
 	return nil
 }
 
+func (m *mockDiscoveryService) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	return nil
+}
+
 // createTestApplication creates a minimal Application for testing
 func createTestApplication(t *testing.T) *Application {
 	logger := &mockStyledLogger{}

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -131,6 +131,11 @@ func (a *Application) executeProxyRequest(ctx context.Context, w http.ResponseWr
 		r = r.WithContext(ctx)
 	}
 
+	// pass routing decision to stats for headers
+	if pr.profile != nil && pr.profile.RoutingDecision != nil {
+		pr.stats.RoutingDecision = pr.profile.RoutingDecision
+	}
+
 	return a.proxyService.ProxyRequestToEndpoints(ctx, w, r, endpoints, pr.stats, pr.requestLogger)
 }
 
@@ -287,51 +292,44 @@ func (a *Application) filterEndpointsByProfile(endpoints []*domain.Endpoint, pro
 		}
 	}
 
-	// stage 3: specific model filtering eg. llama to llama
+	// stage 3: specific model filtering using routing strategy
 	if profile != nil && profile.ModelName != "" && a.modelRegistry != nil {
 		ctx := context.Background()
-		modelEndpoints, err := a.modelRegistry.GetEndpointsForModel(ctx, profile.ModelName)
+
+		// use new routing strategy method
+		routableEndpoints, decision, err := a.modelRegistry.GetRoutableEndpointsForModel(ctx, profile.ModelName, profileFiltered)
+
+		// store routing decision for headers and metrics
+		if decision != nil {
+			profile.RoutingDecision = decision
+		}
+
 		if err != nil {
-			logger.Warn("Failed to get endpoints for model, skipping model filtering",
+			// handle routing errors based on decision
+			if decision != nil && decision.StatusCode > 0 {
+				logger.Warn("Model routing rejected request",
+					"model", profile.ModelName,
+					"strategy", decision.Strategy,
+					"reason", decision.Reason,
+					"status", decision.StatusCode)
+				// return empty to trigger appropriate error response
+				return []*domain.Endpoint{}
+			}
+
+			logger.Warn("Model routing failed, using all compatible endpoints",
 				"model", profile.ModelName,
 				"error", err)
 			return profileFiltered
 		}
 
-		if len(modelEndpoints) == 0 {
-			logger.Warn("No endpoints have the requested model, using profile-filtered endpoints",
-				"model", profile.ModelName,
-				"available_endpoints", len(profileFiltered))
-			return profileFiltered
-		}
-
-		modelEndpointMap := make(map[string]bool)
-		for _, endpointURL := range modelEndpoints {
-			modelEndpointMap[endpointURL] = true
-		}
-
-		modelFiltered := make([]*domain.Endpoint, 0, len(profileFiltered))
-		for _, endpoint := range profileFiltered {
-			if modelEndpointMap[endpoint.URLString] {
-				modelFiltered = append(modelFiltered, endpoint)
-			}
-		}
-
-		if len(modelFiltered) == 0 {
-			logger.Warn("No profile-compatible endpoints have the requested model, falling back",
-				"model", profile.ModelName,
-				"model_endpoints", len(modelEndpoints),
-				"compatible_endpoints", len(profileFiltered))
-			return profileFiltered
-		}
-
-		logger.Debug("Filtered endpoints by model availability",
+		logger.Debug("Model routing decision",
 			"model", profile.ModelName,
-			"model_filtered_count", len(modelFiltered),
-			"profile_filtered_count", len(profileFiltered),
-			"total_count", len(endpoints))
+			"strategy", decision.Strategy,
+			"action", decision.Action,
+			"routable", len(routableEndpoints),
+			"compatible", len(profileFiltered))
 
-		return modelFiltered
+		return routableEndpoints
 	}
 
 	return profileFiltered

--- a/internal/app/handlers/handler_proxy_fallback_test.go
+++ b/internal/app/handlers/handler_proxy_fallback_test.go
@@ -1,0 +1,176 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/logger"
+	"github.com/thushan/olla/theme"
+)
+
+// TestModelFallbackWhenEndpointGoesOffline tests the specific scenario reported by the user:
+// When an endpoint with a model goes offline, requests should fall back to other healthy endpoints
+func TestModelFallbackWhenEndpointGoesOffline(t *testing.T) {
+	testLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockLogger := logger.NewStyledLogger(testLogger, &theme.Theme{}, false)
+
+	// Create test endpoints - note localOllama is offline (not in healthy list)
+	macOllama := &domain.Endpoint{
+		Name:      "mac-ollama",
+		URLString: "http://192.168.0.144:11434",
+		Type:      "ollama",
+		Status:    domain.StatusHealthy,
+		Priority:  100,
+	}
+
+	// Mock registry that knows local-ollama has the model (even though it's offline)
+	mockRegistry := &mockModelRegistryForFallback{
+		endpointsForModel: map[string][]string{
+			"phi3.5:latest": {"http://localhost:11434"}, // Only the offline endpoint has it
+		},
+	}
+
+	app := &Application{
+		logger:        mockLogger,
+		modelRegistry: mockRegistry,
+	}
+
+	// Create request profile for phi3.5:latest
+	profile := &domain.RequestProfile{
+		ModelName:   "phi3.5:latest",
+		Path:        "/api/chat",
+		SupportedBy: []string{"ollama"},
+	}
+
+	// Test filtering - only healthy endpoints passed in
+	healthyEndpoints := []*domain.Endpoint{macOllama}
+	filtered := app.filterEndpointsByProfile(healthyEndpoints, profile, mockLogger)
+
+	// Should return mac-ollama even though it doesn't have the model in registry
+	// because local-ollama (which has the model) is offline
+	if len(filtered) != 1 {
+		t.Fatalf("Expected 1 endpoint after filtering, got %d", len(filtered))
+	}
+
+	if filtered[0].Name != "mac-ollama" {
+		t.Errorf("Expected mac-ollama to be selected for fallback, got %s", filtered[0].Name)
+	}
+}
+
+// TestModelRoutingWhenAllHealthy tests normal routing when all endpoints are healthy
+func TestModelRoutingWhenAllHealthy(t *testing.T) {
+	testLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockLogger := logger.NewStyledLogger(testLogger, &theme.Theme{}, false)
+
+	localOllama := &domain.Endpoint{
+		Name:      "local-ollama",
+		URLString: "http://localhost:11434",
+		Type:      "ollama",
+		Status:    domain.StatusHealthy,
+		Priority:  100,
+	}
+
+	macOllama := &domain.Endpoint{
+		Name:      "mac-ollama",
+		URLString: "http://192.168.0.144:11434",
+		Type:      "ollama",
+		Status:    domain.StatusHealthy,
+		Priority:  100,
+	}
+
+	// Mock registry - local-ollama has the model
+	mockRegistry := &mockModelRegistryForFallback{
+		endpointsForModel: map[string][]string{
+			"phi3.5:latest": {"http://localhost:11434"},
+		},
+	}
+
+	app := &Application{
+		logger:        mockLogger,
+		modelRegistry: mockRegistry,
+	}
+
+	profile := &domain.RequestProfile{
+		ModelName:   "phi3.5:latest",
+		Path:        "/api/chat",
+		SupportedBy: []string{"ollama"},
+	}
+
+	// Test filtering
+	healthyEndpoints := []*domain.Endpoint{localOllama, macOllama}
+	filtered := app.filterEndpointsByProfile(healthyEndpoints, profile, mockLogger)
+
+	// Should return only local-ollama since it has the model
+	if len(filtered) != 1 {
+		t.Fatalf("Expected 1 endpoint after filtering, got %d", len(filtered))
+	}
+
+	if filtered[0].Name != "local-ollama" {
+		t.Errorf("Expected local-ollama to be selected (has model), got %s", filtered[0].Name)
+	}
+}
+
+// mockModelRegistryForFallback for testing
+type mockModelRegistryForFallback struct {
+	baseMockRegistry
+	endpointsForModel map[string][]string
+}
+
+func (m *mockModelRegistryForFallback) GetEndpointsForModel(ctx context.Context, modelName string) ([]string, error) {
+	if endpoints, ok := m.endpointsForModel[modelName]; ok {
+		return endpoints, nil
+	}
+	return []string{}, nil
+}
+
+func (m *mockModelRegistryForFallback) IsModelAvailable(ctx context.Context, modelName string) bool {
+	_, ok := m.endpointsForModel[modelName]
+	return ok
+}
+
+func (m *mockModelRegistryForFallback) GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// get endpoints that have this model
+	modelEndpoints, _ := m.GetEndpointsForModel(ctx, modelName)
+
+	// filter healthy endpoints to only those with the model
+	modelEndpointMap := make(map[string]bool)
+	for _, url := range modelEndpoints {
+		modelEndpointMap[url] = true
+	}
+
+	var routable []*domain.Endpoint
+	for _, endpoint := range healthyEndpoints {
+		if modelEndpointMap[endpoint.URLString] {
+			routable = append(routable, endpoint)
+		}
+	}
+
+	// if no healthy endpoints have the model, fall back to all healthy
+	if len(routable) == 0 && len(modelEndpoints) > 0 {
+		// model exists but only on unhealthy endpoints - fallback
+		return healthyEndpoints, &domain.ModelRoutingDecision{
+			Strategy: "test-fallback",
+			Action:   "fallback",
+			Reason:   "model only on unhealthy endpoints",
+		}, nil
+	}
+
+	if len(routable) == 0 {
+		// model doesn't exist
+		return nil, &domain.ModelRoutingDecision{
+			Strategy:   "test",
+			Action:     "rejected",
+			Reason:     "model not found",
+			StatusCode: 404,
+		}, nil
+	}
+
+	return routable, &domain.ModelRoutingDecision{
+		Strategy: "test",
+		Action:   "routed",
+		Reason:   "model found",
+	}, nil
+}

--- a/internal/app/handlers/handler_unified_models_test.go
+++ b/internal/app/handlers/handler_unified_models_test.go
@@ -86,7 +86,7 @@ func TestUnifiedModelsHandler_IncludeUnavailable(t *testing.T) {
 	}
 
 	// Create registry with test models
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
 	ctx := context.Background()
 
 	// Register models on both endpoints

--- a/internal/app/handlers/mock_registry_test.go
+++ b/internal/app/handlers/mock_registry_test.go
@@ -1,0 +1,69 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+// baseMockRegistry provides default implementations for all ModelRegistry methods
+type baseMockRegistry struct{}
+
+func (m *baseMockRegistry) RegisterModel(ctx context.Context, endpointURL string, model *domain.ModelInfo) error {
+	return nil
+}
+
+func (m *baseMockRegistry) RegisterModels(ctx context.Context, endpointURL string, models []*domain.ModelInfo) error {
+	return nil
+}
+
+func (m *baseMockRegistry) GetModelsForEndpoint(ctx context.Context, endpointURL string) ([]*domain.ModelInfo, error) {
+	return nil, nil
+}
+
+func (m *baseMockRegistry) GetEndpointsForModel(ctx context.Context, modelName string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (m *baseMockRegistry) IsModelAvailable(ctx context.Context, modelName string) bool {
+	return false
+}
+
+func (m *baseMockRegistry) GetAllModels(ctx context.Context) (map[string][]*domain.ModelInfo, error) {
+	return nil, nil
+}
+
+func (m *baseMockRegistry) GetEndpointModelMap(ctx context.Context) (map[string]*domain.EndpointModels, error) {
+	return nil, nil
+}
+
+func (m *baseMockRegistry) RemoveEndpoint(ctx context.Context, endpointURL string) error {
+	return nil
+}
+
+func (m *baseMockRegistry) GetStats(ctx context.Context) (domain.RegistryStats, error) {
+	return domain.RegistryStats{}, nil
+}
+
+func (m *baseMockRegistry) ModelsToString(models []*domain.ModelInfo) string {
+	return ""
+}
+
+func (m *baseMockRegistry) ModelsToStrings(models []*domain.ModelInfo) []string {
+	return nil
+}
+
+func (m *baseMockRegistry) GetModelsByCapability(ctx context.Context, capability string) ([]*domain.UnifiedModel, error) {
+	return nil, nil
+}
+
+// GetRoutableEndpointsForModel provides basic routing without strategy
+func (m *baseMockRegistry) GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	// basic implementation - return all healthy endpoints
+	decision := &domain.ModelRoutingDecision{
+		Strategy: "mock",
+		Action:   "routed",
+		Reason:   "mock routing",
+	}
+	return healthyEndpoints, decision, nil
+}

--- a/internal/app/model_routing_integration_test.go
+++ b/internal/app/model_routing_integration_test.go
@@ -67,7 +67,7 @@ func TestModelRoutingIntegration(t *testing.T) {
 	styledLogger := logger.NewPlainStyledLogger(log)
 
 	// Create unified registry
-	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil)
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
 
 	// Create test endpoints
 	endpoint1, _ := url.Parse("http://localhost:11434")

--- a/internal/app/services/proxy.go
+++ b/internal/app/services/proxy.go
@@ -169,6 +169,11 @@ func (a *endpointRepositoryAdapter) RefreshEndpoints(ctx context.Context) error 
 	return nil
 }
 
+func (a *endpointRepositoryAdapter) UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error {
+	// Update endpoint status in repository
+	return a.repo.UpdateEndpoint(ctx, endpoint)
+}
+
 // SetStatsService sets the stats service dependency
 func (s *ProxyServiceWrapper) SetStatsService(statsService *StatsService) {
 	s.statsService = statsService

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,6 +90,14 @@ func DefaultConfig() *Config {
 		ModelRegistry: ModelRegistryConfig{
 			Type:          DefaultModelRegistryType,
 			EnableUnifier: true,
+			RoutingStrategy: ModelRoutingStrategy{
+				Type: "strict", // default to strict for predictable behavior
+				Options: ModelRoutingStrategyOptions{
+					DiscoveryRefreshOnMiss: false,
+					DiscoveryTimeout:       2 * time.Second,
+					FallbackBehavior:       "compatible_only",
+				},
+			},
 			Unification: UnificationConfig{
 				Enabled:  true,
 				CacheTTL: 10 * time.Minute,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -115,9 +115,23 @@ type EngineeringConfig struct {
 
 // ModelRegistryConfig holds model registry configuration
 type ModelRegistryConfig struct {
-	Type          string            `yaml:"type"`
-	Unification   UnificationConfig `yaml:"unification"`
-	EnableUnifier bool              `yaml:"enable_unifier"`
+	RoutingStrategy ModelRoutingStrategy `yaml:"routing_strategy"`
+	Type            string               `yaml:"type"`
+	Unification     UnificationConfig    `yaml:"unification"`
+	EnableUnifier   bool                 `yaml:"enable_unifier"`
+}
+
+// ModelRoutingStrategy configures how models are routed when not all endpoints have them
+type ModelRoutingStrategy struct {
+	Type    string                      `yaml:"type"` // strict, optimistic, discovery
+	Options ModelRoutingStrategyOptions `yaml:"options"`
+}
+
+// ModelRoutingStrategyOptions holds routing strategy configuration
+type ModelRoutingStrategyOptions struct {
+	FallbackBehavior       string        `yaml:"fallback_behavior"` // compatible_only, none
+	DiscoveryTimeout       time.Duration `yaml:"discovery_timeout"`
+	DiscoveryRefreshOnMiss bool          `yaml:"discovery_refresh_on_miss"`
 }
 
 // UnificationConfig holds model unification configuration

--- a/internal/core/constants/content.go
+++ b/internal/core/constants/content.go
@@ -98,9 +98,12 @@ const (
 	HeaderXProfileOllamaVersion = "X-ProfileOllama-Version"
 
 	// Olla-Specific Headers
-	HeaderXOllaRequestID    = "X-Olla-Request-ID"
-	HeaderXOllaEndpoint     = "X-Olla-Endpoint"
-	HeaderXOllaBackendType  = "X-Olla-Backend-Type"
-	HeaderXOllaModel        = "X-Olla-Model"
-	HeaderXOllaResponseTime = "X-Olla-Response-Time"
+	HeaderXOllaRequestID       = "X-Olla-Request-ID"
+	HeaderXOllaEndpoint        = "X-Olla-Endpoint"
+	HeaderXOllaBackendType     = "X-Olla-Backend-Type"
+	HeaderXOllaModel           = "X-Olla-Model"
+	HeaderXOllaResponseTime    = "X-Olla-Response-Time"
+	HeaderXOllaRoutingStrategy = "X-Olla-Routing-Strategy"
+	HeaderXOllaRoutingDecision = "X-Olla-Routing-Decision"
+	HeaderXOllaRoutingReason   = "X-Olla-Routing-Reason"
 )

--- a/internal/core/constants/context.go
+++ b/internal/core/constants/context.go
@@ -6,4 +6,5 @@ const (
 	ContextRequestTimeKey  = "request_time"  // generated each proxy_handler request to track the time taken for the request
 	ContextOriginalPathKey = "original_path" // original path before any modifications, useful for logging/debugging
 	ContextKeyStream       = "stream"        // indicates whether the response should be streamed or buffered
+	ContextProviderTypeKey = "provider_type" // the provider type for the request, used for routing and load balancing
 )

--- a/internal/core/domain/errors.go
+++ b/internal/core/domain/errors.go
@@ -123,20 +123,34 @@ func NewProxyError(requestID, targetURL, method, path string, statusCode int, la
 	}
 }
 
-/*
-func NewConfigValidationError(field string, value interface{}, reason string) *ConfigValidationError {
-	return &ConfigValidationError{
-		Field:  field,
-		Value:  value,
-		Reason: reason,
-	}
+type ModelRoutingError struct {
+	Err              error
+	Model            string
+	Strategy         string
+	Decision         string
+	ModelEndpoints   []string
+	HealthyEndpoints int
 }
 
-func NewLoadBalancerError(strategy string, endpointCount int, err error) *LoadBalancerError {
-	return &LoadBalancerError{
-		Strategy:      strategy,
-		EndpointCount: endpointCount,
-		Err:           err,
+func (e *ModelRoutingError) Error() string {
+	if e.Decision == "rejected" {
+		return fmt.Sprintf("model routing strategy %s rejected request for %s: %d healthy endpoints, model on %v: %v",
+			e.Strategy, e.Model, e.HealthyEndpoints, e.ModelEndpoints, e.Err)
+	}
+	return fmt.Sprintf("model routing strategy %s failed for %s: %v", e.Strategy, e.Model, e.Err)
+}
+
+func (e *ModelRoutingError) Unwrap() error {
+	return e.Err
+}
+
+func NewModelRoutingError(model, strategy, decision string, healthyEndpoints int, modelEndpoints []string, err error) *ModelRoutingError {
+	return &ModelRoutingError{
+		Model:            model,
+		Strategy:         strategy,
+		Decision:         decision,
+		HealthyEndpoints: healthyEndpoints,
+		ModelEndpoints:   modelEndpoints,
+		Err:              err,
 	}
 }
-*/

--- a/internal/core/domain/model.go
+++ b/internal/core/domain/model.go
@@ -51,6 +51,17 @@ type ModelRegistry interface {
 	ModelsToString(models []*ModelInfo) string
 	ModelsToStrings(models []*ModelInfo) []string
 	GetModelsByCapability(ctx context.Context, capability string) ([]*UnifiedModel, error)
+
+	// GetRoutableEndpointsForModel returns endpoints that should handle a model request based on routing strategy
+	GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*Endpoint) ([]*Endpoint, *ModelRoutingDecision, error)
+}
+
+// ModelRoutingDecision captures routing decision information
+type ModelRoutingDecision struct {
+	Strategy   string // strategy name
+	Action     string // routed, fallback, rejected
+	Reason     string // human-readable reason
+	StatusCode int    // suggested HTTP status for failures
 }
 
 type RegistryStats struct {

--- a/internal/core/domain/routing.go
+++ b/internal/core/domain/routing.go
@@ -23,6 +23,7 @@ type RequestProfile struct {
 	// Rich request metadata for intelligent routing
 	ModelCapabilities    *ModelCapabilities    // What the request needs
 	ResourceRequirements *ResourceRequirements // Resources needed
+	RoutingDecision      *ModelRoutingDecision // Routing strategy decision
 	Path                 string
 	ModelName            string
 	SupportedBy          []string

--- a/internal/core/ports/model_routing.go
+++ b/internal/core/ports/model_routing.go
@@ -1,0 +1,52 @@
+package ports
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+// ModelRoutingStrategy defines how to route requests when models aren't available on all endpoints
+type ModelRoutingStrategy interface {
+	// GetRoutableEndpoints returns endpoints that should handle the model request
+	GetRoutableEndpoints(
+		ctx context.Context,
+		modelName string,
+		healthyEndpoints []*domain.Endpoint,
+		modelEndpoints []string,
+	) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error)
+
+	// Name returns the strategy name for logging
+	Name() string
+}
+
+// routing decision actions
+const (
+	RoutingActionRouted   = "routed"
+	RoutingActionFallback = "fallback"
+	RoutingActionRejected = "rejected"
+)
+
+// NewRoutingDecision creates a routing decision
+func NewRoutingDecision(strategy, action, reason string) *domain.ModelRoutingDecision {
+	decision := &domain.ModelRoutingDecision{
+		Strategy: strategy,
+		Action:   action,
+		Reason:   reason,
+	}
+
+	// set appropriate status codes based on action
+	switch action {
+	case RoutingActionRejected:
+		if reason == "model_not_found" {
+			decision.StatusCode = http.StatusNotFound
+		} else {
+			decision.StatusCode = http.StatusServiceUnavailable
+		}
+	default:
+		decision.StatusCode = http.StatusOK
+	}
+
+	return decision
+}

--- a/internal/core/ports/proxy.go
+++ b/internal/core/ports/proxy.go
@@ -70,10 +70,5 @@ type DiscoveryService interface {
 	GetEndpoints(ctx context.Context) ([]*domain.Endpoint, error)
 	GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error)
 	RefreshEndpoints(ctx context.Context) error
-}
-
-// DiscoveryServiceWithEndpointUpdate extends DiscoveryService with endpoint update capability
-type DiscoveryServiceWithEndpointUpdate interface {
-	DiscoveryService
 	UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error
 }

--- a/internal/core/ports/proxy.go
+++ b/internal/core/ports/proxy.go
@@ -71,3 +71,9 @@ type DiscoveryService interface {
 	GetHealthyEndpoints(ctx context.Context) ([]*domain.Endpoint, error)
 	RefreshEndpoints(ctx context.Context) error
 }
+
+// DiscoveryServiceWithEndpointUpdate extends DiscoveryService with endpoint update capability
+type DiscoveryServiceWithEndpointUpdate interface {
+	DiscoveryService
+	UpdateEndpointStatus(ctx context.Context, endpoint *domain.Endpoint) error
+}

--- a/internal/core/ports/proxy.go
+++ b/internal/core/ports/proxy.go
@@ -45,10 +45,12 @@ type ProxyFactory interface {
 }
 
 type RequestStats struct {
+	StartTime       time.Time
+	EndTime         time.Time
+	RoutingDecision *domain.ModelRoutingDecision // routing decision for this request
+
 	RequestID    string
 	Model        string
-	StartTime    time.Time
-	EndTime      time.Time
 	EndpointName string
 	TargetUrl    string
 	TotalBytes   int

--- a/internal/util/backoff.go
+++ b/internal/util/backoff.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"math"
+	"time"
+)
+
+// CalculateExponentialBackoff computes exponential backoff with optional jitter.
+// Formula: baseDelay * 2^(attempt-1), capped at maxDelay
+func CalculateExponentialBackoff(attempt int, baseDelay time.Duration, maxDelay time.Duration, jitterPercent float64) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+
+	backoff := float64(baseDelay) * math.Pow(2, float64(attempt-1))
+
+	if backoff > float64(maxDelay) {
+		backoff = float64(maxDelay)
+	}
+
+	if jitterPercent > 0 {
+		// Time-based pseudo-random avoids import of math/rand
+		pseudoRandom := float64(time.Now().UnixNano()%1000) / 1000.0
+		jitter := backoff * jitterPercent * (pseudoRandom - 0.5)
+		backoff += jitter
+	}
+
+	return time.Duration(backoff)
+}
+
+const (
+	DefaultMaxBackoffMultiplier = 12
+	DefaultMaxBackoffSeconds    = 60 * time.Second
+)
+
+// CalculateEndpointBackoff computes backoff interval for endpoint health checks.
+// Uses exponential multiplier for proper backoff progression
+func CalculateEndpointBackoff(checkInterval time.Duration, backoffMultiplier int) time.Duration {
+	if backoffMultiplier <= 0 {
+		return checkInterval
+	}
+
+	// Use the provided multiplier directly (already exponential: 1, 2, 4, 8...)
+	backoffInterval := checkInterval * time.Duration(backoffMultiplier)
+
+	if backoffInterval > DefaultMaxBackoffSeconds {
+		backoffInterval = DefaultMaxBackoffSeconds
+	}
+
+	return backoffInterval
+}
+
+// CalculateConnectionRetryBackoff computes backoff for connection retry attempts.
+// Linear progression: consecutiveFailures * 2 seconds, capped at MaxBackoffSeconds
+func CalculateConnectionRetryBackoff(consecutiveFailures int) time.Duration {
+	backoffDuration := time.Duration(consecutiveFailures*2) * time.Second
+	if backoffDuration > DefaultMaxBackoffSeconds {
+		backoffDuration = DefaultMaxBackoffSeconds
+	}
+	return backoffDuration
+}

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ In the above example, we configure [Jetbrains Junie](https://www.jetbrains.com/j
 - **🔍 Smart Model Unification**: [Per-provider unification + OpenAI-compatible cross-provider routing](https://thushan.github.io/olla/concepts/model-unification/)
 - **⚡ Dual Proxy Engines**: [Sherpa (simple) and Olla (high-performance)](https://thushan.github.io/olla/concepts/proxy-engines/)
 - **💊 Health Monitoring**: [Continuous endpoint health checks](https://thushan.github.io/olla/concepts/health-checking/) with circuit breakers and automatic recovery
-- **🔁 Intelligent Retry**: Automatic retry on connection failures with immediate endpoint failover
+- **🔁 Intelligent Retry**: Automatic retry on connection failures with immediate transparent endpoint failover
 - **🔧 Self-Healing**: Automatic model discovery refresh when endpoints recover
 - **📊 Request Tracking**: Detailed response headers and [statistics](https://thushan.github.io/olla/api-reference/overview/#response-headers)
 - **🛡️ Production Ready**: Rate limiting, request size limits, graceful shutdown

--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,12 @@ In the above example, we configure [Jetbrains Junie](https://www.jetbrains.com/j
 
 ## Key Features
 
-- **🔄 Smart Load Balancing**: [Priority-based routing](https://thushan.github.io/olla/concepts/load-balancing/) with automatic failover
+- **🔄 Smart Load Balancing**: [Priority-based routing](https://thushan.github.io/olla/concepts/load-balancing/) with automatic failover and connection retry
 - **🔍 Smart Model Unification**: [Per-provider unification + OpenAI-compatible cross-provider routing](https://thushan.github.io/olla/concepts/model-unification/)
 - **⚡ Dual Proxy Engines**: [Sherpa (simple) and Olla (high-performance)](https://thushan.github.io/olla/concepts/proxy-engines/)
-- **💊 Health Monitoring**: [Continuous endpoint health checks](https://thushan.github.io/olla/concepts/health-checking/) with circuit breakers
+- **💊 Health Monitoring**: [Continuous endpoint health checks](https://thushan.github.io/olla/concepts/health-checking/) with circuit breakers and automatic recovery
+- **🔁 Intelligent Retry**: Automatic retry on connection failures with immediate endpoint failover
+- **🔧 Self-Healing**: Automatic model discovery refresh when endpoints recover
 - **📊 Request Tracking**: Detailed response headers and [statistics](https://thushan.github.io/olla/api-reference/overview/#response-headers)
 - **🛡️ Production Ready**: Rate limiting, request size limits, graceful shutdown
 - **⚡ High Performance**: Sub-millisecond endpoint selection with lock-free atomic stats

--- a/test/scripts/logic/test-model-routing-strategy.sh
+++ b/test/scripts/logic/test-model-routing-strategy.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# test model routing strategies
+
+set -e
+
+OLLA_URL=${OLLA_URL:-"http://localhost:8080"}
+MODEL=${MODEL:-"phi3.5:latest"}
+
+echo "Testing Model Routing Strategies"
+echo "================================"
+echo ""
+
+# function to make a request and check headers
+test_request() {
+    local description="$1"
+    local model="$2"
+    local expected_strategy="$3"
+    
+    echo "Test: $description"
+    echo "Model: $model"
+    echo "Expected Strategy: $expected_strategy"
+    
+    response=$(curl -s -i -X POST "$OLLA_URL/olla/api/generate" \
+        -H "Content-Type: application/json" \
+        -d "{\"model\": \"$model\", \"prompt\": \"test\", \"stream\": false}" \
+        2>&1 || true)
+    
+    # extract headers
+    strategy_header=$(echo "$response" | grep -i "X-Olla-Routing-Strategy:" | head -n 1 || echo "")
+    decision_header=$(echo "$response" | grep -i "X-Olla-Routing-Decision:" | head -n 1 || echo "")
+    reason_header=$(echo "$response" | grep -i "X-Olla-Routing-Reason:" | head -n 1 || echo "")
+    status_code=$(echo "$response" | head -n 1 | awk '{print $2}')
+    
+    echo "Response Status: $status_code"
+    echo "Routing Strategy: $strategy_header"
+    echo "Routing Decision: $decision_header"
+    echo "Routing Reason: $reason_header"
+    
+    # check if strategy matches expected
+    if [[ "$strategy_header" == *"$expected_strategy"* ]]; then
+        echo "✓ Strategy matches expected: $expected_strategy"
+    else
+        echo "✗ Strategy mismatch. Expected: $expected_strategy"
+    fi
+    
+    echo "---"
+    echo ""
+}
+
+# test 1: request with a known model
+echo "=== Test 1: Known Model (should use configured strategy) ==="
+test_request "Request with known model" "$MODEL" "strict"
+
+# test 2: request with unknown model
+echo "=== Test 2: Unknown Model (should reject with strict strategy) ==="
+test_request "Request with unknown model" "unknown-model:latest" "strict"
+
+# test 3: request without model (should not trigger routing strategy)
+echo "=== Test 3: No Model Specified ==="
+response=$(curl -s -i -X POST "$OLLA_URL/olla/api/chat" \
+    -H "Content-Type: application/json" \
+    -d "{\"messages\": [{\"role\": \"user\", \"content\": \"test\"}]}" \
+    2>&1 || true)
+
+strategy_header=$(echo "$response" | grep -i "X-Olla-Routing-Strategy:" | head -n 1 || echo "")
+if [[ -z "$strategy_header" ]]; then
+    echo "✓ No routing strategy header (as expected for no model)"
+else
+    echo "✗ Unexpected routing strategy header: $strategy_header"
+fi
+
+echo ""
+echo "================================"
+echo "Model Routing Strategy Tests Complete"


### PR DESCRIPTION
This PR introduces new behaviours to improve how routing should work when endpoints become unhealthy. We had a rethink of retry and health checking post failures and rewrote a fair chunk of the implementation from the simple backoff/retries to a more robust one.

We now have three distinct strategies for rerouting when an endpoint is offline and was the primary node.

* **strict** (default) - Only routes requests to endpoints known to have the model.
* **optimistic** - Attempts to route to any healthy endpoint when the model isn't found.
* **discovery** - Refreshes model discovery before making routing decisions (but may fail if none found)

Some headers are added to give better indication of what happened:

```
X-Olla-Routing-Strategy: strict
X-Olla-Routing-Decision: routed
X-Olla-Routing-Reason: model_found
```
This does mean that the configuration setting:

```
proxy:
  max_retries: 3
  retry_backoff: 500ms
```

Is deprecated, instead in its place we have:

```
model_registry:
  # Model routing strategy (v0.0.16+)
  # Controls how requests are routed when models aren't available on all endpoints
  routing_strategy:
    type: "strict"  # Options: strict, optimistic, discovery
    options:
      # Fallback behavior when model not found (optimistic mode)
      fallback_behavior: "compatible_only"  # Options: compatible_only, all, none
      
      # Discovery mode settings
      discovery_timeout: 2s  # Timeout for discovery refresh
      discovery_refresh_on_miss: false  # Refresh discovery when model not found
```

As a preetty example, we start with:

<img width="629" height="114" alt="image" src="https://github.com/user-attachments/assets/a9cc0f02-3b3c-4159-a6c5-8b8e320be8e5" />

Turned off `local-ollama` which had `phi4:latest`, but Olla reroutes to `mac-ollama` automatically realising that `local-ollama` is offline (this does add a bit of latency).

<img width="516" height="725" alt="image" src="https://github.com/user-attachments/assets/816c673b-3707-4956-b566-6a974a21cdd7" />

Rerouting and handling failure is transparent to the user (except for headers saying what happened).

When `local-ollama` is restarted, olla detects and refreshes models:

<img width="672" height="204" alt="image" src="https://github.com/user-attachments/assets/2ad4c0c8-cd76-4c1f-8dcf-f6b03dda02fe" />

This will help most users who  use  vllm backends and stop & restart instances to avoid stale model  usage.