### PR TITLE
feat: docker release build locally without goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ config.yaml
 *.local.yml
 *.local.json
 *.log
+/test/reports/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ make build-local     # Build binary to ./build/ (fast, for testing)
 make run             # Run with version info
 make run-debug       # Run with debug logging
 make docker-build    # Build Docker image with goreleaser (requires goreleaser)
-make docker-build-local # Build Docker image locally (no goreleaser required)
-make docker-run      # Run Docker image with local config
+make docker-build-local # Build Docker image locally for amd64 (no goreleaser required)
+make docker-build-local-arm64 # Build Docker image locally for ARM64 (no goreleaser required)
+make docker-run      # Run Docker image with local config (amd64)
 make ci              # Run full CI pipeline locally
 make help            # Show all available targets
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ make build           # Build optimised binary with version info
 make build-local     # Build binary to ./build/ (fast, for testing)
 make run             # Run with version info
 make run-debug       # Run with debug logging
+make docker-build    # Build Docker image with goreleaser (requires goreleaser)
+make docker-build-local # Build Docker image locally (no goreleaser required)
+make docker-run      # Run Docker image with local config
 make ci              # Run full CI pipeline locally
 make help            # Show all available targets
 ```

--- a/docs/content/development/setup.md
+++ b/docs/content/development/setup.md
@@ -85,6 +85,14 @@ make dev
 | `make lint` | Run golangci-lint |
 | `make ready` | Run all checks (test-short, test-race, fmt, lint, align) |
 
+### Docker Commands
+
+| Command | Description |
+|---------|-------------|
+| `make docker-build-local` | Build Docker image locally (no goreleaser required) |
+| `make docker-build` | Build Docker image with goreleaser (requires goreleaser installed) |
+| `make docker-run` | Run Docker image with local config |
+
 ## Configuration
 
 ### Development Config
@@ -181,6 +189,39 @@ Run with hot reload:
 
 ```bash
 air
+```
+
+## Docker Development
+
+### Building Docker Images Locally
+
+You can build Docker images without requiring [goreleaser](https://goreleaser.com/):
+
+```bash
+# Quick local build (recommended for development)
+make docker-build-local
+
+# This produces: ghcr.io/thushan/olla:local
+```
+
+If you have goreleaser installed, use the full release build:
+
+```bash
+# Full goreleaser build with all platforms and tags
+make docker-build
+```
+
+### Running the Docker Image
+
+```bash
+# Run the locally built image
+docker run -p 40114:40114 \
+  -v "$(pwd)/config/config.local.yaml:/config/config.yaml:ro" \
+  -e OLLA_CONFIG_FILE=/config/config.yaml \
+  ghcr.io/thushan/olla:local
+
+# Or use the convenience make target
+make docker-run
 ```
 
 ## IDE Configuration

--- a/docs/content/development/setup.md
+++ b/docs/content/development/setup.md
@@ -89,9 +89,10 @@ make dev
 
 | Command | Description |
 |---------|-------------|
-| `make docker-build-local` | Build Docker image locally (no goreleaser required) |
+| `make docker-build-local` | Build Docker image locally for amd64 (no goreleaser required) |
+| `make docker-build-local-arm64` | Build Docker image locally for ARM64 (no goreleaser required) |
 | `make docker-build` | Build Docker image with goreleaser (requires goreleaser installed) |
-| `make docker-run` | Run Docker image with local config |
+| `make docker-run` | Run Docker image with local config (amd64) |
 
 ## Configuration
 
@@ -197,11 +198,25 @@ air
 
 You can build Docker images without requiring [goreleaser](https://goreleaser.com/):
 
-```bash
-# Quick local build (recommended for development)
-make docker-build-local
+#### AMD64 (Intel/most systems)
 
-# This produces: ghcr.io/thushan/olla:local
+```bash
+make docker-build-local
+# Produces: ghcr.io/thushan/olla:local-amd64
+```
+
+#### ARM64 (Apple Silicon, Raspberry Pi, ARM servers)
+
+```bash
+make docker-build-local-arm64
+# Produces: ghcr.io/thushan/olla:local-arm64
+```
+
+#### Custom architecture
+
+```bash
+make docker-build-local DOCKER_ARCH=arm64
+# Produces: ghcr.io/thushan/olla:local-arm64
 ```
 
 If you have goreleaser installed, use the full release build:
