### PR TITLE
fix: be lenient for anthropic parsing

### DIFF
--- a/docs/content/integrations/api-translation/anthropic.md
+++ b/docs/content/integrations/api-translation/anthropic.md
@@ -153,6 +153,8 @@ Olla supports two modes for handling Anthropic API requests, selected automatica
 - Tool definitions → OpenAI function definitions
 - Stop sequences → OpenAI stop parameter
 
+**Unknown and experimental fields**: Unrecognised Anthropic request fields (for example `context_management`, `output_config`, and future experimental beta fields) are tolerated and safely ignored during translation rather than rejected. In passthrough mode these fields are forwarded to the backend untouched, so backends with native Anthropic support receive them as-is.
+
 ### Response Translation (OpenAI → Anthropic)
 
 **OpenAI Response**:

--- a/internal/adapter/translator/anthropic/extended_features_test.go
+++ b/internal/adapter/translator/anthropic/extended_features_test.go
@@ -372,6 +372,38 @@ func TestCountSystemChars(t *testing.T) {
 	}
 }
 
+// TestTransformRequest_WithContextManagementField is a regression test for GitHub issue #154.
+// Claude Code v2.1.156+ sends context_management in requests; lenient parsing must not reject it.
+func TestTransformRequest_WithContextManagementField(t *testing.T) {
+	translator := NewTranslator(createTestLogger(), createTestConfig())
+
+	// Realistic context_management payload as sent by Claude Code.
+	rawJSON := `{
+		"model": "claude-3-5-sonnet-20241022",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": "Hello"}
+		],
+		"context_management": {
+			"edits": [
+				{"type": "clear_tool_uses_20250919"}
+			]
+		}
+	}`
+
+	req := &http.Request{
+		Body: io.NopCloser(bytes.NewReader([]byte(rawJSON))),
+	}
+
+	result, err := translator.TransformRequest(context.Background(), req)
+	require.NoError(t, err, "context_management field must be tolerated and not cause a parse error")
+	require.NotNil(t, result)
+
+	// context_management has no OpenAI equivalent and must not leak into the translated request.
+	_, present := result.OpenAIRequest["context_management"]
+	assert.False(t, present, "context_management must not appear in the translated OpenAI request")
+}
+
 // TestEstimateTokens_WithSystemArray tests token estimation with array system prompt
 func TestEstimateTokens_WithSystemArray(t *testing.T) {
 	req := &AnthropicRequest{

--- a/internal/adapter/translator/anthropic/request.go
+++ b/internal/adapter/translator/anthropic/request.go
@@ -17,10 +17,12 @@ func (t *Translator) TransformRequest(ctx context.Context, r *http.Request) (*tr
 	limitedBody := io.LimitReader(r.Body, t.maxMessageSize)
 	defer r.Body.Close()
 
-	// use decoder for memory efficiency and strict validation
+	// Parse leniently: as a proxy we must not be stricter than the upstream API we emulate.
+	// Unknown or newer Anthropic fields (e.g. context_management, experimental beta fields)
+	// are silently ignored rather than rejected. The streaming decoder is kept for memory
+	// efficiency on large requests.
 	var anthropicReq AnthropicRequest
 	decoder := json.NewDecoder(limitedBody)
-	decoder.DisallowUnknownFields()
 
 	if err := decoder.Decode(&anthropicReq); err != nil {
 		return nil, fmt.Errorf("failed to parse Anthropic request: %w", err)

--- a/internal/adapter/translator/anthropic/security_test.go
+++ b/internal/adapter/translator/anthropic/security_test.go
@@ -345,32 +345,33 @@ func TestRequestSizeLimit(t *testing.T) {
 	})
 }
 
-func TestUnknownFieldsRejection(t *testing.T) {
+func TestUnknownFieldsTolerated(t *testing.T) {
 	translator := NewTranslator(createTestLogger(), createTestConfig())
 	ctx := context.Background()
 
 	t.Run("request_with_unknown_field", func(t *testing.T) {
-		// Create raw JSON with an unknown field
+		// Unknown fields must be silently ignored, not rejected. A proxy must not be
+		// stricter than the upstream API it emulates.
 		rawJSON := `{
 			"model": "claude-sonnet-4-20250929",
 			"max_tokens": 1024,
 			"messages": [
 				{"role": "user", "content": "Hello"}
 			],
-			"unknown_field": "this should cause rejection"
+			"unknown_field": "should be tolerated and ignored"
 		}`
 
 		req := &http.Request{
 			Body: io.NopCloser(bytes.NewReader([]byte(rawJSON))),
 		}
 
-		_, err := translator.TransformRequest(ctx, req)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to parse Anthropic request")
+		result, err := translator.TransformRequest(ctx, req)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
 	})
 
 	t.Run("request_without_unknown_fields", func(t *testing.T) {
-		// Valid request should succeed
+		// Valid request should succeed as before.
 		rawJSON := `{
 			"model": "claude-sonnet-4-20250929",
 			"max_tokens": 1024,
@@ -393,7 +394,7 @@ func TestSecurityFeaturesCombined(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("invalid_params_with_unknown_fields", func(t *testing.T) {
-		// Request with both unknown field and invalid temperature
+		// Unknown field is tolerated; validation still rejects the out-of-range temperature.
 		rawJSON := `{
 			"model": "claude-sonnet-4-20250929",
 			"max_tokens": 1024,
@@ -410,7 +411,7 @@ func TestSecurityFeaturesCombined(t *testing.T) {
 
 		_, err := translator.TransformRequest(ctx, req)
 		require.Error(t, err)
-		// Should fail at JSON parsing stage due to unknown field
-		assert.Contains(t, err.Error(), "failed to parse Anthropic request")
+		// Unknown field is silently ignored; rejection comes from Validate() on temperature.
+		assert.Contains(t, err.Error(), "invalid request")
 	})
 }


### PR DESCRIPTION
Addresses #154 and how newer fields cause issues for the Anthropic transformer.

This PR makes it more lenient and accepting of unknown fields in the Anthropic Translator and proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Olla now tolerates unrecognised and experimental Anthropic request fields, ignoring them during translation and forwarding them unchanged in passthrough mode to backends with native Anthropic support.

* **Tests**
  * Added regression test coverage for unknown field handling and updated security tests to reflect the new lenient parsing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->