### PR TITLE
feat: backend/litellm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Overview
-Olla is a high-performance proxy and load balancer for LLM infrastructure, written in Go. It intelligently routes requests across local and remote inference nodes (Ollama, LM Studio, OpenAI-compatible endpoints). 
+Olla is a high-performance proxy and load balancer for LLM infrastructure, written in Go. It intelligently routes requests across local and remote inference nodes (Ollama, LM Studio, LiteLLM, vLLM, OpenAI-compatible endpoints). 
 
 The project provides two proxy engines: Sherpa (simple, maintainable) and Olla (high-performance with advanced features).
 
@@ -22,6 +22,7 @@ olla/
 │   ├── profiles/            # Provider-specific profiles
 │   │   ├── ollama.yaml     # Ollama configuration
 │   │   ├── lmstudio.yaml   # LM Studio configuration
+│   │   ├── litellm.yaml    # LiteLLM gateway configuration
 │   │   ├── openai.yaml     # OpenAI-compatible configuration
 │   │   └── vllm.yaml       # vLLM configuration
 │   └── models.yaml         # Model configurations
@@ -87,7 +88,7 @@ olla/
 ## Response Headers
 - `X-Olla-Endpoint`: Backend name
 - `X-Olla-Model`: Model used
-- `X-Olla-Backend-Type`: ollama/openai/lmstudio/vllm
+- `X-Olla-Backend-Type`: ollama/openai/lmstudio/vllm/litellm
 - `X-Olla-Request-ID`: Request ID
 - `X-Olla-Response-Time`: Total processing time
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -78,7 +78,7 @@ discovery:
         health_check_url: "/"
         check_interval: 2s # How often to check when healthy
         check_timeout: 1s
-      - url: "http://localhost:11234"
+      - url: "http://localhost:1234"
         name: "local-lm-studio"
         type: "lm-studio"
         priority: 100
@@ -86,7 +86,7 @@ discovery:
         health_check_url: "/"
         check_interval: 2s
         check_timeout: 1s
-      - url: "http://192.168.0.1:8000"
+      - url: "http://localhost:8000"
         name: "local-vllm"
         type: "vllm"
         priority: 100

--- a/config/profiles/litellm.yaml
+++ b/config/profiles/litellm.yaml
@@ -1,0 +1,291 @@
+# LiteLLM unified gateway profile
+# Docs: https://litellm.ai/
+# Revised 17-08-2025
+# 17-08-2025 [TF]: Updated to match latest LiteLLM features and OpenAI compatibility 
+name: litellm
+version: "1.0"
+display_name: "LiteLLM"
+description: "Unified gateway to 100+ LLM providers with automatic fallbacks and load balancing"
+
+# Routing configuration
+routing:
+  prefixes:
+    - litellm
+    #- lite
+
+# API compatibility
+api:
+  openai_compatible: true
+  paths:
+    # Core OpenAI-compatible endpoints (always available)
+    - /                          # 0: root health check
+    - /health                    # 1: health check
+    - /v1/chat/completions       # 2: chat completions (primary)
+    - /v1/completions            # 3: text completions
+    - /v1/embeddings             # 4: embeddings
+    - /v1/models                 # 5: list models
+    # Alternative paths (some deployments)
+    - /chat/completions          # 6: chat completions (alt)
+    - /completions               # 7: text completions (alt)
+    - /embeddings                # 8: embeddings (alt)
+    - /models                    # 9: list models (alt)
+    # Health probes (Kubernetes deployments)
+    # Unsure if these are needed in proxy mode, but included for completeness
+    - /health/readiness          # 10: readiness probe
+    - /health/liveness           # 11: liveness probe
+    # Note: Management endpoints (/key/*, /user/*, /team/*, /spend/*) 
+    # require database backend and are not available in basic proxy mode
+    
+  model_discovery_path: /v1/models
+  health_check_path: /health
+
+# Platform characteristics
+characteristics:
+  timeout: 5m  # Remote providers can be slow
+  max_concurrent_requests: 100  # LiteLLM handles high concurrency well
+  default_priority: 95  # High priority as a unified gateway
+  streaming_support: true
+  
+# Detection hints for auto-discovery
+detection:
+  user_agent_patterns:
+    - "litellm/"
+  headers:
+    - "X-LiteLLM-Version"
+    - "X-LiteLLM-Provider"
+  path_indicators:
+    - "/v1/models"
+    - "/health"
+    - "/model/info"
+    - "/key/generate"
+  default_ports:
+    - 4000  # LiteLLM proxy default
+    - 8000  # Common alternative
+    - 8080  # Another common port
+
+# Model handling
+models:
+  name_format: "{{.Name}}"
+  # LiteLLM uses provider-prefixed model names
+  provider_prefixes:
+    - "openai/"
+    - "azure/"
+    - "bedrock/"
+    - "anthropic/"
+    - "cohere/"
+    - "together_ai/"
+    - "replicate/"
+    - "huggingface/"
+    - "vertex_ai/"
+    - "palm/"
+    - "gemini/"
+    - "groq/"
+    - "mistral/"
+    - "deepinfra/"
+    - "perplexity/"
+    - "anyscale/"
+    - "cloudflare/"
+    - "voyage/"
+    - "databricks/"
+    - "ai21/"
+    - "nlp_cloud/"
+    - "aleph_alpha/"
+    - "baseten/"
+    - "openrouter/"
+    - "custom/"  # Custom endpoints
+    
+  capability_patterns:
+    chat:
+      # OpenAI models
+      - "gpt-5*"
+      - "gpt-4*"
+      - "gpt-3.5*"
+      - "chatgpt*"
+      # Anthropic models
+      - "claude-*"
+      - "anthropic/*"
+      # Google models
+      - "gemini*"
+      - "palm*"
+      - "chat-bison*"
+      # Open models
+      - "llama*"
+      - "mistral*"
+      - "mixtral*"
+      - "vicuna*"
+      - "alpaca*"
+      - "wizardlm*"
+      - "mpt*"
+      - "falcon*"
+      - "starchat*"
+      # Cohere models
+      - "command*"
+      # Provider-prefixed
+      - "*/gpt-*"
+      - "*/claude-*"
+      - "*/llama*"
+      - "*/mistral*"
+      
+    embeddings:
+      - "*embedding*"
+      - "voyage-*"
+      - "embed-*"
+      - "text-embedding-*"
+      - "*/embedding*"
+      - "cohere/embed-*"
+      - "openai/text-embedding-*"
+      - "bedrock/amazon.titan-embed*"
+      
+    vision:
+      - "gpt-5-vision*"
+      - "gpt-5-turbo*"
+      - "gpt-4-vision*"
+      - "gpt-4-turbo*"
+      - "claude-3-*"
+      - "claude-4-*"
+      - "gemini-*vision*"
+      - "gemini-*pro*"
+      - "llava*"
+      - "bakllava*"
+      - "*/vision*"
+      - "anthropic/claude-3-*"
+      - "anthropic/claude-4-*"
+      
+    code:
+      - "*code*"
+      - "codellama*"
+      - "deepseek-coder*"
+      - "starcoder*"
+      - "codegen*"
+      - "replit*"
+      - "wizardcoder*"
+      - "phind*"
+      - "*/code*"
+      
+    function_calling:
+      - "gpt-5*"
+      - "gpt-4*"
+      - "gpt-3.5-turbo*"
+      - "claude-3-*"
+      - "claude-4-*"
+      - "mistral-large*"
+      - "mixtral*"
+      - "gemini*"
+      - "*/function*"
+      
+  # Context window detection patterns (LiteLLM handles many model variants)
+  context_patterns:
+    - pattern: "*-128k*"
+      context: 131072
+    - pattern: "*-100k*"
+      context: 102400
+    - pattern: "*-64k*"
+      context: 65536
+    - pattern: "*-32k*"
+      context: 32768
+    - pattern: "*-16k*"
+      context: 16384
+    - pattern: "*-8k*"
+      context: 8192
+    - pattern: "*-4k*"
+      context: 4096
+    - pattern: "gpt-4-turbo*"
+      context: 128000
+    - pattern: "gpt-4-32k*"
+      context: 32768
+    - pattern: "gpt-4*"
+      context: 8192
+    - pattern: "claude-3-opus*"
+      context: 200000
+    - pattern: "claude-3-sonnet*"
+      context: 200000
+    - pattern: "claude-3-haiku*"
+      context: 200000
+    - pattern: "claude-2*"
+      context: 100000
+    - pattern: "gemini-1.5-pro*"
+      context: 1048576  # 1M context
+    - pattern: "gemini-1.5-flash*"
+      context: 1048576  # 1M context
+    - pattern: "mistral-large*"
+      context: 32768
+    - pattern: "mixtral*"
+      context: 32768
+
+# Request/response handling
+request:
+  model_field_paths:
+    - "model"
+  response_format: "openai"  # LiteLLM uses OpenAI-compatible format
+  parsing_rules:
+    chat_completions_path: "/v1/chat/completions"
+    completions_path: "/v1/completions"
+    embeddings_path: "/v1/embeddings"
+    model_field_name: "model"
+    supports_streaming: true
+
+# Path indices for specific functions  
+path_indices:
+  health: 1
+  chat_completions: 2
+  completions: 3
+  embeddings: 4
+  models: 5
+
+# Resource management
+resources:
+  # LiteLLM proxy itself is lightweight - actual models run elsewhere
+  defaults:
+    min_memory_gb: 0.5
+    recommended_memory_gb: 1
+    requires_gpu: false
+    estimated_load_time_ms: 100
+  
+  # Concurrency is handled by remote providers
+  concurrency_limits:
+    - min_memory_gb: 0
+      max_concurrent: 1000  # LiteLLM can handle many concurrent requests
+  
+  # Basic timeout configuration
+  timeout_scaling:
+    base_timeout_seconds: 60
+    load_time_buffer: false  # No model loading for proxy
+
+# Metrics extraction for LiteLLM responses
+# 18-08-2025 [TF]: These are based on standard OpenAI response formats
+metrics:
+  extraction:
+    enabled: true
+    source: "response_body"
+    format: "json"
+    
+    # LiteLLM returns standard OpenAI format JSON responses
+    paths:
+      # Basic response fields
+      request_id: "$.id"
+      model: "$.model"
+      created: "$.created"
+      object_type: "$.object"
+      
+      # Completion status - finish_reason can be: stop, length, function_call, content_filter, null (streaming)
+      finish_reason: "$.choices[0].finish_reason"
+      
+      # Token usage (always present in non-streaming responses)
+      input_tokens: "$.usage.prompt_tokens"
+      output_tokens: "$.usage.completion_tokens" 
+      total_tokens: "$.usage.total_tokens"
+      
+      # Cache tokens (present when caching is enabled)
+      cache_read_tokens: "$.usage.cache_read_input_tokens"
+      cache_creation_tokens: "$.usage.cache_creation_input_tokens"
+      
+    calculations:
+      # Response is complete when finish_reason is present and not null
+      # Valid completion reasons: stop (normal), length (max tokens), function_call, content_filter
+      is_complete: 'finish_reason != null && finish_reason != ""'
+      
+      # Check if response was from cache (when cache tokens are present and > 0)
+      is_cached: 'cache_read_tokens != null && cache_read_tokens > 0'
+      
+      # Calculate actual new tokens (total minus cached)
+      new_tokens: 'cache_read_tokens != null ? total_tokens - cache_read_tokens : total_tokens'

