### PR TITLE
fix: extract model name from large requests via streaming JSON prefix scan

### DIFF
--- a/internal/adapter/inspector/body_inspector.go
+++ b/internal/adapter/inspector/body_inspector.go
@@ -79,6 +79,10 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 	// "model" key using token-level iteration that skips large nested values without buffering
 	// them. This handles the case where "messages" (with large base64 images) precedes "model".
 	if r.ContentLength > bi.maxBodySize {
+		// captured is a locally-allocated bytes.Buffer (not from a sync.Pool), so
+		// captured.Bytes() is safe to use directly without an extra copy — unlike the
+		// small-body path below which must copy buffer.Bytes() to avoid pool aliasing
+		// once the deferred Reset()/Put() runs.
 		captured := &bytes.Buffer{}
 		origBody := r.Body
 		tee := io.TeeReader(io.LimitReader(origBody, modelScanSize), captured)
@@ -87,7 +91,7 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 
 		// Restore body: bytes the decoder read (captured via TeeReader) + remaining original body.
 		// The decoder may have stopped before the limit, so origBody still holds the unconsumed tail.
-		// Use readCloser so Close() propagates to the original body and drains the connection.
+		// readCloser ensures Close() propagates to origBody to drain the connection and avoid leaks.
 		r.Body = readCloser{
 			Reader: io.MultiReader(bytes.NewReader(captured.Bytes()), origBody),
 			Closer: origBody,

--- a/internal/adapter/inspector/body_inspector.go
+++ b/internal/adapter/inspector/body_inspector.go
@@ -76,14 +76,14 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 	if r.ContentLength > bi.maxBodySize {
 		prefix := make([]byte, modelScanSize)
 		n, err := io.ReadFull(r.Body, prefix)
+		// Always restore whatever bytes we read so downstream handlers are not starved,
+		// regardless of whether the read succeeded or partially failed.
+		prefix = prefix[:n]
+		r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(prefix), r.Body))
 		if err != nil && err != io.ErrUnexpectedEOF {
 			bi.logger.Debug("Failed to read request body prefix", "error", err)
 			return nil
 		}
-		prefix = prefix[:n]
-
-		// Restore the full body: prefix bytes already consumed + remainder still in original body
-		r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(prefix), r.Body))
 
 		modelName := bi.extractModelName(prefix)
 		if modelName != "" {
@@ -200,41 +200,39 @@ func extractTopLevelModelField(body []byte) string {
 		return ""
 	}
 
-	depth := 1
 	for dec.More() {
-		// Read the key token.
+		// Read the key token. At this position the decoder always yields a string key.
 		keyTok, err := dec.Token()
 		if err != nil {
 			return ""
 		}
 
-		switch v := keyTok.(type) {
-		case json.Delim:
-			if v == '{' || v == '[' {
-				depth++
-			} else {
-				depth--
-			}
-			continue
-		case string:
-			if depth == 1 && strings.EqualFold(v, "model") {
-				// Read the value token.
-				valTok, err := dec.Token()
-				if err != nil {
-					return ""
-				}
-				if modelStr, ok := valTok.(string); ok && modelStr != "" {
-					return modelStr
-				}
-				// Value wasn't a string — keep scanning.
-				continue
-			}
-			// Skip the value for this key by decoding it into a discard target.
-			var discard json.RawMessage
-			if err := dec.Decode(&discard); err != nil {
-				// Likely truncated JSON — stop scanning.
+		key, ok := keyTok.(string)
+		if !ok {
+			// Malformed JSON — key position must be a string.
+			return ""
+		}
+
+		if strings.EqualFold(key, "model") {
+			// Decode the full value so the decoder is always left in a consistent state,
+			// even when the value is a non-string type (object, array, number, etc.).
+			var val json.RawMessage
+			if err := dec.Decode(&val); err != nil {
 				return ""
 			}
+			var modelStr string
+			if err := json.Unmarshal(val, &modelStr); err == nil && modelStr != "" {
+				return modelStr
+			}
+			// Value wasn't a string — keep scanning.
+			continue
+		}
+
+		// Skip the value for this key by decoding it into a discard target.
+		var discard json.RawMessage
+		if err := dec.Decode(&discard); err != nil {
+			// Likely truncated JSON — stop scanning.
+			return ""
 		}
 	}
 

--- a/internal/adapter/inspector/body_inspector.go
+++ b/internal/adapter/inspector/body_inspector.go
@@ -20,11 +20,15 @@ const (
 	BodyInspectorName = "body"
 	MaxBodySize       = 1024 * 1024 // 1MB max body size for full body inspection (capabilities etc.)
 
-	// modelScanSize is the maximum number of bytes scanned when extracting only the top-level
-	// "model" field from large requests (e.g. vision requests with base64 image payloads).
-	// The model field is always near the start of the JSON object, so 64 KB is more than enough
-	// while keeping memory pressure negligible even for multi-megabyte bodies.
-	modelScanSize = 64 * 1024
+	// modelScanSize is the hard ceiling on bytes read when scanning for the top-level "model"
+	// field in large requests (e.g. vision requests with base64 image payloads). The scan
+	// stops as soon as the field is found, so for the common case where "model" appears near
+	// the start only a handful of bytes are consumed. The ceiling exists to bound memory use
+	// when "model" appears after large fields (e.g. a multi-megabyte "messages" array);
+	// 8 MB accommodates typical vision payloads while staying well within practical limits.
+	// Requests where "model" is absent or appears beyond this ceiling will not be routed by
+	// model name — capability-based or default routing applies instead.
+	modelScanSize = 8 * 1024 * 1024
 )
 
 type modelRequest struct {
@@ -70,30 +74,29 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 
 	// For large requests (e.g. vision with base64 images) we still need the model name for
 	// routing, but buffering the full body just to parse JSON is wasteful and would OOM for
-	// multi-megabyte payloads. Instead, read a small prefix sufficient to find the top-level
-	// "model" key, restore the full body for downstream handlers, and skip capability detection
-	// (which requires the full body and is only used for optional capability-based filtering).
+	// multi-megabyte payloads. Instead, stream-scan up to modelScanSize bytes using a
+	// TeeReader so all bytes read are captured for body restoration, and locate the top-level
+	// "model" key using token-level iteration that skips large nested values without buffering
+	// them. This handles the case where "messages" (with large base64 images) precedes "model".
 	if r.ContentLength > bi.maxBodySize {
-		prefix := make([]byte, modelScanSize)
-		n, err := io.ReadFull(r.Body, prefix)
-		// Always restore whatever bytes we read so downstream handlers are not starved,
-		// regardless of whether the read succeeded or partially failed.
-		prefix = prefix[:n]
+		captured := &bytes.Buffer{}
 		origBody := r.Body
+		tee := io.TeeReader(io.LimitReader(origBody, modelScanSize), captured)
+
+		modelName := extractTopLevelModelFieldFromReader(tee)
+
+		// Restore body: bytes the decoder read (captured via TeeReader) + remaining original body.
+		// The decoder may have stopped before the limit, so origBody still holds the unconsumed tail.
+		// Use readCloser so Close() propagates to the original body and drains the connection.
 		r.Body = readCloser{
-			Reader: io.MultiReader(bytes.NewReader(prefix), origBody),
+			Reader: io.MultiReader(bytes.NewReader(captured.Bytes()), origBody),
 			Closer: origBody,
 		}
-		if err != nil && err != io.ErrUnexpectedEOF {
-			bi.logger.Debug("Failed to read request body prefix", "error", err)
-			return nil
-		}
 
-		modelName := bi.extractModelName(prefix)
 		if modelName != "" {
-			profile.ModelName = modelName
-			bi.logger.Debug("Extracted model name from large request body prefix",
-				"model", modelName, "content_length", r.ContentLength)
+			profile.ModelName = bi.normalizeModelName(modelName)
+			bi.logger.Debug("Extracted model name from large request body scan",
+				"model", profile.ModelName, "content_length", r.ContentLength)
 		} else {
 			bi.logger.Debug("Could not extract model name from large request body",
 				"content_length", r.ContentLength)
@@ -166,7 +169,7 @@ func (bi *BodyInspector) extractModelName(body []byte) string {
 	// Streaming path: works on both complete and truncated JSON (e.g. a 64 KB prefix of a
 	// multi-megabyte vision request). Scan only top-level tokens so we never descend into
 	// the large base64 image string embedded in the messages array.
-	if model := extractTopLevelModelField(body); model != "" {
+	if model := extractTopLevelModelFieldFromReader(bytes.NewReader(body)); model != "" {
 		return bi.normalizeModelName(model)
 	}
 
@@ -197,12 +200,13 @@ func (bi *BodyInspector) extractModelName(body []byte) string {
 	return ""
 }
 
-// extractTopLevelModelField scans a JSON byte slice (which may be truncated) with a
-// streaming decoder and returns the value of the first top-level "model" string key.
-// It never descends into nested objects or arrays, so it is safe to call on multi-megabyte
-// bodies as well as short prefix slices.
-func extractTopLevelModelField(body []byte) string {
-	dec := json.NewDecoder(bytes.NewReader(body))
+// extractTopLevelModelFieldFromReader scans JSON from r (which may be a truncated stream)
+// with a streaming decoder and returns the value of the first top-level "model" string key.
+// Non-model field values are skipped using token-level iteration so large nested values
+// (e.g. base64 image payloads in "messages") are never buffered into memory.
+// This allows correct extraction even when "model" appears after large fields.
+func extractTopLevelModelFieldFromReader(r io.Reader) string {
+	dec := json.NewDecoder(r)
 
 	// Consume the opening '{' of the top-level object.
 	tok, err := dec.Token()
@@ -227,8 +231,7 @@ func extractTopLevelModelField(body []byte) string {
 		}
 
 		if strings.EqualFold(key, "model") {
-			// Decode the full value so the decoder is always left in a consistent state,
-			// even when the value is a non-string type (object, array, number, etc.).
+			// Read the value as a raw message; the value is small so allocation is fine.
 			var val json.RawMessage
 			if err := dec.Decode(&val); err != nil {
 				return ""
@@ -241,15 +244,51 @@ func extractTopLevelModelField(body []byte) string {
 			continue
 		}
 
-		// Skip the value for this key by decoding it into a discard target.
-		var discard json.RawMessage
-		if err := dec.Decode(&discard); err != nil {
-			// Likely truncated JSON — stop scanning.
+		// Skip the value for this key using token-level iteration so we never buffer
+		// a large nested value (e.g. a messages array containing base64 images).
+		if err := skipValueTokens(dec); err != nil {
+			// Truncated JSON or I/O error — stop scanning.
 			return ""
 		}
 	}
 
 	return ""
+}
+
+// skipValueTokens advances dec past the next JSON value at the current read position.
+// It uses token-level iteration to avoid allocating a buffer for the entire value,
+// which is important when skipping large nested arrays or objects (e.g. vision payloads).
+func skipValueTokens(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		// Scalar value (string, number, bool, null) — already consumed.
+		return nil
+	}
+	if delim != '{' && delim != '[' {
+		// Unexpected closing delimiter at value position — treat as error.
+		return fmt.Errorf("unexpected closing delimiter %v", delim)
+	}
+	// Track open/close depth to handle arbitrarily nested structures.
+	depth := 1
+	for depth > 0 {
+		tok, err = dec.Token()
+		if err != nil {
+			return err
+		}
+		if d, ok := tok.(json.Delim); ok {
+			switch d {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return nil
 }
 
 func (bi *BodyInspector) normalizeModelName(model string) string {

--- a/internal/adapter/inspector/body_inspector.go
+++ b/internal/adapter/inspector/body_inspector.go
@@ -79,7 +79,11 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 		// Always restore whatever bytes we read so downstream handlers are not starved,
 		// regardless of whether the read succeeded or partially failed.
 		prefix = prefix[:n]
-		r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(prefix), r.Body))
+		origBody := r.Body
+		r.Body = readCloser{
+			Reader: io.MultiReader(bytes.NewReader(prefix), origBody),
+			Closer: origBody,
+		}
 		if err != nil && err != io.ErrUnexpectedEOF {
 			bi.logger.Debug("Failed to read request body prefix", "error", err)
 			return nil
@@ -112,7 +116,11 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 
 	// Restore the body for downstream handlers by creating a new reader that combines
 	// what we've already read with any remaining unread content
-	r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(buffer.Bytes()), r.Body))
+	origBody := r.Body
+	r.Body = readCloser{
+		Reader: io.MultiReader(bytes.NewReader(buffer.Bytes()), origBody),
+		Closer: origBody,
+	}
 
 	modelName := bi.extractModelName(buffer.Bytes())
 	if modelName != "" {
@@ -244,6 +252,13 @@ func (bi *BodyInspector) normalizeModelName(model string) string {
 	model = strings.ToLower(model)
 	// Model aliasing and tag handling is delegated to the registry layer
 	return model
+}
+
+// readCloser combines a reader (e.g. io.MultiReader) with the original body's Closer so that
+// Close properly drains/releases the underlying connection rather than becoming a no-op.
+type readCloser struct {
+	io.Reader
+	io.Closer
 }
 
 // detectRequiredCapabilities analyzes the request body to determine what capabilities are needed

--- a/internal/adapter/inspector/body_inspector.go
+++ b/internal/adapter/inspector/body_inspector.go
@@ -18,7 +18,13 @@ import (
 
 const (
 	BodyInspectorName = "body"
-	MaxBodySize       = 1024 * 1024 // 1MB max body size for inspection
+	MaxBodySize       = 1024 * 1024 // 1MB max body size for full body inspection (capabilities etc.)
+
+	// modelScanSize is the maximum number of bytes scanned when extracting only the top-level
+	// "model" field from large requests (e.g. vision requests with base64 image payloads).
+	// The model field is always near the start of the JSON object, so 64 KB is more than enough
+	// while keeping memory pressure negligible even for multi-megabyte bodies.
+	modelScanSize = 64 * 1024
 )
 
 type modelRequest struct {
@@ -62,8 +68,32 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 		return nil
 	}
 
+	// For large requests (e.g. vision with base64 images) we still need the model name for
+	// routing, but buffering the full body just to parse JSON is wasteful and would OOM for
+	// multi-megabyte payloads. Instead, read a small prefix sufficient to find the top-level
+	// "model" key, restore the full body for downstream handlers, and skip capability detection
+	// (which requires the full body and is only used for optional capability-based filtering).
 	if r.ContentLength > bi.maxBodySize {
-		bi.logger.Debug("Skipping body inspection for large request", "content_length", r.ContentLength)
+		prefix := make([]byte, modelScanSize)
+		n, err := io.ReadFull(r.Body, prefix)
+		if err != nil && err != io.ErrUnexpectedEOF {
+			bi.logger.Debug("Failed to read request body prefix", "error", err)
+			return nil
+		}
+		prefix = prefix[:n]
+
+		// Restore the full body: prefix bytes already consumed + remainder still in original body
+		r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(prefix), r.Body))
+
+		modelName := bi.extractModelName(prefix)
+		if modelName != "" {
+			profile.ModelName = modelName
+			bi.logger.Debug("Extracted model name from large request body prefix",
+				"model", modelName, "content_length", r.ContentLength)
+		} else {
+			bi.logger.Debug("Could not extract model name from large request body",
+				"content_length", r.ContentLength)
+		}
 		return nil
 	}
 
@@ -114,12 +144,21 @@ func (bi *BodyInspector) extractModelName(body []byte) string {
 		return ""
 	}
 
+	// Fast path: complete JSON — unmarshal directly.
 	var req modelRequest
 	if err := json.Unmarshal(body, &req); err == nil && req.Model != "" {
 		return bi.normalizeModelName(req.Model)
 	}
 
-	// Fall back to flexible map-based extraction to handle non-standard formats
+	// Streaming path: works on both complete and truncated JSON (e.g. a 64 KB prefix of a
+	// multi-megabyte vision request). Scan only top-level tokens so we never descend into
+	// the large base64 image string embedded in the messages array.
+	if model := extractTopLevelModelField(body); model != "" {
+		return bi.normalizeModelName(model)
+	}
+
+	// Fall back to flexible map-based extraction to handle non-standard formats.
+	// This only succeeds for complete, valid JSON bodies.
 	var data map[string]interface{}
 	if err := json.Unmarshal(body, &data); err != nil {
 		return ""
@@ -138,6 +177,63 @@ func (bi *BodyInspector) extractModelName(body []byte) string {
 		if firstMsg, ok := messages[0].(map[string]interface{}); ok {
 			if model, ok := firstMsg["model"].(string); ok && model != "" {
 				return bi.normalizeModelName(model)
+			}
+		}
+	}
+
+	return ""
+}
+
+// extractTopLevelModelField scans a JSON byte slice (which may be truncated) with a
+// streaming decoder and returns the value of the first top-level "model" string key.
+// It never descends into nested objects or arrays, so it is safe to call on multi-megabyte
+// bodies as well as short prefix slices.
+func extractTopLevelModelField(body []byte) string {
+	dec := json.NewDecoder(bytes.NewReader(body))
+
+	// Consume the opening '{' of the top-level object.
+	tok, err := dec.Token()
+	if err != nil {
+		return ""
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return ""
+	}
+
+	depth := 1
+	for dec.More() {
+		// Read the key token.
+		keyTok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+
+		switch v := keyTok.(type) {
+		case json.Delim:
+			if v == '{' || v == '[' {
+				depth++
+			} else {
+				depth--
+			}
+			continue
+		case string:
+			if depth == 1 && strings.EqualFold(v, "model") {
+				// Read the value token.
+				valTok, err := dec.Token()
+				if err != nil {
+					return ""
+				}
+				if modelStr, ok := valTok.(string); ok && modelStr != "" {
+					return modelStr
+				}
+				// Value wasn't a string — keep scanning.
+				continue
+			}
+			// Skip the value for this key by decoding it into a discard target.
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				// Likely truncated JSON — stop scanning.
+				return ""
 			}
 		}
 	}

--- a/internal/adapter/inspector/body_inspector.go
+++ b/internal/adapter/inspector/body_inspector.go
@@ -114,11 +114,16 @@ func (bi *BodyInspector) Inspect(ctx context.Context, r *http.Request, profile *
 		return nil
 	}
 
+	// Copy the buffer bytes before the deferred Reset()/Put() invalidates the slice.
+	// buffer.Bytes() aliases the pool buffer's internal array; once Reset() runs the
+	// underlying array can be reused for another request, corrupting r.Body reads.
+	restored := append([]byte(nil), buffer.Bytes()...)
+
 	// Restore the body for downstream handlers by creating a new reader that combines
 	// what we've already read with any remaining unread content
 	origBody := r.Body
 	r.Body = readCloser{
-		Reader: io.MultiReader(bytes.NewReader(buffer.Bytes()), origBody),
+		Reader: io.MultiReader(bytes.NewReader(restored), origBody),
 		Closer: origBody,
 	}
 

--- a/internal/adapter/inspector/body_inspector_test.go
+++ b/internal/adapter/inspector/body_inspector_test.go
@@ -150,8 +150,10 @@ func TestBodyInspector_LargeBody(t *testing.T) {
 		t.Fatalf("Failed to create body inspector: %v", err)
 	}
 
-	// Create a large body that exceeds max size
-	largeBody := strings.Repeat("a", MaxBodySize+1000)
+	// Build a large JSON body that mimics a vision request: the model field is at the very
+	// start (well within modelScanSize), while the bulk of the body is a large base64 image.
+	imagePayload := strings.Repeat("A", MaxBodySize+1000)
+	largeBody := `{"model":"vision-model","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,` + imagePayload + `"}}]}]}`
 
 	req := &http.Request{
 		Body:          io.NopCloser(strings.NewReader(largeBody)),
@@ -162,10 +164,16 @@ func TestBodyInspector_LargeBody(t *testing.T) {
 
 	profile := domain.NewRequestProfile("/v1/chat/completions")
 
-	// Should skip inspection for large body
+	// Large body: model name must still be extracted from the prefix scan so routing works.
+	// Capability detection is intentionally skipped (no full parse) for large requests.
 	err = inspector.Inspect(ctx, req, profile)
 	assert.NoError(t, err)
-	assert.Empty(t, profile.ModelName)
+	assert.Equal(t, "vision-model", profile.ModelName, "model name must be extracted even from large vision requests")
+
+	// The full body must be restored intact for downstream proxy handlers.
+	restored, readErr := io.ReadAll(req.Body)
+	assert.NoError(t, readErr)
+	assert.Equal(t, largeBody, string(restored), "full body must be restored after prefix scan")
 }
 
 func TestBodyInspector_NoBody(t *testing.T) {

--- a/internal/adapter/inspector/body_inspector_test.go
+++ b/internal/adapter/inspector/body_inspector_test.go
@@ -176,6 +176,46 @@ func TestBodyInspector_LargeBody(t *testing.T) {
 	assert.Equal(t, largeBody, string(restored), "full body must be restored after prefix scan")
 }
 
+// TestBodyInspector_LargeBodyModelAfterMessages verifies that model extraction works
+// correctly when the "model" field appears after a large "messages" array (containing
+// base64 image payloads) in a request body exceeding MaxBodySize.
+// This is the field-order case that the fixed 64 KB prefix approach would silently miss.
+func TestBodyInspector_LargeBodyModelAfterMessages(t *testing.T) {
+	ctx := context.Background()
+	logCfg := &logger.Config{Level: "debug", PrettyLogs: false}
+	log, _, err := logger.New(logCfg)
+	require.NoError(t, err)
+	styledLog := &mockStyledLogger{underlying: log}
+	inspector, err := NewBodyInspector(styledLog)
+	require.NoError(t, err)
+
+	// Build a large JSON body where "messages" (with a base64 image payload) appears
+	// before "model". The model field is beyond the first 64 KB of the body, which
+	// would have caused extraction to fail with the old fixed-prefix approach.
+	imagePayload := strings.Repeat("B", MaxBodySize+1000)
+	largeBody := `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,` +
+		imagePayload + `"}}]}],"model":"vision-model-late"}`
+
+	req := &http.Request{
+		Body:          io.NopCloser(strings.NewReader(largeBody)),
+		Header:        make(http.Header),
+		ContentLength: int64(len(largeBody)),
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+
+	err = inspector.Inspect(ctx, req, profile)
+	assert.NoError(t, err)
+	assert.Equal(t, "vision-model-late", profile.ModelName,
+		"model name must be extracted even when 'model' field appears after large 'messages'")
+
+	// The full body must be restored intact for downstream proxy handlers.
+	restored, readErr := io.ReadAll(req.Body)
+	assert.NoError(t, readErr)
+	assert.Equal(t, largeBody, string(restored), "full body must be restored after incremental scan")
+}
+
 func TestBodyInspector_NoBody(t *testing.T) {
 	ctx := context.Background()
 	logCfg := &logger.Config{Level: "debug", PrettyLogs: false}

--- a/internal/adapter/inspector/body_inspector_test.go
+++ b/internal/adapter/inspector/body_inspector_test.go
@@ -169,6 +169,7 @@ func TestBodyInspector_LargeBody(t *testing.T) {
 	err = inspector.Inspect(ctx, req, profile)
 	assert.NoError(t, err)
 	assert.Equal(t, "vision-model", profile.ModelName, "model name must be extracted even from large vision requests")
+	assert.Nil(t, profile.ModelCapabilities, "capability detection must be skipped for large requests")
 
 	// The full body must be restored intact for downstream proxy handlers.
 	restored, readErr := io.ReadAll(req.Body)


### PR DESCRIPTION
Fixes #127

## Summary

- The body inspector silently skipped model name extraction for requests >1 MB, leaving `profile.ModelName` empty and causing the routing strategy to be bypassed entirely
- Vision/OCR requests with base64 image payloads (typically 1.5–3 MB) always hit this cap, resulting in non-deterministic misrouting to wrong backends
- Fix reads only the first 64 KB of large requests, restores the full body via `io.MultiReader`, and locates the top-level `model` key using a `json.Decoder` token scan — the same approach already used in the proxy rewrite layer
- Capability detection is intentionally skipped for large requests (unchanged behaviour); only routing correctness is addressed
- `TestBodyInspector_LargeBody` updated to assert model name is correctly extracted from a realistic large vision-request body and that the full body is restored intact for downstream handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Improved handling of very large request payloads: the inspector now scans an initial prefix to reliably detect top‑level model info (even when it appears later) and fully restores the original request body for downstream handlers; logging for large‑request model extraction is clearer.

* **Tests**
  - Added tests to verify model extraction from large/truncated payloads and confirm complete request‑body restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->