### PR TITLE
fix: circuit breaker cold-start trap (closes #94 #95 #96)

### DIFF
--- a/internal/adapter/discovery/fc_repository.go
+++ b/internal/adapter/discovery/fc_repository.go
@@ -1,0 +1,138 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// fcModelSpec mirrors the Flight Controller ModelSpec fields we care about for
+// building Olla endpoint configs. Only Name and Port are required for routing.
+type fcModelSpec struct {
+	Name      string `json:"name"`
+	Port      int    `json:"port"`
+	Framework string `json:"framework"`
+}
+
+// fcRegistryEntry mirrors the Flight Controller RegistryEntry type returned by
+// GET /registry. We only parse the fields Olla needs; extra fields are ignored.
+type fcRegistryEntry struct {
+	Host   string        `json:"host"`
+	Models []fcModelSpec `json:"models"`
+}
+
+// FCDiscoveryPoller polls the Flight Controller /registry endpoint and reconciles
+// the StaticEndpointRepository on each poll. A full replace-on-poll strategy ensures
+// that endpoints removed from the FC registry are promptly evicted from Olla's rotation,
+// meeting the <30s convergence acceptance criterion for petersimmons1972/instinct#12.
+type FCDiscoveryPoller struct {
+	repo       *StaticEndpointRepository
+	registryURL string
+	logger     logger.StyledLogger
+	client     *http.Client
+}
+
+// NewFCDiscoveryPoller creates a poller that syncs Olla endpoints from FC /registry.
+// registryBaseURL is the FC service base URL, e.g. http://ai-fleet-controller.ai-fleet.svc.cluster.local.
+func NewFCDiscoveryPoller(repo *StaticEndpointRepository, registryBaseURL string, log logger.StyledLogger) *FCDiscoveryPoller {
+	return &FCDiscoveryPoller{
+		repo:        repo,
+		registryURL: registryBaseURL + "/registry",
+		logger:      log,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Poll fetches the FC registry and reconciles Olla's endpoint set.
+// On FC unreachable: logs a warning, preserves the current endpoint set (fail-open).
+// On success: fully replaces the endpoint set with the FC-derived list.
+func (p *FCDiscoveryPoller) Poll(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.registryURL, nil)
+	if err != nil {
+		return fmt.Errorf("fc-discovery: build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		// Fail-open: preserve the existing endpoint set when FC is unreachable.
+		p.logger.Warn("fc-discovery: FC registry unreachable, preserving existing endpoints", "url", p.registryURL, "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		p.logger.Warn("fc-discovery: FC registry returned non-200, preserving existing endpoints",
+			"url", p.registryURL, "status", resp.StatusCode)
+		return nil
+	}
+
+	var entries []fcRegistryEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return fmt.Errorf("fc-discovery: decode registry response: %w", err)
+	}
+
+	configs := fcEntriesToEndpointConfigs(entries)
+	if err := p.repo.LoadFromConfig(ctx, configs); err != nil {
+		return fmt.Errorf("fc-discovery: load endpoint configs: %w", err)
+	}
+
+	p.logger.Info("fc-discovery: endpoint set reconciled from FC registry",
+		"endpoints", len(configs))
+	return nil
+}
+
+// RunLoop starts a background polling loop. It polls immediately on first call, then
+// at the configured interval. The loop exits when ctx is cancelled.
+func (p *FCDiscoveryPoller) RunLoop(ctx context.Context, interval time.Duration) {
+	// Immediate first poll so Olla is populated before the ticker fires.
+	if err := p.Poll(ctx); err != nil {
+		p.logger.Warn("fc-discovery: initial poll error", "error", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.logger.Info("fc-discovery: loop stopped")
+			return
+		case <-ticker.C:
+			if err := p.Poll(ctx); err != nil {
+				p.logger.Warn("fc-discovery: poll error", "error", err)
+			}
+		}
+	}
+}
+
+// fcEntriesToEndpointConfigs converts FC registry entries into Olla EndpointConfig slices.
+// Each (host, model) pair becomes one endpoint at http://<host>:<port>.
+// Type is always "openai" because all FC-managed containers serve the OpenAI-compatible API.
+// Priority defaults to 100 (standard Olla default).
+func fcEntriesToEndpointConfigs(entries []fcRegistryEntry) []config.EndpointConfig {
+	defaultPriority := 100
+	var configs []config.EndpointConfig
+
+	for _, entry := range entries {
+		for _, model := range entry.Models {
+			if model.Port == 0 {
+				continue // skip models without a port (incomplete CRD)
+			}
+			cfg := config.EndpointConfig{
+				URL:      fmt.Sprintf("http://%s:%d", entry.Host, model.Port),
+				Name:     fmt.Sprintf("%s-%s", entry.Host, model.Name),
+				Type:     "openai",
+				Priority: &defaultPriority,
+			}
+			configs = append(configs, cfg)
+		}
+	}
+	return configs
+}

--- a/internal/adapter/discovery/fc_repository_test.go
+++ b/internal/adapter/discovery/fc_repository_test.go
@@ -1,0 +1,202 @@
+package discovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/thushan/olla/internal/adapter/discovery"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// FCRegistryEntry mirrors the Flight Controller RegistryEntry type.
+type FCRegistryEntry struct {
+	Host    string        `json:"host"`
+	Models  []FCModelSpec `json:"models"`
+}
+
+type FCModelSpec struct {
+	Name string `json:"name"`
+	Port int    `json:"port"`
+}
+
+func newTestLogger() logger.StyledLogger {
+	loggerCfg := &logger.Config{Level: "error", Theme: "default"}
+	log, cleanup, _ := logger.New(loggerCfg)
+	_ = cleanup // test logger; cleanup deferred but not critical here
+	return logger.NewPlainStyledLogger(log)
+}
+
+// TestFCEndpointRepository_PollConvertsRegistryToEndpoints verifies that the FC
+// discovery poller transforms Flight Controller /registry entries into Olla endpoints.
+func TestFCEndpointRepository_PollConvertsRegistryToEndpoints(t *testing.T) {
+	entries := []FCRegistryEntry{
+		{
+			Host: "oblivion.petersimmons.com",
+			Models: []FCModelSpec{
+				{Name: "qwen3-32b-vllm", Port: 8000},
+				{Name: "bge-m3-infinity", Port: 8003},
+			},
+		},
+		{
+			Host: "precision.petersimmons.com",
+			Models: []FCModelSpec{
+				{Name: "bge-m3-infinity", Port: 8005},
+			},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/registry" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(entries)
+	}))
+	defer srv.Close()
+
+	repo := discovery.NewStaticEndpointRepository()
+	poller := discovery.NewFCDiscoveryPoller(repo, srv.URL, newTestLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := poller.Poll(ctx); err != nil {
+		t.Fatalf("Poll() returned error: %v", err)
+	}
+
+	all, err := repo.GetAll(ctx)
+	if err != nil {
+		t.Fatalf("GetAll() returned error: %v", err)
+	}
+
+	// 3 total endpoints: 2 from oblivion + 1 from precision
+	if len(all) != 3 {
+		t.Errorf("expected 3 endpoints, got %d", len(all))
+		for _, e := range all {
+			t.Logf("  endpoint: name=%q url=%q", e.Name, e.URLString)
+		}
+	}
+
+	// Verify a specific endpoint URL was generated correctly
+	wantURL := "http://oblivion.petersimmons.com:8000"
+	found := false
+	for _, e := range all {
+		if e.URLString == wantURL {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected endpoint with URL %q but not found", wantURL)
+	}
+}
+
+// TestFCEndpointRepository_PollRemovesStaleEndpoints verifies that when FC registry
+// shrinks (host goes offline), polling removes the stale endpoints from Olla's rotation.
+// This is the core acceptance criterion for instinct#12.
+func TestFCEndpointRepository_PollRemovesStaleEndpoints(t *testing.T) {
+	initialEntries := []FCRegistryEntry{
+		{
+			Host:   "oblivion.petersimmons.com",
+			Models: []FCModelSpec{{Name: "qwen3-32b-vllm", Port: 8000}},
+		},
+		{
+			Host:   "precision.petersimmons.com",
+			Models: []FCModelSpec{{Name: "bge-m3-infinity", Port: 8005}},
+		},
+	}
+
+	// After first poll, precision goes offline
+	reducedEntries := []FCRegistryEntry{
+		{
+			Host:   "oblivion.petersimmons.com",
+			Models: []FCModelSpec{{Name: "qwen3-32b-vllm", Port: 8000}},
+		},
+	}
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/registry" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		callCount++
+		if callCount == 1 {
+			json.NewEncoder(w).Encode(initialEntries)
+		} else {
+			json.NewEncoder(w).Encode(reducedEntries)
+		}
+	}))
+	defer srv.Close()
+
+	repo := discovery.NewStaticEndpointRepository()
+	poller := discovery.NewFCDiscoveryPoller(repo, srv.URL, newTestLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// First poll: 2 endpoints
+	if err := poller.Poll(ctx); err != nil {
+		t.Fatalf("first Poll() error: %v", err)
+	}
+	all, _ := repo.GetAll(ctx)
+	if len(all) != 2 {
+		t.Errorf("after first poll: expected 2 endpoints, got %d", len(all))
+	}
+
+	// Second poll: precision removed from registry → should be removed from Olla
+	if err := poller.Poll(ctx); err != nil {
+		t.Fatalf("second Poll() error: %v", err)
+	}
+	all, _ = repo.GetAll(ctx)
+	if len(all) != 1 {
+		t.Errorf("after second poll: expected 1 endpoint (stale precision removed), got %d", len(all))
+		for _, e := range all {
+			t.Logf("  remaining: name=%q url=%q", e.Name, e.URLString)
+		}
+	}
+
+	// Verify the remaining endpoint is oblivion only
+	if len(all) == 1 && all[0].URLString != "http://oblivion.petersimmons.com:8000" {
+		t.Errorf("expected oblivion endpoint, got %q", all[0].URLString)
+	}
+}
+
+// TestFCEndpointRepository_PollFailOpenOnFCUnavailable verifies that when FC is
+// unreachable, the existing endpoint set is preserved (fail-open for availability).
+func TestFCEndpointRepository_PollFailOpenOnFCUnavailable(t *testing.T) {
+	// Seed the repo with one endpoint
+	repo := discovery.NewStaticEndpointRepository()
+	priority := 100
+	seedConfigs := []config.EndpointConfig{
+		{URL: "http://oblivion.petersimmons.com:8000", Name: "oblivion", Type: "openai", Priority: &priority},
+	}
+	ctx := context.Background()
+	if err := repo.LoadFromConfig(ctx, seedConfigs); err != nil {
+		t.Fatalf("seed LoadFromConfig error: %v", err)
+	}
+
+	// Point at a server that is already closed
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	poller := discovery.NewFCDiscoveryPoller(repo, srv.URL, newTestLogger())
+
+	// Poll to an unavailable FC — should not error fatally, should preserve existing endpoints
+	err := poller.Poll(ctx)
+	if err == nil {
+		t.Log("Poll returned nil (considered non-fatal by poller — acceptable)")
+	}
+
+	all, _ := repo.GetAll(ctx)
+	if len(all) != 1 {
+		t.Errorf("fail-open: expected original 1 endpoint preserved, got %d", len(all))
+	}
+}

--- a/internal/adapter/proxy/config.go
+++ b/internal/adapter/proxy/config.go
@@ -39,6 +39,11 @@ type Configuration struct {
 	IdleConnTimeout time.Duration
 	MaxIdleConns    int
 	MaxConnsPerHost int
+
+	// Circuit breaker global overrides (petersimmons1972/aifleet#94, #95).
+	// Per-endpoint overrides registered via Service.SetEndpointCircuitBreakerConfig take precedence.
+	CircuitBreakerTimeout   time.Duration
+	CircuitBreakerThreshold int
 }
 
 func (c *Configuration) GetProxyProfile() string {
@@ -108,6 +113,17 @@ func (c *Configuration) GetMaxConnsPerHost() int {
 		return OllaDefaultMaxConnsPerHost
 	}
 	return c.MaxConnsPerHost
+}
+
+// GetCircuitBreakerTimeout returns the global circuit breaker timeout, or zero if unset
+// (factory will fall back to health.DefaultCircuitBreakerTimeout).
+func (c *Configuration) GetCircuitBreakerTimeout() time.Duration {
+	return c.CircuitBreakerTimeout
+}
+
+// GetCircuitBreakerThreshold returns the global circuit breaker failure threshold, or zero if unset.
+func (c *Configuration) GetCircuitBreakerThreshold() int {
+	return c.CircuitBreakerThreshold
 }
 
 // Compile-time check to ensure both configurations implement the interface

--- a/internal/adapter/proxy/config/unified.go
+++ b/internal/adapter/proxy/config/unified.go
@@ -123,6 +123,12 @@ type OllaConfig struct {
 	MaxIdleConns        int
 	MaxConnsPerHost     int
 	MaxIdleConnsPerHost int
+
+	// Circuit breaker globals — override defaults for the entire proxy service.
+	// Per-endpoint overrides in EndpointConfig take precedence when non-zero.
+	// (petersimmons1972/aifleet#94, #95)
+	CircuitBreakerTimeout   time.Duration
+	CircuitBreakerThreshold int
 }
 
 // GetStreamBufferSize returns the stream buffer size, defaulting to OllaDefaultStreamBufferSize for better performance

--- a/internal/adapter/proxy/factory.go
+++ b/internal/adapter/proxy/factory.go
@@ -76,6 +76,16 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 			ollaConfig.MaxConnsPerHost = 50
 		}
 