--- a/docs/content/api-reference/litellm.md
+++ b/docs/content/api-reference/litellm.md
@@ -1,0 +1,286 @@
+# LiteLLM API
+
+Proxy endpoints for LiteLLM gateway. All LiteLLM API endpoints are available through the `/olla/litellm/` prefix.
+
+## Endpoints Overview
+
+### Core Endpoints (Always Available)
+
+These endpoints are available in all LiteLLM deployments:
+
+| Method | URI | Description |
+|--------|-----|-------------|
+| GET | `/olla/litellm/health` | Health check |
+| GET | `/olla/litellm/v1/models` | List available models |
+| POST | `/olla/litellm/v1/chat/completions` | Chat completion |
+| POST | `/olla/litellm/v1/completions` | Text completion |
+| POST | `/olla/litellm/v1/embeddings` | Generate embeddings |
+
+### Optional Endpoints (Kubernetes/Advanced Deployments)
+
+| Method | URI | Description |
+|--------|-----|-------------|
+| GET | `/olla/litellm/health/readiness` | Readiness probe (K8s) |
+| GET | `/olla/litellm/health/liveness` | Liveness probe (K8s) |
+
+### Database-Required Endpoints
+
+**Note:** These endpoints only work when LiteLLM is configured with a PostgreSQL database backend:
+
+| Method | URI | Description | Requirements |
+|--------|-----|-------------|--------------|
+| POST | `/olla/litellm/key/generate` | Generate API key | Database + Admin |
+| GET | `/olla/litellm/key/info` | Get key info | Database |
+| GET | `/olla/litellm/user/info` | User information | Database |
+| GET | `/olla/litellm/team/info` | Team information | Database |
+| GET | `/olla/litellm/spend/calculate` | Calculate spend | Database |
+
+---
+
+## POST /olla/litellm/v1/chat/completions
+
+Chat completion using OpenAI-compatible format, routing to 100+ providers.
+
+### Request
+
+```bash
+curl -X POST http://localhost:40114/olla/litellm/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user", 
+        "content": "Explain quantum computing in simple terms."
+      }
+    ],
+    "temperature": 0.7,
+    "max_tokens": 500,
+    "stream": false
+  }'
+```
+
+### Response
+
+```json
+{
+  "id": "chatcmpl-123",
+  "object": "chat.completion",
+  "created": 1705320600,
+  "model": "gpt-4",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Quantum computing is like having a super-powered calculator that can try many solutions at once..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 25,
+    "completion_tokens": 120,
+    "total_tokens": 145
+  }
+}
+```
+
+### Streaming Response
+
+When `"stream": true`:
+
+```
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1705320600,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Quantum"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1705320600,"model":"gpt-4","choices":[{"index":0,"delta":{"content":" computing"},"finish_reason":null}]}
+
+data: [DONE]
+```
+
+---
+
+## GET /olla/litellm/v1/models
+
+List all available models from configured providers.
+
+### Request
+
+```bash
+curl http://localhost:40114/olla/litellm/v1/models
+```
+
+### Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "gpt-4",
+      "object": "model",
+      "created": 1698959748,
+      "owned_by": "openai"
+    },
+    {
+      "id": "claude-3-opus",
+      "object": "model",
+      "created": 1698959748,
+      "owned_by": "anthropic"
+    },
+    {
+      "id": "gemini-pro",
+      "object": "model",
+      "created": 1698959748,
+      "owned_by": "google"
+    },
+    {
+      "id": "llama-70b",
+      "object": "model",
+      "created": 1698959748,
+      "owned_by": "together_ai"
+    }
+  ]
+}
+```
+
+---
+
+## POST /olla/litellm/v1/embeddings
+
+Generate embeddings using available embedding models.
+
+### Request
+
+```bash
+curl -X POST http://localhost:40114/olla/litellm/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "text-embedding-ada-002",
+    "input": "The quick brown fox jumps over the lazy dog"
+  }'
+```
+
+### Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [
+        -0.006929283,
+        -0.005336422,
+        -0.00040876168,
+        ...
+      ]
+    }
+  ],
+  "model": "text-embedding-ada-002",
+  "usage": {
+    "prompt_tokens": 9,
+    "total_tokens": 9
+  }
+}
+```
+
+---
+
+## GET /olla/litellm/health
+
+Check LiteLLM gateway health status.
+
+### Request
+
+```bash
+curl http://localhost:40114/olla/litellm/health
+```
+
+### Response
+
+```json
+{
+  "status": "healthy",
+  "models": 25,
+  "providers": [
+    "openai",
+    "anthropic",
+    "bedrock",
+    "gemini",
+    "together_ai"
+  ]
+}
+```
+
+
+---
+
+## Provider-Specific Models
+
+LiteLLM supports provider-prefixed model names:
+
+### OpenAI Models
+- `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`
+- `text-embedding-ada-002`, `text-embedding-3-small`
+
+### Anthropic Models
+- `claude-3-opus`, `claude-3-sonnet`, `claude-3-haiku`
+- `claude-2.1`, `claude-2`, `claude-instant`
+
+### Google Models
+- `gemini-pro`, `gemini-pro-vision`
+- `palm-2`, `chat-bison`
+
+### AWS Bedrock Models
+- `bedrock/claude-3-opus`, `bedrock/claude-3-sonnet`
+- `bedrock/llama2-70b`, `bedrock/mistral-7b`
+
+### Together AI Models
+- `together_ai/llama-3-70b`, `together_ai/mixtral-8x7b`
+- `together_ai/qwen-72b`, `together_ai/deepseek-coder`
+
+---
+
+## Response Headers
+
+All LiteLLM requests through Olla include tracking headers:
+
+```
+X-Olla-Endpoint: litellm-gateway
+X-Olla-Backend-Type: litellm
+X-Olla-Model: gpt-4
+X-Olla-Request-ID: req_abc123
+X-Olla-Response-Time: 2.341s
+```
+
+---
+
+## Error Handling
+
+LiteLLM errors are passed through with additional context:
+
+```json
+{
+  "error": {
+    "message": "Rate limit exceeded for model gpt-4",
+    "type": "rate_limit_error",
+    "code": 429,
+    "provider": "openai"
+  }
+}
+```
+
+---
+
+## See Also
+
+- [LiteLLM Integration Guide](../integrations/backend/litellm.md)
+- [OpenAI API Reference](./openai.md)
+- [Model Routing](../concepts/model-routing.md)
+- [Load Balancing](../concepts/load-balancing.md)

