### PR TITLE
update host string parsing to fix ipv6 wildcards

### DIFF
--- a/internal/util/network.go
+++ b/internal/util/network.go
@@ -50,9 +50,11 @@ func NormaliseBaseURL(baseURL string) string {
 	return baseURL
 }
 
-// IsPortAvailable checks if a port is available by attempting to bind to it
+// IsPortAvailable checks if a port is available by attempting to bind to it.
+// Strips brackets from IPv6 addresses since net.JoinHostPort adds them.
 func IsPortAvailable(host string, port int) bool {
-	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	ipStr := strings.Trim(host, "[]")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", net.JoinHostPort(ipStr, strconv.Itoa(port)))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
for some networks, it is desirable to bind to ipv6 addresses instead of just ipv4 addresses - this PR introduces a change which allows ipv6 binds. 

this fix just trims the brackets from addresses, and allows JoinHostPort to add the brackets back in.


## ISSUE

currently, on main, this is the following behavior when binding to ipv6 wildcards:
```yaml
server:
  host: "[::]"
```

```log
2026-05-05 13:42:32 ERROR Failed to start service
                      ├ name: http
                      └ error: port 40114 is already in use on host [::]
```

the "port already in use" error, is a red herring - the failure comes from JoinHostPort checking "[::]". since JoinHostPort adds a set of brackets if there are colons in the address string, it actually tries to check "[[::]]", which fails because the address is malformed, and the red herring error is printed. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved port availability checking to correctly process IPv6 addresses when enclosed in brackets, ensuring proper listener creation and enhancing compatibility with standard IPv6 address formats. This fix resolves issues in network configurations and supports seamless IPv6 deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->