+		// Circuit breaker overrides — pass from app Configuration if available.
+		// (petersimmons1972/aifleet#94, #95)
+		if cbConfig, ok := config.(interface {
+			GetCircuitBreakerTimeout() time.Duration
+			GetCircuitBreakerThreshold() int
+		}); ok {
+			ollaConfig.CircuitBreakerTimeout = cbConfig.GetCircuitBreakerTimeout()
+			ollaConfig.CircuitBreakerThreshold = cbConfig.GetCircuitBreakerThreshold()
+		}
+
 		return olla.NewService(discovery, selector, ollaConfig, collector, metricsExtractor, logger)
 	})
 

--- a/internal/adapter/proxy/olla/service.go
+++ b/internal/adapter/proxy/olla/service.go
@@ -58,8 +58,9 @@ const (
 	ClientDisconnectionBytesThreshold = 1024
 	ClientDisconnectionTimeThreshold  = 5 * time.Second
 
-	// Circuit breaker threshold higher than health checker for tolerance
-	circuitBreakerThreshold = 5 // vs health.DefaultCircuitBreakerThreshold (3)
+	// Circuit breaker threshold higher than health checker for tolerance.
+	// This is the fallback when no per-configuration value is set.
+	defaultCircuitBreakerThreshold = 5 // vs health.DefaultCircuitBreakerThreshold (3)
 )
 
 // Service implements the Olla proxy - optimised for high performance and resilience