--- a/docs/content/api-reference/overview.md
+++ b/docs/content/api-reference/overview.md
@@ -51,6 +51,11 @@ Proxy endpoints for vLLM servers.
 
 - `/olla/vllm/*` - vLLM API endpoints
 
+### [LiteLLM API](litellm.md)
+Proxy endpoints for LiteLLM gateway (100+ providers).
+
+- `/olla/litellm/*` - LiteLLM API endpoints
+
 ## Authentication
 
 Currently, Olla does not implement authentication at the proxy level. Authentication should be handled by:

--- a/docs/content/compare/integration-patterns.md
+++ b/docs/content/compare/integration-patterns.md
@@ -125,32 +125,38 @@ endpoints:
 
 ## Tool-Specific Integrations
 
-### Olla + [LiteLLM](./litellm.md)
+### Olla + [LiteLLM](./litellm.md) (Native Support!)
 
-**Option 1: LiteLLM for Cloud, Olla for Everything**
+**Option 1: Native Integration with LiteLLM (Recommended)**
 ```yaml
-# Olla manages routing, LiteLLM handles cloud APIs
+# Olla has native LiteLLM support - use the dedicated profile
 endpoints:
   - name: local-models
     url: http://ollama:11434
-    priority: 1
+    type: ollama
+    priority: 100
     
   - name: litellm-cloud
-    url: http://litellm:8000
-    priority: 5  # When local unavailable
+    url: http://litellm:4000
+    type: litellm  # Native LiteLLM profile!
+    priority: 75
+    model_url: /v1/models
+    health_check_url: /health
 ```
 
-**Option 2: Redundant LiteLLM Instances**
+**Option 2: Redundant LiteLLM Instances with Native Support**
 ```yaml
-# Olla provides HA for LiteLLM
+# Multiple LiteLLM instances with health monitoring
 endpoints:
   - name: litellm-primary
-    url: http://litellm1:8000
-    priority: 1
+    url: http://litellm1:4000
+    type: litellm
+    priority: 90
     
   - name: litellm-backup
-    url: http://litellm2:8000
-    priority: 1  # Round-robin
+    url: http://litellm2:4000
+    type: litellm
+    priority: 90  # Same priority for round-robin
 ```
 
 ### Olla + [GPUStack](./gpustack.md)

--- a/docs/content/compare/litellm.md
+++ b/docs/content/compare/litellm.md
@@ -6,9 +6,12 @@ keywords: olla vs litellm, litellm comparison, llm proxy comparison, ai gateway,
 
 # Olla vs LiteLLM
 