@@ -223,6 +238,10 @@ docker run -p 40114:40114 \
 # Or use the convenience make target
 make docker-run
 ```
+
+!!! warning "Docker Network Configuration"
+
+    When running Olla in Docker, ensure your config has `server.host: 0.0.0.0` (not `localhost`). Inside the container, `localhost` binds to the loopback interface and won't be accessible from the host machine, even with published ports (`-p 40114:40114`). Use `0.0.0.0` to listen on all interfaces.
 
 ## IDE Configuration
 

--- a/makefile
+++ b/makefile
@@ -205,21 +205,27 @@ build-snapshot:
 # Deprecated: use build-local or build-snapshot instead
 ready-local: build-snapshot
 
+DOCKER_ARCH ?= amd64
+
 # Build Docker image without goreleaser (for local development)
 docker-build-local:
-	@echo "Building Docker image locally (without goreleaser)..."
+	@echo "Building Docker image locally (without goreleaser) for $(DOCKER_ARCH)..."
 	@echo "Building olla binary to root..."
-	@go build $(LDFLAGS) -o olla .
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$(DOCKER_ARCH) go build $(LDFLAGS) -o olla .
 	@echo "Building Docker image..."
-	@docker build -t ghcr.io/thushan/olla:local .
+	@docker build -t ghcr.io/thushan/olla:local-$(DOCKER_ARCH) .
 	@echo "Cleaning up binary..."
 	@rm -f olla
-	@echo "Docker image built: ghcr.io/thushan/olla:local"
+	@echo "Docker image built: ghcr.io/thushan/olla:local-$(DOCKER_ARCH)"
 	@docker images --filter reference='*olla*local*'
+
+# Build Docker image for ARM64 (convenience target)
+docker-build-local-arm64:
+	@$(MAKE) docker-build-local DOCKER_ARCH=arm64
 
 # Build and test Docker image locally
 docker-build:
-	@if ! command -v goreleaser &> /dev/null; then \
+	@if ! command -v goreleaser > /dev/null 2>&1; then \
 		echo "❌ goreleaser not found. Use 'make docker-build-local' instead (no goreleaser required)"; \
 		exit 1; \
 	fi
@@ -228,14 +234,14 @@ docker-build:
 	@echo "Docker images:"
 	@docker images | grep olla | head -5
 
-# Run Docker image with local config
+# Run Docker image with local config (defaults to amd64)
 docker-run:
-	@echo "Running Docker image with local config..."
+	@echo "Running Docker image with local config (amd64)..."
 	@docker run --rm -it \
 		-p 40114:40114 \
 		-v "$(shell pwd)/config/config.local.yaml:/config/config.yaml:ro" \
 		-e OLLA_CONFIG_FILE=/config/config.yaml \
-		ghcr.io/thushan/olla:latest
+		ghcr.io/thushan/olla:local-amd64
 
 # Test full release locally (binaries + docker + archives)
 release-test:

--- a/makefile
+++ b/makefile
@@ -205,8 +205,24 @@ build-snapshot:
 # Deprecated: use build-local or build-snapshot instead
 ready-local: build-snapshot
 
+# Build Docker image without goreleaser (for local development)
+docker-build-local:
+	@echo "Building Docker image locally (without goreleaser)..."
+	@echo "Building olla binary to root..."
+	@go build $(LDFLAGS) -o olla .
+	@echo "Building Docker image..."
+	@docker build -t ghcr.io/thushan/olla:local .
+	@echo "Cleaning up binary..."
+	@rm -f olla
+	@echo "Docker image built: ghcr.io/thushan/olla:local"
+	@docker images --filter reference='*olla*local*'
+
 # Build and test Docker image locally
 docker-build:
+	@if ! command -v goreleaser &> /dev/null; then \
+		echo "❌ goreleaser not found. Use 'make docker-build-local' instead (no goreleaser required)"; \
+		exit 1; \
+	fi
 	@echo "Building Docker image locally..."
 	@goreleaser release --snapshot --clean --skip=publish,announce,sign,sbom
 	@echo "Docker images:"

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,12 @@ git clone https://github.com/thushan/olla.git && cd olla && make build-release
 ./bin/olla
 ```
 
+```bash
+# Build Docker image locally (no goreleaser required)
+git clone https://github.com/thushan/olla.git && cd olla && make docker-build-local
+docker run -p 40114:40114 ghcr.io/thushan/olla:local
+```
+
 ### Verification
 
 When you have everything running, you can check it's all working with:


### PR DESCRIPTION
lets you build docker image locally without goreleaser

Addresses #135 comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `docker-build-local` command to build Docker images locally without external dependencies.
  * Added `docker-run` command for easy container execution with pre-configured settings.

* **Documentation**
  * Updated setup guides with Docker development instructions and quick-start examples.
  * Added Docker commands reference to build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->