### PR TITLE
fix(openai-compat): surface availability state for OpenAI-compatible backends

### DIFF
--- a/internal/adapter/converter/unified_converter.go
+++ b/internal/adapter/converter/unified_converter.go
@@ -74,9 +74,15 @@ func (c *UnifiedConverter) ConvertToFormat(models []*domain.UnifiedModel, filter
 func (c *UnifiedConverter) convertModel(model *domain.UnifiedModel) UnifiedModelData {
 	availability := make([]EndpointStatus, 0, len(model.SourceEndpoints))
 	for _, ep := range model.SourceEndpoints {
+		// Use GetEffectiveState() rather than ep.State directly: the lifecycle
+		// unifier updates the typed ModelState field, while ep.State (the legacy
+		// string) is only set at discovery time and never transitions. Reading
+		// the effective state ensures health-driven transitions surface in the
+		// API response. GetEffectiveState() also normalises legacy string values
+		// ("loaded", "not-loaded", "available") to the typed enum.
 		availability = append(availability, EndpointStatus{
 			Endpoint: ep.EndpointName, // Use endpoint name instead of URL
-			State:    ep.State,
+			State:    string(ep.GetEffectiveState()),
 		})
 	}
 	// OLLA-85: [Unification] Models with different digests fail to unify correctly.

--- a/internal/adapter/registry/profile/parsers.go
+++ b/internal/adapter/registry/profile/parsers.go
@@ -225,6 +225,15 @@ func (p *openAIParser) Parse(data []byte) ([]*domain.ModelInfo, error) {
 			Name:     model.ID,
 			Type:     model.Object, // always "model" in openai responses
 			LastSeen: now,
+			// OpenAI-compatible /v1/models has no size or state fields. For these
+			// backends (vllm, llama.cpp, Infinity, etc.) the presence of a model
+			// in the discovery response IS the availability signal — these servers
+			// only list models that are loaded and ready to serve. Without a
+			// non-zero Size, MapModelState() falls through to "unknown" and the
+			// model never appears available in the unified /olla/models response.
+			// Set a sentinel size of 1 to signal "loaded / available, exact size
+			// not reported by this backend".
+			Size: 1,
 		}
 
 		// openai is stingy with metadata


### PR DESCRIPTION
## Summary

OpenAI-compatible backends (vLLM, llama.cpp, Infinity, sglang, lmdeploy, etc.) always show `state: "unknown"` in `/olla/models`, even when they are healthy, discovered, and actively serving traffic. This makes `/olla/models` unusable as a model-availability signal for clients that filter on `availability[].state == "available"`.

## Reproduction

1. Configure Olla with at least one OpenAI-compatible endpoint (e.g., a vLLM server at `http://host:8000`).
2. Wait for model discovery to complete (Olla logs confirm models discovered, requests route successfully).
3. `curl http://olla/olla/models`.
4. Observe `availability[].state: "unknown"` for every endpoint, indefinitely.

## Root cause

There are two cooperating bugs:

**Bug 1 — `openAIParser` never populates state-inferring fields.** The standard OpenAI `/v1/models` response contains only `id`, `object`, `created`, `owned_by` — no `size`, no `state`. `openAIParser.Parse` in `internal/adapter/registry/profile/parsers.go` therefore leaves `modelInfo.Size = 0` and never writes `metadata["state"]`. `ModelExtractor.MapModelState` (in `internal/adapter/unifier/model_builder.go`) checks `metadata["state"]`, then `metadata["loaded"]`, then `modelSize > 0`, and falls through to `return "unknown"`. For every OpenAI-compatible backend, the fall-through is the only branch ever taken.

**Bug 2 — converter reads stale string field, not effective state.** `UnifiedConverter.convertModel` in `internal/adapter/converter/unified_converter.go` reads `ep.State` directly. `SourceEndpoint` has two parallel state fields: `State` (legacy string set once at discovery) and `ModelState` (typed enum updated by the lifecycle unifier). The lifecycle unifier writes only to `ModelState`, so any health-driven transitions never surface in the API response. The domain already provides `SourceEndpoint.GetEffectiveState()` which consults both fields and normalises legacy strings — the converter just wasn't using it.

## Fix

Two small changes:

1. **`internal/adapter/registry/profile/parsers.go`** — In `openAIParser.Parse`, set `modelInfo.Size = 1` as a sentinel for any successfully-discovered model. For OpenAI-compatible backends, presence in the `/v1/models` response IS the availability signal — these servers only list models that are loaded and ready to serve. `MapModelState` then returns `"available"` via the existing `modelSize > 0` branch.

2. **`internal/adapter/converter/unified_converter.go`** — Replace `State: ep.State` with `State: string(ep.GetEffectiveState())` so the converter consults both the typed state machine and the legacy string field, with the existing fallback semantics defined in `SourceEndpoint.GetEffectiveState()`.

## Why these changes are safe

- The `Size` sentinel is only consumed by `MapModelState` (for the unknown/available branch) and by parameter-count estimation; neither makes behavioural assumptions about absolute byte values that a sentinel of `1` would violate.
- `GetEffectiveState()` already exists, is used in tests, and falls through to `ModelStateUnknown` when neither field has data — so the previous behaviour is preserved for genuinely unknown endpoints.
- No schema change, no migration, no config flag.

## Test plan

- [x] `go test ./...` — all packages pass (28 test packages, zero failures)
- [x] Built local Docker image, ran against production-like config with vLLM, llama-cpp, and Infinity endpoints — all three reported `state: "available"` after the patch (`state: "unknown"` before)
- [ ] Reviewer to confirm Ollama backends (which DO populate `size`/`state` natively) are unaffected — these flow through `ollamaParser`, not `openAIParser`, and the converter change reads `GetEffectiveState()` which preserves Ollama's `"loaded"`/`"not-loaded"` semantics via the existing switch in `SourceEndpoint.GetEffectiveState()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint availability state detection for more accurate status reporting across integrations.
  * Fixed model availability recognition for OpenAI-compatible backends during model discovery to prevent models being incorrectly marked as unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thushan/olla/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->