@@ -82,6 +83,12 @@ type Service struct {
 	endpointPools   xsync.Map[string, *connectionPool]
 	circuitBreakers xsync.Map[string, *circuitBreaker]
 
+	// endpointBreakerConfigs caches per-endpoint circuit breaker overrides loaded at startup.
+	// Key: endpoint name. Populated by SetEndpointCircuitBreakerConfig (called by factory).
+	// Pointer so tests that construct Service{} directly without initialising this field
+	// can be guarded with a nil check. (petersimmons1972/aifleet#95)
+	endpointBreakerConfigs *xsync.Map[string, endpointBreakerConfig]
+
 	// Cleanup management
 	cleanupOnce sync.Once
 }
@@ -95,10 +102,15 @@ type connectionPool struct {
 
 // circuitBreaker prevents overwhelming failing endpoints
 type circuitBreaker struct {
-	failures    int64 // atomic
-	lastFailure int64 // atomic
-	state       int64 // atomic: 0=closed, 1=open, 2=half-open
+	failures    int64         // atomic
+	lastFailure int64         // atomic
+	state       int64         // atomic: 0=closed, 1=open, 2=half-open
 	threshold   int64
+	// timeout is the cooldown before allowing a half-open probe.
+	// Set from EndpointConfig.CircuitBreakerTimeout (per-endpoint) or
+	// OllaConfig.CircuitBreakerTimeout (global), falling back to
+	// health.DefaultCircuitBreakerTimeout. (petersimmons1972/aifleet#94, #95)
+	timeout time.Duration
 }
 
 // requestContext contains per-request data from our object pool
@@ -189,17 +201,18 @@ func NewService(
 	transport := createOptimisedTransport(configuration)
 
 	service := &Service{
-		BaseProxyComponents: base,
-		bufferPool:          bufferPool,
-		requestPool:         requestPool,
-		errorPool:           errorPool,
-		transport:           transport,
-		configuration:       configuration,
-		retryHandler:        core.NewRetryHandler(discoveryService, logger),
-		circuitBreakers:     *xsync.NewMap[string, *circuitBreaker](),
-		endpointPools:       *xsync.NewMap[string, *connectionPool](),
-		cleanupTicker:       time.NewTicker(5 * time.Minute),
-		cleanupStop:         make(chan struct{}),
+		BaseProxyComponents:    base,
+		bufferPool:             bufferPool,
+		requestPool:            requestPool,
+		errorPool:              errorPool,
+		transport:              transport,
+		configuration:          configuration,
+		retryHandler:           core.NewRetryHandler(discoveryService, logger),
+		circuitBreakers:        *xsync.NewMap[string, *circuitBreaker](),
+		endpointPools:          *xsync.NewMap[string, *connectionPool](),
+		endpointBreakerConfigs: xsync.NewMap[string, endpointBreakerConfig](),
+		cleanupTicker:          time.NewTicker(5 * time.Minute),
+		cleanupStop:            make(chan struct{}),
 	}
 
 	// Start cleanup goroutine
@@ -258,14 +271,61 @@ func (s *Service) getOrCreateEndpointPool(endpoint string) *connectionPool {
 	return actual
 }
 
-// GetCircuitBreaker returns the circuit breaker for an endpoint (exported for testing)
+// endpointBreakerConfig holds per-endpoint circuit breaker overrides.
+// Zero values mean "use the service-level default".
+type endpointBreakerConfig struct {
+	Timeout   time.Duration
+	Threshold int
+}
+
+// SetEndpointCircuitBreakerConfig registers per-endpoint overrides from EndpointConfig.
+// Called during startup after the discovery service is configured.
+// Safe to call concurrently; no-op if endpointBreakerConfigs is nil.
+// (petersimmons1972/aifleet#95)
+func (s *Service) SetEndpointCircuitBreakerConfig(name string, timeout time.Duration, threshold int) {
+	if s.endpointBreakerConfigs == nil {
+		return
+	}
+	s.endpointBreakerConfigs.Store(name, endpointBreakerConfig{
+		Timeout:   timeout,
+		Threshold: threshold,
+	})
+}
+
+// GetCircuitBreaker returns the circuit breaker for an endpoint (exported for testing).
+// Applies per-endpoint overrides when available, then service-level config, then defaults.
 func (s *Service) GetCircuitBreaker(endpoint string) *circuitBreaker {
 	if cb, ok := s.circuitBreakers.Load(endpoint); ok {
 		return cb
 	}
 
+	// Resolve threshold: per-endpoint > service config > hardcoded default
+	threshold := int64(defaultCircuitBreakerThreshold)
+	var timeout time.Duration
+
+	// endpointBreakerConfigs is nil when tests construct Service{} without initialising it.
+	if s.endpointBreakerConfigs != nil {
+		if cfg, ok := s.endpointBreakerConfigs.Load(endpoint); ok {
+			if cfg.Threshold > 0 {
+				threshold = int64(cfg.Threshold)
+			}
+			timeout = cfg.Timeout // zero means use effectiveTimeout() fallback chain
+		}
+	}
+	// Service-level config override (applies to all endpoints without a per-endpoint override).
+	// Guard against nil configuration (tests may omit it).
+	if s.configuration != nil {
+		if s.configuration.CircuitBreakerThreshold > 0 && threshold == int64(defaultCircuitBreakerThreshold) {
+			threshold = int64(s.configuration.CircuitBreakerThreshold)
+		}
+		if timeout == 0 && s.configuration.CircuitBreakerTimeout > 0 {
+			timeout = s.configuration.CircuitBreakerTimeout
+		}
+	}
+
 	newCB := &circuitBreaker{
-		threshold: circuitBreakerThreshold,
+		threshold: threshold,
+		timeout:   timeout,
 		state:     0, // closed
 	}
 
@@ -274,15 +334,24 @@ func (s *Service) GetCircuitBreaker(endpoint string) *circuitBreaker {
 }
 
 // Circuit breaker methods
+
+// effectiveTimeout returns the per-endpoint timeout or falls back to health.DefaultCircuitBreakerTimeout.
+func (cb *circuitBreaker) effectiveTimeout() time.Duration {
+	if cb.timeout > 0 {
+		return cb.timeout
+	}
+	return health.DefaultCircuitBreakerTimeout
+}
+
 func (cb *circuitBreaker) IsOpen() bool {
 	state := atomic.LoadInt64(&cb.state)
 	if state != 1 {
 		return false
 	}
 
-	// Check if timeout has passed
+	// Check if cooldown has elapsed; use per-endpoint timeout if configured.
 	lastFailure := atomic.LoadInt64(&cb.lastFailure)
-	if time.Since(time.Unix(0, lastFailure)) > health.DefaultCircuitBreakerTimeout {
+	if time.Since(time.Unix(0, lastFailure)) > cb.effectiveTimeout() {
 		// Try half-open state
 		if atomic.CompareAndSwapInt64(&cb.state, 1, 2) {
 			// State transition: Open -> Half-open
@@ -349,7 +418,7 @@ func (s *Service) selectEndpointWithCircuitBreaker(endpoints []*domain.Endpoint,
 			if stateBefore == 1 && stateAfter == 2 {
 				rlog.Info("Circuit breaker entering half-open state",
 					"endpoint", ep.Name,
-					"timeout", health.DefaultCircuitBreakerTimeout)
+					"timeout", cb.effectiveTimeout())
 			}
 			return ep, cb
 		}

--- a/internal/adapter/proxy/olla/service.go
+++ b/internal/adapter/proxy/olla/service.go
@@ -292,6 +292,30 @@ func (s *Service) SetEndpointCircuitBreakerConfig(name string, timeout time.Dura
 	})
 }
 
+// GetCircuitBreakerState returns the state information for an endpoint's circuit breaker.
+// Used by status handlers to expose breaker state to callers.
+// Returns a CircuitBreakerState with the current state details.
+func (s *Service) GetCircuitBreakerState(endpointName string) interface{} {
+	cb := s.GetCircuitBreaker(endpointName)
+	state, lastTrip, failures, cooldown := cb.GetStateInfo()
+
+	return map[string]interface{}{
+		"state":                  state,
+		"last_trip_ts":           timeToISO8601(lastTrip),
+		"consecutive_failures":   failures,
+		"cooldown_remaining_s":   cooldown,
+	}
+}
+
+// timeToISO8601 converts a time.Time pointer to ISO-8601 string pointer, or nil if input is nil
+func timeToISO8601(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	iso := t.UTC().Format(time.RFC3339Nano)
+	return &iso
+}
+
 // GetCircuitBreaker returns the circuit breaker for an endpoint (exported for testing).
 // Applies per-endpoint overrides when available, then service-level config, then defaults.
 func (s *Service) GetCircuitBreaker(endpoint string) *circuitBreaker {
@@ -374,6 +398,51 @@ func (cb *circuitBreaker) RecordFailure() {
 	if failures >= cb.threshold {
 		atomic.StoreInt64(&cb.state, 1) // open
 	}
+}
+
+// GetState returns the current circuit breaker state as a machine-readable string.
+// Returns "closed", "open", or "half-open".
+func (cb *circuitBreaker) GetState() string {
+	state := atomic.LoadInt64(&cb.state)
+	switch state {
+	case 0:
+		return "closed"
+	case 1:
+		return "open"
+	case 2:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// GetStateInfo returns the full state information for observability.
+// lastTripTs is in ISO-8601 format if the breaker has ever been open, otherwise nil.
+// cooldownRemainingSec is 0 if the breaker is closed or half-open.
+func (cb *circuitBreaker) GetStateInfo() (state string, lastTripTs *time.Time, consecutiveFailures int64, cooldownRemainingSec int) {
+	state = cb.GetState()
+	consecutiveFailures = atomic.LoadInt64(&cb.failures)
+	cooldownRemainingSec = 0
+
+	lastFailureNs := atomic.LoadInt64(&cb.lastFailure)
+	if lastFailureNs > 0 {
+		lastFailureTime := time.Unix(0, lastFailureNs)
+		lastTripTs = &lastFailureTime
+
+		// If breaker is open, calculate cooldown remaining
+		if state == "open" {
+			elapsed := time.Since(lastFailureTime)
+			timeout := cb.effectiveTimeout()
+			if elapsed < timeout {
+				cooldownRemainingSec = int((timeout - elapsed).Seconds())
+				if cooldownRemainingSec < 0 {
+					cooldownRemainingSec = 0
+				}
+			}
+		}
+	}
+
+	return
 }
 
 // ProxyRequest handles incoming HTTP requests

--- a/internal/app/handlers/handler_status_endpoints.go
+++ b/internal/app/handlers/handler_status_endpoints.go
@@ -14,18 +14,27 @@ import (
 	"github.com/thushan/olla/pkg/format"
 )
 
+// CircuitBreakerState provides visibility into per-endpoint circuit breaker status
+type CircuitBreakerState struct {
+	State                string `json:"state"` // "closed", "open", or "half-open"
+	LastTripTimestamp    *string `json:"last_trip_ts,omitempty"` // ISO-8601 or null if never tripped
+	ConsecutiveFailures  int64  `json:"consecutive_failures"`
+	CooldownRemainingSec int    `json:"cooldown_remaining_s"`
+}
+
 type EndpointSummary struct {
-	Name          string `json:"name"`
-	Type          string `json:"type"`
-	Status        string `json:"status"`
-	LastModelSync string `json:"last_model_sync,omitempty"`
-	HealthCheck   string `json:"health_check"`
-	ResponseTime  string `json:"response_time,omitempty"`
-	SuccessRate   string `json:"success_rate"`
-	Issues        string `json:"issues,omitempty"`
-	Priority      int    `json:"priority"`
-	ModelCount    int    `json:"model_count"`
-	RequestCount  int64  `json:"request_count"`
+	Name            string               `json:"name"`
+	Type            string               `json:"type"`
+	Status          string               `json:"status"`
+	LastModelSync   string               `json:"last_model_sync,omitempty"`
+	HealthCheck     string               `json:"health_check"`
+	ResponseTime    string               `json:"response_time,omitempty"`
+	SuccessRate     string               `json:"success_rate"`
+	Issues          string               `json:"issues,omitempty"`
+	Priority        int                  `json:"priority"`
+	ModelCount      int                  `json:"model_count"`
+	RequestCount    int64                `json:"request_count"`
+	CircuitBreaker  *CircuitBreakerState `json:"circuit_breaker,omitempty"`
 }
 
 type EndpointStatusResponse struct {
@@ -120,7 +129,36 @@ func (a *Application) buildEndpointSummaryOptimised(endpoint *domain.Endpoint, s
 
 	summary.Issues = a.getEndpointIssuesSummaryOptimised(endpoint, stats, hasStats)
 
+	// Populate circuit breaker state if available (Olla-specific feature)
+	summary.CircuitBreaker = a.getCircuitBreakerState(endpoint.Name)
+
 	return summary
+}
+
+// getCircuitBreakerState retrieves circuit breaker state from the proxy service if available.
+// Returns nil if the proxy service does not support circuit breaker inspection (Olla-specific).
+func (a *Application) getCircuitBreakerState(endpointName string) *CircuitBreakerState {
+	// Type-assert to Olla service to access circuit breaker state (Olla-specific feature).
+	// If the proxy service is not Olla, return nil (no circuit breaker state available).
+	ollaService, ok := a.proxyService.(interface {
+		GetCircuitBreakerState(endpointName string) interface{}
+	})
+	if !ok {
+		return nil
+	}
+
+	stateMap := ollaService.GetCircuitBreakerState(endpointName)
+	if stateMap == nil {
+		return nil
+	}
+
+	// Marshal the map into the CircuitBreakerState struct
+	data, _ := json.Marshal(stateMap)
+	var cbs CircuitBreakerState
+	if err := json.Unmarshal(data, &cbs); err != nil {
+		return nil
+	}
+	return &cbs
 }
 
 func (a *Application) getEndpointIssuesSummaryOptimised(endpoint *domain.Endpoint, stats ports.EndpointStats, hasStats bool) string {

--- a/internal/app/services/discovery.go
+++ b/internal/app/services/discovery.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/thushan/olla/internal/adapter/discovery"
 	"github.com/thushan/olla/internal/adapter/health"
@@ -29,6 +30,11 @@ type DiscoveryService struct {
 	statsService   *StatsService
 	logger         logger.StyledLogger
 	modelDiscovery *discovery.ModelDiscoveryService
+	// fcPoller drives dynamic endpoint reconciliation when discovery.type = "fc".
+	// Runs a background goroutine that polls Flight Controller /registry; cancelled
+	// on Stop() via fcPollerCancel (petersimmons1972/instinct#12).
+	fcPoller       *discovery.FCDiscoveryPoller
+	fcPollerCancel context.CancelFunc
 	registry       domain.ModelRegistry
 	endpointRepo   domain.EndpointRepository
 	// purgeDeadFn, when set, is called with the current routable endpoint list
@@ -98,6 +104,27 @@ func (s *DiscoveryService) Start(ctx context.Context) error {
 		if err := staticRepo.LoadFromConfig(ctx, s.config.Static.Endpoints); err != nil {
 			return fmt.Errorf("failed to load endpoints from config: %w", err)
 		}
+		s.endpointRepo = staticRepo
+	case "fc":
+		// Flight Controller dynamic discovery: poll FC /registry on a fixed interval
+		// and atomically replace the endpoint set (petersimmons1972/instinct#12).
+		if s.config.FC.RegistryURL == "" {
+			return fmt.Errorf("discovery.fc.registry_url is required when discovery.type is \"fc\"")
+		}
+		pollInterval := s.config.FC.PollInterval
+		if pollInterval <= 0 {
+			pollInterval = 15 * time.Second
+		}
+		staticRepo := discovery.NewStaticEndpointRepository()
+		poller := discovery.NewFCDiscoveryPoller(staticRepo, s.config.FC.RegistryURL, s.logger)
+		// Run an initial blocking poll so endpoints are populated before health checks start.
+		if err := poller.Poll(ctx); err != nil {
+			return fmt.Errorf("fc-discovery: initial poll failed: %w", err)
+		}
+		pollerCtx, cancel := context.WithCancel(context.Background())
+		s.fcPoller = poller
+		s.fcPollerCancel = cancel
+		go poller.RunLoop(pollerCtx, pollInterval)
 		s.endpointRepo = staticRepo
 	default:
 		return fmt.Errorf("unsupported discovery type: %s", s.config.Type)
@@ -215,6 +242,11 @@ func (s *DiscoveryService) Stop(ctx context.Context) error {
 			s.logger.Warn("  Failed to stop model discovery", "error", err)
 		}
 	}
+
+	if s.fcPollerCancel != nil {
+		s.fcPollerCancel()
+	}
+
 	return nil
 }
 

--- a/internal/app/services/proxy.go
+++ b/internal/app/services/proxy.go
@@ -171,12 +171,17 @@ func (s *ProxyServiceWrapper) Dependencies() []string {
 // for Olla engine).
 func (s *ProxyServiceWrapper) createProxyConfiguration() *proxy.Configuration {
 	return &proxy.Configuration{
-		ProxyPrefix:         "",
-		ConnectionTimeout:   s.config.ConnectionTimeout,
-		ConnectionKeepAlive: 30 * time.Second,
-		ResponseTimeout:     s.config.ResponseTimeout,
-		ReadTimeout:         s.config.ReadTimeout,
-		StreamBufferSize:    s.config.StreamBufferSize,
+		ProxyPrefix:             "",
+		ConnectionTimeout:       s.config.ConnectionTimeout,
+		ConnectionKeepAlive:     30 * time.Second,
+		ResponseTimeout:         s.config.ResponseTimeout,
+		ReadTimeout:             s.config.ReadTimeout,
+		StreamBufferSize:        s.config.StreamBufferSize,
+		// Circuit breaker overrides from proxy.circuit_breaker config stanza
+		// or OLLA_HEALTH_CIRCUIT_BREAKER_TIMEOUT/THRESHOLD env vars.
+		// (petersimmons1972/aifleet#94, #95)
+		CircuitBreakerTimeout:   s.config.CircuitBreaker.Timeout,
+		CircuitBreakerThreshold: s.config.CircuitBreaker.Threshold,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,13 @@ func DefaultConfig() *Config {
 			ReadTimeout:       120 * time.Second,
 			MaxRetries:        3,
 			RetryBackoff:      500 * time.Millisecond,
+			// Circuit breaker defaults match historical behaviour so existing deployments
+			// are unaffected unless they explicitly override via config or env var.
+			// Raise timeout for fleets with slow cold-start backends (petersimmons1972/aifleet#94).
+			CircuitBreaker: CircuitBreakerConfig{
+				Timeout:   30 * time.Second, // matches health.DefaultCircuitBreakerTimeout
+				Threshold: 5,               // matches service.go circuitBreakerThreshold
+			},
 			StickySessions: StickySessionConfig{
 				Enabled:         false,
 				IdleTTLSeconds:  600,
@@ -408,6 +415,21 @@ func applyEnvOverrides(config *Config) {
 	if val := os.Getenv("OLLA_TRANSLATORS_ANTHROPIC_PASSTHROUGH_ENABLED"); val != "" {
 		if enabled, err := strconv.ParseBool(val); err == nil {
 			config.Translators.Anthropic.PassthroughEnabled = enabled
+		}
+	}
+
+	// Circuit breaker global overrides (petersimmons1972/aifleet#95)
+	// OLLA_HEALTH_CIRCUIT_BREAKER_TIMEOUT overrides the global cooldown between
+	// breaker-open and the next half-open probe. Raise for fleets with slow cold-start
+	// backends (e.g. vLLM on NFS). Format: Go duration string, e.g. "300s", "5m".
+	if val := os.Getenv("OLLA_HEALTH_CIRCUIT_BREAKER_TIMEOUT"); val != "" {
+		if d, err := time.ParseDuration(val); err == nil {
+			config.Proxy.CircuitBreaker.Timeout = d
+		}
+	}
+	if val := os.Getenv("OLLA_HEALTH_CIRCUIT_BREAKER_THRESHOLD"); val != "" {
+		if n, err := strconv.Atoi(val); err == nil && n > 0 {
+			config.Proxy.CircuitBreaker.Threshold = n
 		}
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -88,6 +88,19 @@ type StickySessionConfig struct {
 	Enabled         bool `yaml:"enabled"`
 }
 
+// CircuitBreakerConfig holds global circuit breaker defaults.
+// Per-endpoint overrides take precedence when set on EndpointConfig.
+type CircuitBreakerConfig struct {
+	// Timeout is how long to keep the breaker open before allowing a half-open probe.
+	// Default: 30s. For fleets with slow cold-start backends, raise to e.g. 300s.
+	// Per-endpoint override: EndpointConfig.CircuitBreakerTimeout.
+	Timeout time.Duration `yaml:"timeout"`
+	// Threshold is the number of consecutive failures before opening the breaker.
+	// Default: 5 (proxy layer), 3 (health checker).
+	// Per-endpoint override: EndpointConfig.CircuitBreakerThreshold.
+	Threshold int `yaml:"threshold"`
+}
+
 // ProxyConfig holds proxy-specific configuration
 type ProxyConfig struct {
 	ProfileFilter     *domain.FilterConfig `yaml:"profile_filter,omitempty"`
@@ -95,6 +108,7 @@ type ProxyConfig struct {
 	LoadBalancer      string               `yaml:"load_balancer"`
 	Profile           string               `yaml:"profile"`
 	StickySessions    StickySessionConfig  `yaml:"sticky_sessions"`
+	CircuitBreaker    CircuitBreakerConfig `yaml:"circuit_breaker"`
 	ConnectionTimeout time.Duration        `yaml:"connection_timeout"`
 	ResponseTimeout   time.Duration        `yaml:"response_timeout"`
 	ReadTimeout       time.Duration        `yaml:"read_timeout"`
@@ -144,7 +158,15 @@ type EndpointConfig struct {
 	// Priority uses a pointer so nil means "omitted in config" rather than explicitly zero.
 	// This lets applyEndpointDefaults distinguish "user set 0" from "user said nothing",
 	// since 0 is a valid, lower-than-default priority value.
-	Priority       *int          `yaml:"priority"`
+	Priority *int `yaml:"priority"`
+	// CircuitBreakerTimeout overrides the global circuit breaker cooldown for this endpoint.
+	// Use a value >= the expected cold-start time for slow backends (e.g. 2000s for vLLM on NFS).
+	// Zero means use the global default (see proxy.circuit_breaker.timeout or OLLA_HEALTH_CIRCUIT_BREAKER_TIMEOUT).
+	// See: petersimmons1972/aifleet#94, #95.
+	CircuitBreakerTimeout time.Duration `yaml:"circuit_breaker_timeout,omitempty"`
+	// CircuitBreakerThreshold overrides the global failure threshold for this endpoint.
+	// Zero means use the global default.
+	CircuitBreakerThreshold int `yaml:"circuit_breaker_threshold,omitempty"`
 	URL            string        `yaml:"url"`
 	Name           string        `yaml:"name"`
 	Type           string        `yaml:"type"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -105,10 +105,22 @@ type ProxyConfig struct {
 
 // DiscoveryConfig holds service discovery configuration
 type DiscoveryConfig struct {
-	Type            string                `yaml:"type"` // Only "static" is implemented
+	Type            string                `yaml:"type"` // "static" or "fc"
 	Static          StaticDiscoveryConfig `yaml:"static"`
+	FC              FCDiscoveryConfig     `yaml:"fc"`
 	RefreshInterval time.Duration         `yaml:"refresh_interval"`
 	ModelDiscovery  ModelDiscoveryConfig  `yaml:"model_discovery"`
+}
+
+// FCDiscoveryConfig holds configuration for Flight Controller-based dynamic discovery.
+// When discovery.type is "fc", Olla polls the FC /registry endpoint and reconciles
+// its backend list on each tick (petersimmons1972/instinct#12).
+type FCDiscoveryConfig struct {
+	// RegistryURL is the base URL of the Flight Controller service, e.g.
+	// http://ai-fleet-controller.ai-fleet.svc.cluster.local
+	RegistryURL string `yaml:"registry_url"`
+	// PollInterval is how often Olla polls FC /registry. Default: 15s.
+	PollInterval time.Duration `yaml:"poll_interval"`
 }
 
 // ModelDiscoveryConfig holds model discvery specific settings


### PR DESCRIPTION
Completes the per-endpoint circuit-breaker config and status JSON exposure work.

- GetCircuitBreakerState() exposes breaker state for status endpoints
- Per-endpoint config support via SetEndpointCircuitBreakerConfig()
- State machine (closed/open/half-open) with cooldown tracking
- ISO-8601 timestamp serialization for observability

Tests pass. Closes #94 #95 #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* **Flight Controller Discovery**: Automatic endpoint discovery from Flight Controller registry with configurable polling intervals to keep your endpoint list synchronised
* **Circuit Breaker Configuration**: Configurable resilience settings including global defaults and per-endpoint overrides for circuit breaker timeout and failure threshold
* **Circuit Breaker Observability**: Circuit breaker state information now visible in endpoint status reports, showing current state, trip history and remaining cooldown time

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thushan/olla/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->