+> **Native Integration Available!** 🎉  
+> Olla now includes native LiteLLM support through a dedicated profile. This means you can use LiteLLM as a backend provider just like Ollama or LM Studio, with full health checking, load balancing and failover capabilities. See [LiteLLM Integration](../integrations/backend/litellm.md).
+
 ## Overview
 
-[Olla](https://github.com/thushan/olla) and [LiteLLM](https://github.com/BerriAI/litellm) solve different problems in the LLM infrastructure stack. Rather than competitors, they're often complementary tools that work well together.
+[Olla](https://github.com/thushan/olla) and [LiteLLM](https://github.com/BerriAI/litellm) solve different problems in the LLM infrastructure stack. **Olla now provides native LiteLLM support**, making them perfect companions rather than competitors.
 
 ## Core Differences
 
@@ -28,15 +31,19 @@ keywords: olla vs litellm, litellm comparison, llm proxy comparison, ai gateway,
 
 ### Architecture
 
-**Olla**:
+**Olla (with native LiteLLM support)**:
 ```
-Application → Olla → Physical Endpoints
+Application → Olla → Multiple Backends
                 ├── Ollama instance 1
                 ├── Ollama instance 2
-                └── LM Studio instance
+                ├── LM Studio instance
+                └── LiteLLM gateway → Cloud Providers
+                                  ├── OpenAI API
+                                  ├── Anthropic API
+                                  └── 100+ other providers
 ```
 
-**LiteLLM**:
+**LiteLLM (standalone)**:
 ```
 Application → LiteLLM → Provider APIs
                     ├── OpenAI API
@@ -87,30 +94,36 @@ Application → LiteLLM → Provider APIs
 - Require provider-specific features
 - Building provider-agnostic applications
 
-## Using Them Together
+## Using Them Together (Native Integration)
 
-Olla and LiteLLM work brilliantly together in a layered architecture:
+With Olla's **native LiteLLM support**, integration is seamless:
 
-### Option 1: LiteLLM Behind Olla
+### Native Integration (Recommended)
 ```yaml
-# Olla config
+# Olla config with native LiteLLM support
 endpoints:
-  - name: litellm-primary
-    url: http://litellm1:8000
-    priority: 1
-  - name: litellm-backup
-    url: http://litellm2:8000
-    priority: 2
+  # Local models (high priority)
   - name: local-ollama
     url: http://localhost:11434
-    priority: 3
+    type: ollama
+    priority: 100
+    
+  # LiteLLM gateway (native support)
+  - name: litellm-gateway
+    url: http://localhost:4000
+    type: litellm  # Native LiteLLM profile
+    priority: 75
+    model_url: /v1/models
+    health_check_url: /health
 ```
 
 **Benefits**:
 
-- High availability for LiteLLM
-- Failover to local models if cloud is down
-- Unified endpoint for all models
+- Native profile for optimal integration
+- Automatic model discovery from LiteLLM
+- Health monitoring and circuit breakers for cloud providers
+- Unified endpoint for local AND cloud models
+- Intelligent routing based on model availability
 
 ### Option 2: Side-by-Side
 ```

--- a/docs/content/compare/overview.md
+++ b/docs/content/compare/overview.md
@@ -43,7 +43,7 @@ Instead, we excel at:
 **Perfect for Olla!** Point Olla at all your Ollama instances and get automatic failover, load balancing, and unified access.
 
 ### "I need to use OpenAI, Anthropic, and local models"
-**Use Olla + [LiteLLM](./litellm.md)**: LiteLLM handles the API translation, Olla provides resilience and routing between LiteLLM instances and local endpoints.
+**Use Olla with native [LiteLLM](./litellm.md) support**: Olla now includes native LiteLLM integration. Configure LiteLLM as a backend type alongside your local endpoints for seamless routing between local and cloud models.
 
 ### "I have a cluster of GPUs to manage"
 **Use [GPUStack](./gpustack.md) + Olla**: GPUStack orchestrates model deployment across GPUs, Olla provides the reliable routing layer on top.

--- a/docs/content/concepts/profile-system.md
+++ b/docs/content/concepts/profile-system.md
@@ -75,7 +75,7 @@ description: "Local Ollama instance for running GGUF models"
 - `display_name` - A nicer way to display information about the profile
 - `description` - A short description for the interface
 
-### Routing Prefixes
+### Routing Prefixes {#routing-prefixes}
 
 The `routing.prefixes` section defines URL paths that route to this backend.
 
@@ -226,7 +226,7 @@ request:
 | lmstudio | `data` | OpenAI-compatible |
 | vllm | `data` | OpenAI-compatible |
 
-### Capability Detection
+### Capability Detection {#capability-detection}
 
 The `models.capability_patterns` section uses glob patterns to detect model features.
 
@@ -396,7 +396,7 @@ features:
       - /detokenize
 ```
 
-## Creating Custom Profiles
+## Creating Custom Profiles {#creating-custom-profiles}
 
 ### Basic Custom Profile
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -15,6 +15,7 @@ keywords: llm proxy, ollama proxy, lm studio proxy, vllm proxy, model unificatio
     <a href="https://ollama.com"><img src="https://img.shields.io/badge/Ollama-native-lightgreen.svg" alt="Ollama: Native Support"></a> 
     <a href="https://lmstudio.ai/"><img src="https://img.shields.io/badge/LM Studio-native-lightgreen.svg" alt="LM Studio: Native Support"></a> 
     <a href="https://github.com/vllm-project/vllm"><img src="https://img.shields.io/badge/vLLM-native-lightgreen.svg" alt="vLLM: Native Support"></a> 
+    <a href="https://github.com/BerriAI/litellm"><img src="https://img.shields.io/badge/LiteLLM-native-lightgreen.svg" alt="LiteLLM: Native Support"></a> 
     <a href="https://github.com/lemonade-sdk/lemonade"><img src="https://img.shields.io/badge/Lemonade-openai-lightblue.svg" alt="Lemonade AI: OpenAI Compatible"></a> 
     <a href="https://github.com/InternLM/lmdeploy"><img src="https://img.shields.io/badge/LM Deploy-openai-lightblue.svg" alt="Lemonade AI: OpenAI Compatible"></a> 
   </P>
@@ -22,9 +23,9 @@ keywords: llm proxy, ollama proxy, lm studio proxy, vllm proxy, model unificatio
 
 Olla is a high-performance, low-overhead, low-latency proxy, model unifier and load balancer for managing LLM infrastructure. 
 
-It intelligently routes LLM requests across local and remote inference nodes - including [Ollama](https://github.com/ollama/ollama), [LM Studio](https://lmstudio.ai/) and OpenAI-compatible endpoints like [vLLM](https://github.com/vllm-project/vllm). Olla provides model discovery and unified model catalogues within each provider, enabling seamless routing to available models on compatible endpoints.
+It intelligently routes LLM requests across local and remote inference nodes - including [Ollama](https://github.com/ollama/ollama), [LM Studio](https://lmstudio.ai/), [LiteLLM](https://github.com/BerriAI/litellm) (100+ cloud providers), and OpenAI-compatible endpoints like [vLLM](https://github.com/vllm-project/vllm). Olla provides model discovery and unified model catalogues across all providers, enabling seamless routing to available models on compatible endpoints.
 
-Unlike API gateways like [LiteLLM](compare/litellm.md) or orchestration platforms like [GPUStack](compare/gpustack.md), Olla focuses on making your existing LLM infrastructure reliable through intelligent routing and failover.
+With native [LiteLLM support](integrations/backend/litellm.md), Olla bridges local and cloud infrastructure - use local models when available, automatically failover to cloud APIs when needed. Unlike orchestration platforms like [GPUStack](compare/gpustack.md), Olla focuses on making your existing LLM infrastructure reliable through intelligent routing and failover.
 
 ## Key Features
 
@@ -93,7 +94,7 @@ Olla provides detailed response headers for observability:
 |--------|-------------|
 | `X-Olla-Endpoint` | Backend endpoint name |
 | `X-Olla-Model` | Model used for the request |
-| `X-Olla-Backend-Type` | Backend type (ollama/openai/lmstudio/vllm) |
+| `X-Olla-Backend-Type` | Backend type (ollama/openai/lmstudio/vllm/litellm) |
 | `X-Olla-Request-ID` | Unique request identifier |
 | `X-Olla-Response-Time` | Total processing time |
 

--- a/docs/content/integrations/backend/litellm.md
+++ b/docs/content/integrations/backend/litellm.md
@@ -1,0 +1,555 @@
+---
+title: LiteLLM Integration - Unified Gateway to 100+ LLM Providers
+description: Configure and integrate LiteLLM with Olla for unified access to OpenAI, Anthropic, Bedrock, Azure, Google Vertex AI, and 100+ LLM providers through a single interface.
+keywords: LiteLLM, Olla proxy, API gateway, OpenAI, Anthropic, Bedrock, cloud LLM, unified API, model routing
+---
+
+# LiteLLM Integration
+
+<table>
+    <tr>
+        <th>Home</th>
+        <td><a href="https://github.com/BerriAI/litellm">github.com/BerriAI/litellm</a></td>
+    </tr>
+    <tr>
+        <th>Since</th>
+        <td>Olla <code>v0.0.17</code></td>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td><code>litellm</code> (use in endpoint configuration)</td>
+    </tr>
+    <tr>
+        <th>Profile</th>
+        <td><code>litellm.yaml</code> (see <a href="https://github.com/thushan/olla/blob/main/config/profiles/litellm.yaml">latest</a>)</td>
+    </tr>
+    <tr>
+        <th>Features</th>
+        <td>
+            <ul>
+                <li>Proxy Forwarding</li>
+                <li>Health Check (native)</li>
+                <li>Model Unification</li>
+                <li>Model Detection & Normalisation</li>
+                <li>OpenAI API Compatibility</li>
+                <li>100+ Provider Support</li>
+                <li>Automatic API Translation</li>
+                <li>Cost Tracking</li>
+                <li>Response Caching</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Unsupported</th>
+        <td>
+            <ul>
+                <li>Direct Model Management</li>
+                <li>Model Download/Upload</li>
+                <li>GPU Management</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Attributes</th>
+        <td>
+            <ul>
+                <li>OpenAI Compatible</li>
+                <li>Multi-Provider Gateway</li>
+                <li>Automatic Fallbacks</li>
+                <li>Load Balancing</li>
+                <li>Spend Management</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Prefixes</th>
+        <td>
+            <ul>
+                <li><code>/litellm</code>(default)</li>
+                <li><code>/lite</code> (disabled, enable in profile)</li>
+            </ul>
+            (see <a href="/olla/concepts/profile-system/#routing-prefixes">Routing Prefixes</a>)
+        </td>
+    </tr>
+    <tr>
+        <th>Endpoints</th>
+        <td>
+            See <a href="#endpoints-supported">below</a>
+        </td>
+    </tr>
+</table>
+
+## Configuration
+
+### Basic Setup
+
+Add LiteLLM to your Olla configuration:
+
+```yaml
+discovery:
+  static:
+    endpoints:
+      - url: "http://localhost:4000"
+        name: "litellm-gateway"
+        type: "litellm"
+        priority: 75
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
+```
+
+### Multiple LiteLLM Instances
+
+Configure multiple LiteLLM servers for high availability:
+
+```yaml
+discovery:
+  static:
+    endpoints:
+      # Primary LiteLLM instance
+      - url: "http://litellm-primary:4000"
+        name: "litellm-primary"
+        type: "litellm"
+        priority: 90
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
+        
+      # Secondary LiteLLM instance  
+      - url: "http://litellm-secondary:4000"
+        name: "litellm-secondary"
+        type: "litellm"
+        priority: 70
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
+```
+
+## Starting LiteLLM
+
+LiteLLM can run in two modes:
+
+### Basic Proxy Mode (Most Common)
+
+Simple API translation without database - suitable for most use cases:
+
+```bash
+# Install LiteLLM
+pip install 'litellm[proxy]'
+
+# Start with environment variables
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+
+# Run proxy
+litellm --model gpt-3.5-turbo \
+        --model claude-3-haiku-20240307 \
+        --port 4000
+```
+
+### Configuration File Mode
+
+Create a `litellm_config.yaml`:
+
+```yaml
+model_list:
+  # OpenAI models
+  - model_name: gpt-4
+    litellm_params:
+      model: openai/gpt-4
+      api_key: ${OPENAI_API_KEY}
+  
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: openai/gpt-3.5-turbo
+      api_key: ${OPENAI_API_KEY}
+  
+  # Anthropic models
+  - model_name: claude-3-opus
+    litellm_params:
+      model: anthropic/claude-3-opus-20240229
+      api_key: ${ANTHROPIC_API_KEY}
+  
+  - model_name: claude-3-sonnet
+    litellm_params:
+      model: anthropic/claude-3-sonnet-20240229
+      api_key: ${ANTHROPIC_API_KEY}
+  
+  # AWS Bedrock models
+  - model_name: claude-3-bedrock
+    litellm_params:
+      model: bedrock/anthropic.claude-3-sonnet
+      aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+      aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+      aws_region_name: us-east-1
+  
+  # Google models
+  - model_name: gemini-pro
+    litellm_params:
+      model: gemini/gemini-pro
+      api_key: ${GEMINI_API_KEY}
+  
+  # Together AI models
+  - model_name: llama-70b
+    litellm_params:
+      model: together_ai/meta-llama/Llama-3-70b-chat-hf
+      api_key: ${TOGETHER_API_KEY}
+
+# Optional: Caching configuration
+litellm_settings:
+  cache: true
+  cache_ttl: 3600
+  
+  # Optional: Spend tracking
+  max_budget: 100  # $100 budget
+  budget_duration: 30d  # 30 days
+```
+
+Start with configuration:
+
+```bash
+litellm --config litellm_config.yaml --port 4000
+```
+
+## Endpoints Supported
+
+### Core Endpoints (Always Available)
+
+These endpoints work in all LiteLLM deployments:
+
+| Endpoint | Method | Description | Prefix Required |
+|----------|--------|-------------|-----------------|
+| `/v1/chat/completions` | POST | Chat completions | `/olla/litellm` |
+| `/v1/completions` | POST | Text completions | `/olla/litellm` |
+| `/v1/embeddings` | POST | Generate embeddings | `/olla/litellm` |
+| `/v1/models` | GET | List available models | `/olla/litellm` |
+| `/health` | GET | Health check | `/olla/litellm` |
+
+### Advanced Endpoints (Database Required)
+
+These endpoints only work with PostgreSQL database backend:
+
+| Endpoint | Method | Description | Requirements |
+|----------|--------|-------------|--------------|
+| `/key/generate` | POST | Generate API key | Database + Admin auth |
+| `/user/info` | GET | User information | Database |
+| `/team/info` | GET | Team information | Database |
+| `/spend/calculate` | GET | Calculate spend | Database |
+
+**Note:** Most users run LiteLLM in basic proxy mode without database, so these endpoints won't be available by default in the profile in Olla, you will have to add them in.
+
+## Supported Providers
+
+LiteLLM provides access to 100+ LLM providers:
+
+### Major Cloud Providers
+- **OpenAI**: GPT-5, GPT-4, GPT-3.5, Embeddings
+- **Anthropic**: Claude 4.x / 3.x (Opus, Sonnet, Haiku), Claude 2
+- **Google**: Gemini Pro, PaLM, Vertex AI
+- **AWS Bedrock**: Claude, Llama, Mistral, Titan
+- **Azure**: Azure OpenAI Service
+- **Cohere**: Command, Embed
+
+### Open Model Platforms
+- **Together AI**: Llama, Mixtral, Qwen
+- **Replicate**: Various open models
+- **Hugging Face**: Inference API & Endpoints
+- **Anyscale**: Llama, Mistral
+- **Perplexity**: pplx models
+- **Groq**: Fast inference
+
+### Specialized Providers
+- **Voyage AI**: Embeddings
+- **AI21**: Jurassic models
+- **NLP Cloud**: Various models
+- **Aleph Alpha**: Luminous models
+- **Databricks**: DBRX
+- **DeepInfra**: Open models
+
+## Usage Examples
+
+### Basic Chat Completion
+
+```bash
+# Using LiteLLM through Olla
+curl -X POST http://localhost:40114/olla/litellm/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+### Provider-Prefixed Models
+
+LiteLLM supports provider-prefixed model names:
+
+```python
+import openai
+
+client = openai.OpenAI(base_url="http://localhost:40114/olla/openai")
+
+# Routes to OpenAI
+response = client.chat.completions.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Routes to Anthropic via LiteLLM
+response = client.chat.completions.create(
+    model="claude-4-opus",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Routes to AWS Bedrock via LiteLLM
+response = client.chat.completions.create(
+    model="claude-4-bedrock",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+### List Available Models
+
+```bash
+# Get all models from LiteLLM
+curl http://localhost:40114/olla/litellm/v1/models
+
+# Response includes all configured models
+{
+  "data": [
+    {"id": "gpt-4", "object": "model"},
+    {"id": "claude-3-opus", "object": "model"},
+    {"id": "gemini-pro", "object": "model"},
+    {"id": "llama-70b", "object": "model"}
+  ]
+}
+```
+
+## Advanced Configuration
+
+### Cost-Optimised Routing
+
+Configure Olla to route to cheaper providers first:
+
+```yaml
+endpoints:
+  # Local models (free)
+  - url: "http://localhost:11434"
+    name: "local-ollama"
+    type: "ollama"
+    priority: 100
+  
+  # LiteLLM with budget models
+  - url: "http://litellm-budget:4000"
+    name: "litellm-budget"
+    type: "litellm"
+    priority: 75
+  
+  # LiteLLM with premium models
+  - url: "http://litellm-premium:4000"
+    name: "litellm-premium"
+    type: "litellm"
+    priority: 50
+```
+
+### Multi-Region Setup
+
+```yaml
+endpoints:
+  # US East region
+  - url: "http://litellm-us-east:4000"
+    name: "litellm-us-east"
+    type: "litellm"
+    priority: 100
+  
+  # EU West region
+  - url: "http://litellm-eu-west:4000"
+    name: "litellm-eu-west"
+    type: "litellm"
+    priority: 100
+  
+  # Load balance across regions
+proxy:
+  load_balancer: "least-connections"
+```
+
+## Model Capabilities
+
+LiteLLM models are automatically categorised by Olla:
+
+### Chat Models
+- GPT-4, GPT-3.5 (OpenAI)
+- Claude 3 Opus, Sonnet, Haiku (Anthropic)
+- Gemini Pro (Google)
+- Llama 3 (Meta via various providers)
+- Mistral, Mixtral (Mistral AI)
+
+### Embedding Models
+- text-embedding-ada-002 (OpenAI)
+- voyage-\* (Voyage AI)
+- embed-\* (Cohere)
+- titan-embed (AWS Bedrock)
+
+### Vision Models
+- GPT-4 Vision (OpenAI)
+- Claude 3 models (Anthropic)
+- Gemini Pro Vision (Google)
+
+### Code Models
+- GPT-4 (OpenAI)
+- Claude 3 (Anthropic)
+- CodeLlama (Meta via various providers)
+- DeepSeek Coder (via Together AI)
+
+## Response Headers
+
+When requests go through LiteLLM, Olla adds tracking headers:
+
+```
+X-Olla-Endpoint: litellm-gateway
+X-Olla-Backend-Type: litellm
+X-Olla-Model: gpt-4
+X-Olla-Request-ID: req_abc123
+X-Olla-Response-Time: 2.341s
+```
+
+## Health Monitoring
+
+Olla continuously monitors LiteLLM health:
+
+```bash
+# Check LiteLLM status
+curl http://localhost:40114/internal/status/endpoints
+
+# Response
+{
+  "endpoints": [
+    {
+      "name": "litellm-gateway",
+      "url": "http://localhost:4000",
+      "status": "healthy",
+      "type": "litellm",
+      "models_count": 25
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### LiteLLM Not Starting
+
+1. Check Python installation: `python --version`
+2. Install LiteLLM: `pip install litellm`
+3. Verify API keys are set in environment
+4. Check port availability: `lsof -i :4000`
+
+### Model Not Found
+
+1. Verify model is configured in LiteLLM config
+2. Check model name matches exactly
+3. Ensure API key for provider is valid
+4. Check provider-specific requirements
+
+### Slow Response Times
+
+1. Check LiteLLM logs for rate limiting
+2. Monitor provider API status
+3. Enable caching in LiteLLM config
+4. Consider using fallback models
+
+### Connection Errors
+
+1. Verify LiteLLM is running: `curl http://localhost:4000/health`
+2. Check firewall rules
+3. Verify network connectivity
+4. Check Olla can reach LiteLLM endpoint
+
+## Best Practices
+
+1. **Environment Variables**: Store API keys securely
+   ```bash
+   export OPENAI_API_KEY=sk-...
+   export ANTHROPIC_API_KEY=sk-ant-...
+   ```
+
+2. **Enable Caching** (Optional): Reduce costs with in-memory response caching
+   ```yaml
+   litellm_settings:
+     cache: true  # In-memory cache (no database required)
+     cache_ttl: 3600
+   ```
+
+3. **Use Fallbacks**: Configure backup models for reliability
+   ```yaml
+   model_list:
+     - model_name: primary-gpt4
+       litellm_params:
+         model: openai/gpt-4
+         fallbacks: [claude-3-opus, gpt-3.5-turbo]
+   ```
+
+4. **Monitor Health**: Check LiteLLM status
+   ```bash
+   curl http://localhost:40114/olla/litellm/health
+   ```
+   
+   **Note:** Budget limits and spend tracking require database backend.
+
+## Docker Deployment
+
+Run LiteLLM with Docker:
+
+```yaml
+# docker-compose.yml
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm:main-latest
+    ports:
+      - "4000:4000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      - ./litellm_config.yaml:/app/config.yaml
+    command: --config /app/config.yaml --port 4000
+```
+
+## Integration with Other Providers
+
+LiteLLM works seamlessly with other Olla providers:
+
+```yaml
+endpoints:
+  # Local Ollama (highest priority)
+  - url: "http://localhost:11434"
+    type: "ollama"
+    priority: 100
+  
+  # LM Studio (medium priority)
+  - url: "http://localhost:1234"
+    type: "lm-studio"
+    priority: 75
+  
+  # LiteLLM for cloud (lower priority)
+  - url: "http://localhost:4000"
+    type: "litellm"
+    priority: 50
+```
+
+This setup provides:
+1. Local model preference for speed and cost
+2. Automatic fallback to cloud APIs
+3. Unified API across all providers
+4. Single endpoint for all models
+
+## See Also
+
+- [LiteLLM Documentation](https://docs.litellm.ai/)
+- [Provider Setup Guides](https://docs.litellm.ai/docs/providers)
+- [Model Pricing](https://docs.litellm.ai/docs/providers/pricing)
+- [Olla Profile System](../../concepts/profile-system.md)
+- [Load Balancing Guide](../../concepts/load-balancing.md)

--- a/docs/content/integrations/backend/litellm.md
+++ b/docs/content/integrations/backend/litellm.md
@@ -290,23 +290,23 @@ LiteLLM supports provider-prefixed model names:
 ```python
 import openai
 
-client = openai.OpenAI(base_url="http://localhost:40114/olla/openai")
+client = openai.OpenAI(base_url="http://localhost:40114/olla/litellm/v1")
 
-# Routes to OpenAI
+# Routes to OpenAI via LiteLLM
 response = client.chat.completions.create(
-    model="gpt-4",
+    model="openai/gpt-4",
     messages=[{"role": "user", "content": "Hello!"}]
 )
 
 # Routes to Anthropic via LiteLLM
 response = client.chat.completions.create(
-    model="claude-4-opus",
+    model="anthropic/claude-3-opus-20240229",
     messages=[{"role": "user", "content": "Hello!"}]
 )
 
 # Routes to AWS Bedrock via LiteLLM
 response = client.chat.completions.create(
-    model="claude-4-bedrock",
+    model="bedrock/anthropic.claude-3-sonnet",
     messages=[{"role": "user", "content": "Hello!"}]
 )
 ```

--- a/docs/content/integrations/backend/lmstudio.md
+++ b/docs/content/integrations/backend/lmstudio.md
@@ -13,7 +13,7 @@ keywords: LM Studio, Olla, LLM proxy, local inference, OpenAI compatible, model 
     </tr>
     <tr>
         <th>Since</th>
-        <td>Olla <code>v0.0.7</code></td>
+        <td>Olla <code>v0.0.12</code></td>
     </tr>
     <tr>
         <th>Type</th>

--- a/docs/content/integrations/backend/lmstudio.md
+++ b/docs/content/integrations/backend/lmstudio.md
@@ -12,6 +12,10 @@ keywords: LM Studio, Olla, LLM proxy, local inference, OpenAI compatible, model 
         <td><a href="https://lmstudio.ai/">lmstudio.ai</a></td>
     </tr>
     <tr>
+        <th>Since</th>
+        <td>Olla <code>v0.0.7</code></td>
+    </tr>
+    <tr>
         <th>Type</th>
         <td><code>lm-studio</code> (use in endpoint configuration)</td>
     </tr>
@@ -59,7 +63,7 @@ keywords: LM Studio, Olla, LLM proxy, local inference, OpenAI compatible, model 
                 <li><code>/lm-studio</code></li>
                 <li><code>/lm_studio</code></li>
             </ul>
-            (see <a href="../../concepts/profile-system.md#routing-prefixes">Routing Prefixes</a>)
+            (see <a href="/olla/concepts/profile-system/#routing-prefixes">Routing Prefixes</a>)
         </td>
     </tr>
     <tr>

--- a/docs/content/integrations/backend/ollama.md
+++ b/docs/content/integrations/backend/ollama.md
@@ -12,6 +12,10 @@ keywords: ollama integration, ollama proxy, olla ollama, ollama configuration, o
         <td><a href="https://github.com/ollama/ollama">github.com/ollama/ollama</a></td>
     </tr>
     <tr>
+        <th>Since</th>
+        <td>Olla <code>v0.0.1</code></td>
+    </tr>
+    <tr>
         <th>Type</th>
         <td><code>ollama</code> (use in endpoint configuration)</td>
     </tr>
@@ -57,7 +61,7 @@ keywords: ollama integration, ollama proxy, olla ollama, ollama configuration, o
         <th>Prefixes</th>
         <td>
             <ul>
-                <li><code>/ollama</code> (see <a href="../../concepts/profile-system.md#routing-prefixes">Routing Prefixes</a>)</li>
+                <li><code>/ollama</code> (see <a href="/olla/concepts/profile-system/#routing-prefixes">Routing Prefixes</a>)</li>
             </ul>
         </td>
     </tr>

--- a/docs/content/integrations/backend/vllm.md
+++ b/docs/content/integrations/backend/vllm.md
@@ -12,6 +12,10 @@ keywords: vLLM, Olla proxy, LLM inference, GPU optimization, PagedAttention, ten
         <td><a href="https://github.com/vllm-project/vllm">github.com/vllm-project/vllm</a></td>
     </tr>
     <tr>
+        <th>Since</th>
+        <td>Olla <code>v0.0.16</code></td>
+    </tr>
+    <tr>
         <th>Type</th>
         <td><code>vllm</code> (use in endpoint configuration)</td>
     </tr>
@@ -59,7 +63,7 @@ keywords: vLLM, Olla proxy, LLM inference, GPU optimization, PagedAttention, ten
         <th>Prefixes</th>
         <td>
             <ul>
-                <li><code>/vllm</code> (see <a href="../../concepts/profile-system.md#routing-prefixes">Routing Prefixes</a>)</li>
+                <li><code>/vllm</code> (see <a href="/olla/concepts/profile-system/#routing-prefixes">Routing Prefixes</a>)</li>
             </ul>
         </td>
     </tr>

--- a/docs/content/integrations/overview.md
+++ b/docs/content/integrations/overview.md
@@ -15,6 +15,7 @@ Olla natively supports:
 * [Ollama](./backend/ollama.md) - native support for [Ollama](https://github.com/ollama/ollama), including model unification.
 * [LM Studio](./backend/lmstudio.md) - native support for [LM Studio](https://lmstudio.ai/), including model unification.
 * [vLLM](./backend/vllm.md) - native support for [vLLM](https://github.com/vllm-project/vllm), including model unification.
+* [LiteLLM](./backend/litellm.md) - native support for [LiteLLM](https://github.com/BerriAI/litellm), providing unified gateway to 100+ LLM providers.
 
 Other backends that support OpenAI APIs can be integrated too:
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -35,6 +35,7 @@ Perfect for enthusiasts running multiple LLM instances:
 ```yaml
 # Home lab config - local first, cloud fallback
 discovery:
+  type: "static"
   static:
     endpoints:
       - name: "rtx-4090-mobile"
@@ -86,6 +87,7 @@ Seamlessly combine local and cloud models with native LiteLLM support:
 ```yaml
 # Hybrid setup with LiteLLM
 discovery:
+  type: "static"
   static:
     endpoints:
       # Local models for privacy/cost

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -29,21 +29,30 @@ Perfect for enthusiasts running multiple LLM instances:
 - **Multi-GPU Setups**: Route between different models on various GPUs
 - **Model Experimentation**: Easy switching between Ollama, LM Studio and OpenAI backends  
 - **Resource Management**: Automatic failover when local resources are busy
-- **Cost Optimisation**: Priority routing (local first, cloud fallback via [LiteLLM](compare/litellm.md))
+- **Cost Optimisation**: Priority routing (local first, cloud fallback via native [LiteLLM](integrations/backend/litellm.md) support)
+- **Hybrid Cloud**: Access GPT-4, Claude, and 100+ cloud models when needed
 
 ```yaml
-# Home lab config - local first, home-lab second
+# Home lab config - local first, cloud fallback
 discovery:
   static:
     endpoints:
       - name: "rtx-4090-mobile"
         url: "http://localhost:11434" 
         type: "ollama"
-        priority: 100  # Highest priority
+        priority: 100  # Highest priority - use local when available
+        
       - name: "home-lab-rtx-6000"
         url: "https://192.168.0.1:11434"
         type: "ollama"
-        priority: 10   # Fallback only
+        priority: 80   # Second choice
+        
+      - name: "litellm-cloud"
+        url: "http://localhost:4000"
+        type: "litellm"  # Native LiteLLM support
+        priority: 50     # Cloud APIs as last resort
+        model_url: "/v1/models"
+        health_check_url: "/health"
 ```
 
 ### 🏢 Business & Teams
@@ -65,6 +74,37 @@ server:
     global_requests_per_minute: 1000
 ```
 
+### ☁️ Hybrid Cloud Integration
+
+Seamlessly combine local and cloud models with native LiteLLM support:
+
+- **Smart Routing**: Use local models for sensitive data, cloud for complex tasks
+- **Cost Control**: Prioritise free local models, failover to paid APIs
+- **Best-of-Both**: GPT-4 for coding, local Llama for chat, Claude for analysis
+- **Unified Interface**: One API endpoint for all models (local and cloud)
+
+```yaml
+# Hybrid setup with LiteLLM
+discovery:
+  static:
+    endpoints:
+      # Local models for privacy/cost
+      - name: "local-ollama"
+        url: "http://localhost:11434"
+        type: "ollama"
+        priority: 100
+        
+      # LiteLLM gateway to cloud providers
+      - name: "litellm-gateway"
+        url: "http://localhost:4000"
+        type: "litellm"
+        priority: 75
+        
+# Single endpoint accesses all models
+# http://localhost:40114/olla/openai/v1/chat/completions
+# Automatically routes to the right backend based on model name
+```
+
 ### 🏭 Enterprise & Production
 
 Mission-critical AI infrastructure at scale:
@@ -72,7 +112,7 @@ Mission-critical AI infrastructure at scale:
 - **Multi-Region Deployment**: Geographic load balancing and failover
 - **Enterprise Security**: Rate limiting, request validation, audit trails  
 - **Performance Monitoring**: Circuit breakers, health checks, metrics
-- **Vendor Diversity**: Mix of cloud providers and on-premise infrastructure
+- **Vendor Diversity**: Mix of cloud providers (via LiteLLM) and on-premise infrastructure
 
 ```yaml
 # Enterprise config - high performance, observability

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
             - Ollama: integrations/backend/ollama.md
             - LM Studio: integrations/backend/lmstudio.md
             - vLLM: integrations/backend/vllm.md
+            - LiteLLM: integrations/backend/litellm.md
         - Frontends:
             - OpenWebUI: integrations/frontend/openwebui.md
   - Development:
@@ -171,4 +172,5 @@ nav:
           - Ollama: api-reference/ollama.md
           - LM Studio: api-reference/lmstudio.md
           - vLLM: api-reference/vllm.md
+          - LiteLLM: api-reference/litellm.md
           - OpenAI: api-reference/openai.md


### PR DESCRIPTION
This PR adds adds a lightweight lightllm profile.

```
endpoints:
    - url: "http://localhost:4000"
      name: "local-litellm"
      type: "litellm"
      priority: 75
```

Additional things snuck in:
- FIX: default settings includes wrong port for LMStudio and contained non-localhost port for vllm
- FIX: Minor documentation example fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native LiteLLM backend integration enabling routing to 100+ cloud providers via OpenAI-compatible endpoints (/olla/litellm/*).
  - Response headers now include litellm in backend type.

- **Documentation**
  - Added comprehensive LiteLLM integration, API reference and integration guides; updated comparisons, usage, overview and homepage to reflect native LiteLLM support.
  - Added “Since” notes, anchor/link fixes and examples for hybrid cloud setups.

- **Chores**
  - Added LiteLLM profile/config and navigation entries; updated discovery endpoint URLs and priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->