### PR TITLE
feat: CORS implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,7 @@ Always run `make ready` before committing changes.
 "github.com/puzpuzpuz/xsync/v4"  // Concurrent maps/counters
 "github.com/tidwall/gjson"       // Fast JSON parsing
 "github.com/jellydator/ttlcache" // Time-to-live cache
+"github.com/rs/cors"             // CORS middleware for browser clients
 "golang.org/x/sync"              // errgroup
 "golang.org/x/time"              // rate limiting
 ```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,30 @@ server:
   write_timeout: 0s # for LLMs streaming, leave this as 0s
   shutdown_timeout: 10s # Graceful shutdown timeout, increase this for heavy sites that have long-running requests or lots of endpoints (30s is a good)
   request_logging: true # logs Http Requests, may be useful for debugging, noise for other use cases
+
+  # CORS (Cross-Origin Resource Sharing) for browser-based clients (OpenWebUI, dashboards).
+  # Off by default. Non-browser clients (curl, SDKs, coding agents) ignore CORS entirely,
+  # so enabling this has no effect on them. When a request carries no Origin header it is
+  # passed through untouched.
+  #
+  # Caveat: allow_credentials: true is incompatible with allowed_origins: ["*"] (the CORS
+  # spec forbids it and browsers reject the response). List explicit origins when using
+  # credentials. exposed_headers left empty auto-exposes the full X-Olla-* response header
+  # set, so browser clients can read routing/model metadata.
+  cors:
+    enabled: false                   # opt-in: only enable when browser clients need access
+    allowed_origins:
+      - "*"
+    allowed_methods:
+      - "GET"
+      - "POST"
+      - "OPTIONS"
+    allowed_headers:
+      - "*"
+    exposed_headers: []              # empty: auto-exposes the X-Olla-* headers
+    allow_credentials: false         # set true only with explicit allowed_origins (not "*")
+    max_age: 300                     # preflight cache in seconds (5 minutes)
+
   request_limits:
     max_body_size: 52428800  # 50MB
     max_header_size: 524288  # 512KB

--- a/docs/content/api-reference/overview.md
+++ b/docs/content/api-reference/overview.md
@@ -210,8 +210,8 @@ For streaming endpoints (chat completions, text generation), responses use:
 
 ## CORS Support
 
-CORS headers are included for browser-based clients:
+CORS is **disabled by default**. Most clients (CLI tools, SDKs, coding agents, and server-side apps such as OpenWebUI's backend) send no `Origin` header, so CORS does not apply to them.
 
-- `Access-Control-Allow-Origin: *`
-- `Access-Control-Allow-Methods: GET, POST, OPTIONS`
-- `Access-Control-Allow-Headers: Content-Type, Authorization`
+Enable it only when a browser connects directly to Olla, for example a custom web dashboard or a UI configured for browser-direct connections. Once enabled, Olla answers preflight requests automatically and, by default, exposes the full `X-Olla-*` response header set so browser JavaScript can read routing and model metadata.
+
+The allowed origins, methods, headers, exposed headers, credentials, and preflight cache are all configurable. See [Security Best Practices - CORS](../configuration/practices/security.md#cors) and the [Configuration Reference](../configuration/reference.md#cors) for details.

--- a/docs/content/configuration/overview.md
+++ b/docs/content/configuration/overview.md
@@ -143,6 +143,22 @@ server:
 
 See [Rate Limiting Reference](reference.md#rate-limiting) for complete details.
 
+### CORS
+
+CORS is disabled by default. Enable it only when browser clients (such as OpenWebUI or a custom dashboard) connect directly to Olla. Non-browser clients are unaffected.
+
+```yaml
+server:
+  cors:
+    enabled: true
+    allowed_origins:
+      - "https://my-dashboard.example.com"
+    allow_credentials: true
+    max_age: 600
+```
+
+See [Security Best Practices](practices/security.md#cors) for the full configuration reference and credential/wildcard caveat.
+
 Endpoints also support per-endpoint outbound authentication (`auth:`) and custom headers (`headers:`). See [Endpoint Authentication](endpoint-auth.md) for configuration details.
 
 ## Proxy Configuration

--- a/docs/content/configuration/practices/security.md
+++ b/docs/content/configuration/practices/security.md
@@ -339,6 +339,89 @@ Any header named in an endpoint's `auth.header` field or in the `headers:` map i
 !!! note "Custom header names"
     If you configure a non-standard credential header (e.g. `auth.header: X-My-Token`), Olla strips `X-My-Token` from responses as well. No additional configuration is needed.
 
+## CORS {#cors}
+
+CORS is **disabled by default**. It is only relevant when a browser client (OpenWebUI, a custom dashboard, or a web app) connects directly to Olla. CLI tools, SDKs, and coding agents send no `Origin` header and pass through Olla completely untouched regardless of this setting.
+
+### When to enable
+
+Enable CORS when:
+
+- You are running a browser-based UI (e.g. OpenWebUI) that talks directly to Olla rather than through a reverse proxy that handles CORS itself.
+- You have a custom JavaScript dashboard consuming Olla's API.
+
+Do **not** enable CORS when all clients are server-side or CLI-based -- it adds no value and broadens the attack surface.
+
+### Permissive configuration (development)
+
+Suitable for local development where any origin should be allowed:
+
+```yaml
+server:
+  cors:
+    enabled: true
+    allowed_origins:
+      - "*"
+    allowed_methods:
+      - "GET"
+      - "POST"
+      - "OPTIONS"
+    allowed_headers:
+      - "*"
+    max_age: 300
+```
+
+### Locked-down configuration (production)
+
+Restrict to known origins and expose only the headers your UI needs to read:
+
+```yaml
+server:
+  cors:
+    enabled: true
+    allowed_origins:
+      - "https://my-dashboard.example.com"
+    allowed_methods:
+      - "GET"
+      - "POST"
+      - "OPTIONS"
+    allowed_headers:
+      - "Authorization"
+      - "Content-Type"
+    allow_credentials: true
+    max_age: 600
+```
+
+!!! warning "Credentials + wildcard origin"
+    Setting `allow_credentials: true` alongside `allowed_origins: ["*"]` is forbidden by the CORS specification. Olla rejects this combination at startup with a fatal error. Always list explicit origins when enabling credentials.
+
+### Exposed headers
+
+When `exposed_headers` is left empty (the default), Olla automatically exposes the full `X-Olla-*` response header set to browser clients:
+
+- `X-Olla-Endpoint`, `X-Olla-Model`, `X-Olla-Backend-Type`, `X-Olla-Request-ID`, `X-Olla-Response-Time`
+- Routing headers: `X-Olla-Routing-Strategy`, `X-Olla-Routing-Decision`, `X-Olla-Routing-Reason`
+- Sticky session headers: `X-Olla-Sticky-Session`, `X-Olla-Sticky-Key-Source`, `X-Olla-Session-ID`
+
+This means browser JavaScript can read routing and model metadata without any additional configuration. Override by listing specific headers in `exposed_headers` if you want to restrict what the browser can access.
+
+### Environment variable overrides
+
+| Variable | Type | Example |
+|----------|------|---------|
+| `OLLA_SERVER_CORS_ENABLED` | bool | `true` |
+| `OLLA_SERVER_CORS_ALLOWED_ORIGINS` | comma-separated | `https://app.example.com,https://admin.example.com` |
+| `OLLA_SERVER_CORS_ALLOWED_METHODS` | comma-separated | `GET,POST,OPTIONS` |
+| `OLLA_SERVER_CORS_ALLOWED_HEADERS` | comma-separated | `Authorization,Content-Type` |
+| `OLLA_SERVER_CORS_EXPOSED_HEADERS` | comma-separated | `X-Olla-Model,X-Olla-Endpoint` |
+| `OLLA_SERVER_CORS_ALLOW_CREDENTIALS` | bool | `true` |
+| `OLLA_SERVER_CORS_MAX_AGE` | int (seconds) | `600` |
+
+!!! note "No spaces in comma-separated values"
+    Env var lists use commas with no surrounding spaces: `https://a.com,https://b.com` not `https://a.com, https://b.com`.
+
+See [Configuration Reference](../reference.md#cors) for the full field reference.
+
 ## Secrets Resolution
 
 Credential values in `auth:` and `headers:` blocks support two forms:
@@ -454,6 +537,7 @@ Production deployment checklist:
 - [ ] Implement log rotation
 - [ ] Set up alerting
 - [ ] Document security procedures
+- [ ] Enable CORS only if browser clients connect directly; use explicit origins in production
 
 ## Incident Response
 

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -127,6 +127,35 @@ server:
       - "172.16.0.0/12"
 ```
 
+### CORS {#cors}
+
+Cross-Origin Resource Sharing settings. Only relevant when browser clients (OpenWebUI, custom dashboards) connect directly to Olla. Disabled by default; non-browser clients (curl, SDKs, coding agents) are unaffected regardless of this setting.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cors.enabled` | bool | `false` | Enable CORS middleware |
+| `cors.allowed_origins` | []string | `["*"]` | Permitted origins. Must be explicit URLs when `allow_credentials` is `true` |
+| `cors.allowed_methods` | []string | `["GET","POST","OPTIONS"]` | Permitted HTTP methods |
+| `cors.allowed_headers` | []string | `["*"]` | Permitted request headers |
+| `cors.exposed_headers` | []string | `[]` | Response headers exposed to browser JS. Empty = auto-expose full `X-Olla-*` set |
+| `cors.allow_credentials` | bool | `false` | Send `Access-Control-Allow-Credentials: true` |
+| `cors.max_age` | int | `300` | Preflight cache duration in seconds |
+
+!!! warning "Credentials + wildcard origin"
+    Setting `allow_credentials: true` with `allowed_origins: ["*"]` is forbidden by the CORS spec. Olla rejects this combination at startup with a fatal error. List explicit origins when credentials are required.
+
+Example:
+
+```yaml
+server:
+  cors:
+    enabled: true
+    allowed_origins:
+      - "http://localhost:3000"
+    allow_credentials: true
+    max_age: 600
+```
+
 ## Proxy Configuration
 
 Proxy engine and request handling settings.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -79,6 +79,14 @@ OLLA_LOG_LEVEL=debug
 
 However, some settings like `proxy.profile` must be set in the YAML configuration file.
 
+### Do I need to enable CORS?
+
+Only if a browser connects **directly** to Olla, such as a custom web dashboard or a UI configured for browser-direct connections. CORS is disabled by default.
+
+You do **not** need CORS for CLI tools, SDKs, coding agents, or server-side apps. This includes the standard OpenWebUI setup, where OpenWebUI's own backend calls Olla server-to-server (no browser `Origin` is involved). If Olla sits behind a reverse proxy (nginx, Traefik), handle CORS there instead.
+
+When you do enable it, list explicit origins rather than `*` if you also set `allow_credentials: true` (the combination is forbidden by the CORS spec and Olla rejects it at startup). See [CORS configuration](configuration/practices/security.md#cors).
+
 ## Troubleshooting
 
 ### Streaming responses arrive all at once
@@ -322,6 +330,8 @@ Olla adds several headers to responses:
 - `X-Olla-Response-Time`: Total processing time
 
 If missing, check you're using the `/olla/` prefix in your requests.
+
+If a **browser** client cannot read these headers (server-side clients are unaffected), the browser is hiding them, not Olla. Cross-origin JavaScript can only read response headers that are explicitly exposed. Enable CORS and leave `exposed_headers` empty to auto-expose the full `X-Olla-*` set. See [CORS configuration](configuration/practices/security.md#cors).
 
 ### Connection refused errors
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -39,7 +39,7 @@ Olla works alongside API gateways like [LiteLLM](https://github.com/BerriAI/lite
 - **Intelligent Load Balancing**: Priority-based, round-robin, and least-connections strategies
 - **Health Monitoring**: Circuit breakers and automatic failover
 - **High Performance**: Connection pooling, object pooling, and lock-free statistics
-- **Security**: Built-in rate limiting and request validation
+- **Security**: Built-in rate limiting, request validation, and optional CORS for browser clients
 - **Observability**: Comprehensive metrics and request tracing
 - **API Translation**: [Anthropic Messages API](concepts/api-translation.md) support for Claude-compatible clients
 

--- a/docs/content/integrations/frontend/openwebui.md
+++ b/docs/content/integrations/frontend/openwebui.md
@@ -16,6 +16,9 @@ export OLLAMA_BASE_URL="http://localhost:40114/olla/ollama"
 
 You can find an example integration of OpenWebUI with Olla and Ollama instances in <code>examples/ollama-openwebui</code> - see [latest in Github](https://github.com/thushan/olla/tree/main/examples/ollama-openwebui).
 
+!!! note "CORS is not required for this setup"
+    OpenWebUI's backend connects to Olla server-to-server (the `OLLAMA_BASE_URL` above is read by the OpenWebUI server, not the browser), so no browser `Origin` reaches Olla and CORS does not apply. You only need to enable [Olla's CORS support](../../configuration/practices/security.md#cors) if a browser connects **directly** to Olla, such as a UI configured for browser-direct connections.
+
 ## Overview
 
 <table>

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rs/cors v1.11.1 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22
 	github.com/pterm/pterm v0.12.83
 	github.com/puzpuzpuz/xsync/v4 v4.5.0
+	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.19.0
 	golang.org/x/sync v0.19.0
@@ -31,7 +32,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rs/cors v1.11.1 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/pterm/pterm v0.12.83/go.mod h1:xlgc6bFWyJIMtmLJvGim+L7jhSReilOlOnodeI
 github.com/puzpuzpuz/xsync/v4 v4.5.0 h1:vOSWu6b57/emh+L/Cw0BeQfvxa/cogFywXHeGUxQxAg=
 github.com/puzpuzpuz/xsync/v4 v4.5.0/go.mod h1:VJDmTCJMBt8igNxnkQd86r+8KUeN1quSfNKu5bLYFQo=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/app/middleware/cors.go
+++ b/internal/app/middleware/cors.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"github.com/rs/cors"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+)
+
+// DefaultCORSExposedHeaders is the set of X-Olla-* response headers exposed to
+// browser clients when the caller has not configured explicit ExposedHeaders.
+//
+// By default browsers block non-simple response headers from cross-origin reads.
+// Olla's routing, model, and sticky-session metadata all live in X-Olla-* headers,
+// so browser clients (OpenWebUI, custom dashboards) cannot inspect them without
+// this exposure list. We expose the full set rather than a subset to avoid
+// surprising omissions when new headers are added to the proxy output.
+var DefaultCORSExposedHeaders = []string{
+	constants.HeaderXOllaRequestID,
+	constants.HeaderXOllaEndpoint,
+	constants.HeaderXOllaBackendType,
+	constants.HeaderXOllaModel,
+	constants.HeaderXOllaResponseTime,
+	constants.HeaderXOllaRoutingStrategy,
+	constants.HeaderXOllaRoutingDecision,
+	constants.HeaderXOllaRoutingReason,
+	constants.HeaderXOllaMode,
+	constants.HeaderXOllaStickySession,
+	constants.HeaderXOllaStickyKeySource,
+	constants.HeaderXOllaSessionID,
+}
+
+// NewCORS builds an rs/cors handler from Olla's CORS config. It is only constructed
+// when CORS is enabled (the caller gates on cfg.Enabled). When ExposedHeaders is empty
+// we expose the full X-Olla-* response header set so browser clients can read Olla's
+// routing/model metadata, which they otherwise cannot access cross-origin.
+func NewCORS(cfg config.CorsConfig) *cors.Cors {
+	exposed := cfg.ExposedHeaders
+	if len(exposed) == 0 {
+		exposed = DefaultCORSExposedHeaders
+	}
+
+	return cors.New(cors.Options{
+		AllowedOrigins:   cfg.AllowedOrigins,
+		AllowedMethods:   cfg.AllowedMethods,
+		AllowedHeaders:   cfg.AllowedHeaders,
+		ExposedHeaders:   exposed,
+		AllowCredentials: cfg.AllowCredentials,
+		MaxAge:           cfg.MaxAge,
+	})
+}

--- a/internal/app/middleware/cors_test.go
+++ b/internal/app/middleware/cors_test.go
@@ -1,0 +1,228 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+)
+
+// nextCalled is a simple flag handler used across CORS tests to detect whether
+// the next handler in the chain was reached.
+func nextCalledHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func baseCORSConfig() config.CorsConfig {
+	return config.CorsConfig{
+		AllowedOrigins: []string{"https://example.com"},
+		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
+	}
+}
+
+// TestCORSPreflight verifies that a preflight OPTIONS request is answered by
+// rs/cors directly (204, CORS headers set) without reaching the next handler.
+func TestCORSPreflight(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	c := NewCORS(baseCORSConfig())
+	handler := c.Handler(nextCalledHandler(&called))
+
+	req := httptest.NewRequest(http.MethodOptions, "/olla/proxy/", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Error("next handler must not be called for preflight requests")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected 204 for preflight, got %d", rr.Code)
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") == "" {
+		t.Error("expected Access-Control-Allow-Origin to be set on preflight response")
+	}
+	if rr.Header().Get("Access-Control-Allow-Methods") == "" {
+		t.Error("expected Access-Control-Allow-Methods to be set on preflight response")
+	}
+}
+
+// TestCORSActualRequest verifies that a real GET from an allowed origin passes
+// through to the next handler and that the response carries both the origin and
+// the default exposed X-Olla-* headers.
+func TestCORSActualRequest(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	c := NewCORS(baseCORSConfig())
+	handler := c.Handler(nextCalledHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/olla/proxy/v1/models", nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("next handler must be called for actual (non-preflight) requests")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") == "" {
+		t.Error("expected Access-Control-Allow-Origin on actual request response")
+	}
+
+	exposed := rr.Header().Get("Access-Control-Expose-Headers")
+	for _, h := range []string{constants.HeaderXOllaModel, constants.HeaderXOllaEndpoint} {
+		if !strings.Contains(exposed, h) {
+			t.Errorf("expected Access-Control-Expose-Headers to contain %q, got %q", h, exposed)
+		}
+	}
+}
+
+// TestCORSNoOriginPassthrough verifies that requests without an Origin header
+// are passed through unchanged with no CORS headers added.
+func TestCORSNoOriginPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	c := NewCORS(baseCORSConfig())
+	handler := c.Handler(nextCalledHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/health", nil)
+	// Deliberately no Origin header — simulates curl, SDK, or server-to-server calls.
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("next handler must be called when no Origin header is present")
+	}
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no Access-Control-Allow-Origin for non-CORS request, got %q", v)
+	}
+	if v := rr.Header().Get("Access-Control-Expose-Headers"); v != "" {
+		t.Errorf("expected no Access-Control-Expose-Headers for non-CORS request, got %q", v)
+	}
+}
+
+// TestCORSExplicitExposedHeadersOverride confirms that setting ExposedHeaders in
+// the config replaces the default X-Olla-* set entirely — no merging happens.
+func TestCORSExplicitExposedHeadersOverride(t *testing.T) {
+	t.Parallel()
+
+	cfg := baseCORSConfig()
+	cfg.ExposedHeaders = []string{"X-Custom-Header"}
+
+	var called bool
+	c := NewCORS(cfg)
+	handler := c.Handler(nextCalledHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/olla/proxy/v1/models", nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	exposed := rr.Header().Get("Access-Control-Expose-Headers")
+	if !strings.Contains(exposed, "X-Custom-Header") {
+		t.Errorf("expected custom header in Expose-Headers, got %q", exposed)
+	}
+	if strings.Contains(exposed, constants.HeaderXOllaModel) {
+		t.Errorf("default %q must not appear when ExposedHeaders is explicitly set, got %q",
+			constants.HeaderXOllaModel, exposed)
+	}
+}
+
+// TestCORSAllowCredentials verifies that AllowCredentials=true propagates correctly
+// and that the reflected origin is returned (not a wildcard, which the CORS spec forbids).
+func TestCORSAllowCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := baseCORSConfig()
+	cfg.AllowCredentials = true
+
+	var called bool
+	c := NewCORS(cfg)
+	handler := c.Handler(nextCalledHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/olla/proxy/v1/models", nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if v := rr.Header().Get("Access-Control-Allow-Credentials"); v != "true" {
+		t.Errorf("expected Access-Control-Allow-Credentials: true, got %q", v)
+	}
+	// When credentials are in play the CORS spec forbids wildcard; the origin must be echoed.
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v != "https://example.com" {
+		t.Errorf("expected Allow-Origin to reflect request origin with credentials, got %q", v)
+	}
+}
+
+// TestCORSDisallowedOrigin verifies that a request from an unlisted origin does
+// not receive an Access-Control-Allow-Origin header.
+func TestCORSDisallowedOrigin(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	c := NewCORS(baseCORSConfig())
+	handler := c.Handler(nextCalledHandler(&called))
+
+	req := httptest.NewRequest(http.MethodGet, "/olla/proxy/v1/models", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v == "https://evil.example.com" {
+		t.Errorf("disallowed origin must not appear in Access-Control-Allow-Origin, got %q", v)
+	}
+}
+
+// TestDefaultCORSExposedHeaders is a regression guard that asserts every expected
+// X-Olla-* header constant is present in DefaultCORSExposedHeaders. Without this,
+// a new header added to content.go would silently go unexposed to browser clients.
+func TestDefaultCORSExposedHeaders(t *testing.T) {
+	t.Parallel()
+
+	expected := []string{
+		constants.HeaderXOllaRequestID,
+		constants.HeaderXOllaEndpoint,
+		constants.HeaderXOllaBackendType,
+		constants.HeaderXOllaModel,
+		constants.HeaderXOllaResponseTime,
+		constants.HeaderXOllaRoutingStrategy,
+		constants.HeaderXOllaRoutingDecision,
+		constants.HeaderXOllaRoutingReason,
+		constants.HeaderXOllaMode,
+		constants.HeaderXOllaStickySession,
+		constants.HeaderXOllaStickyKeySource,
+		constants.HeaderXOllaSessionID,
+	}
+
+	defaultSet := make(map[string]struct{}, len(DefaultCORSExposedHeaders))
+	for _, h := range DefaultCORSExposedHeaders {
+		defaultSet[h] = struct{}{}
+	}
+
+	for _, h := range expected {
+		if _, ok := defaultSet[h]; !ok {
+			t.Errorf("DefaultCORSExposedHeaders is missing %q", h)
+		}
+	}
+
+	if len(DefaultCORSExposedHeaders) != len(expected) {
+		t.Errorf("DefaultCORSExposedHeaders has %d entries, expected %d — update this test when adding new X-Olla-* headers",
+			len(DefaultCORSExposedHeaders), len(expected))
+	}
+}

--- a/internal/app/services/http.go
+++ b/internal/app/services/http.go
@@ -176,8 +176,15 @@ func (s *HTTPService) Start(ctx context.Context) error {
 	return nil
 }
 
-// applyCORS wraps the root handler with CORS when enabled. Kept as a seam so the
-// enable/disable wiring is testable without standing up the full HTTP server.
+// applyCORS wraps the root handler with CORS as the outermost layer so that
+// browser preflight (OPTIONS) requests are answered directly by rs/cors and
+// never reach the per-route security chain (rate-limiting, access logging).
+// This is correct CORS behaviour: preflights carry no credentials or body and
+// never reach a backend, so letting the security chain return 401/403/429 to
+// a preflight probe would break legitimate browser clients. Actual GET/POST
+// requests pass through rs/cors and then traverse the full security chain as
+// normal. Kept as a seam so the enable/disable wiring is testable without
+// standing up the full HTTP server.
 func applyCORS(handler http.Handler, cfg config.CorsConfig) http.Handler {
 	if !cfg.Enabled {
 		return handler

--- a/internal/app/services/http.go
+++ b/internal/app/services/http.go
@@ -10,6 +10,7 @@ import (
 	"github.com/thushan/olla/internal/util"
 
 	"github.com/thushan/olla/internal/app/handlers"
+	"github.com/thushan/olla/internal/app/middleware"
 	"github.com/thushan/olla/internal/config"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
@@ -138,9 +139,18 @@ func (s *HTTPService) Start(ctx context.Context) error {
 	securityAdapters := s.application.GetSecurityAdapters()
 	routeRegistry.WireUpWithSecurityChain(mux, securityAdapters)
 
+	var root http.Handler = mux
+	root = applyCORS(root, s.fullConfig.Server.Cors)
+
+	if s.fullConfig.Server.Cors.Enabled {
+		s.logger.Info("CORS enabled",
+			"allowed_origins", s.fullConfig.Server.Cors.AllowedOrigins,
+			"allow_credentials", s.fullConfig.Server.Cors.AllowCredentials)
+	}
+
 	s.server = &http.Server{
 		Addr:         s.config.GetAddress(),
-		Handler:      mux,
+		Handler:      root,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,
 		IdleTimeout:  idleTimeout,
@@ -164,6 +174,15 @@ func (s *HTTPService) Start(ctx context.Context) error {
 
 	s.printWarnings()
 	return nil
+}
+
+// applyCORS wraps the root handler with CORS when enabled. Kept as a seam so the
+// enable/disable wiring is testable without standing up the full HTTP server.
+func applyCORS(handler http.Handler, cfg config.CorsConfig) http.Handler {
+	if !cfg.Enabled {
+		return handler
+	}
+	return middleware.NewCORS(cfg).Handler(handler)
 }
 
 func (s *HTTPService) printWarnings() {

--- a/internal/app/services/http_cors_test.go
+++ b/internal/app/services/http_cors_test.go
@@ -1,0 +1,140 @@
+package services
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+)
+
+// stubHandler returns an HTTP handler that records whether it was invoked and
+// always responds 200 OK. Used across CORS wiring tests as the wrapped target.
+func stubHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*called = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func enabledCORSConfig() config.CorsConfig {
+	return config.CorsConfig{
+		Enabled:        true,
+		AllowedOrigins: []string{"https://example.com"},
+		AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
+	}
+}
+
+// TestApplyCORSPreflight verifies that an OPTIONS preflight from an allowed origin
+// is answered with CORS headers and does not reach the wrapped handler.
+func TestApplyCORSPreflight(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	handler := applyCORS(stubHandler(&called), enabledCORSConfig())
+
+	req := httptest.NewRequest(http.MethodOptions, "/olla/proxy/", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Error("wrapped handler must not be reached for preflight OPTIONS")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("expected 204 for preflight, got %d", rr.Code)
+	}
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v == "" {
+		t.Error("expected Access-Control-Allow-Origin on preflight response")
+	}
+	if v := rr.Header().Get("Access-Control-Allow-Methods"); v == "" {
+		t.Error("expected Access-Control-Allow-Methods on preflight response")
+	}
+}
+
+// TestApplyCORSActualRequest verifies that a real GET from an allowed origin
+// reaches the wrapped handler and carries origin + exposed X-Olla-* headers.
+func TestApplyCORSActualRequest(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	handler := applyCORS(stubHandler(&called), enabledCORSConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/olla/proxy/v1/models", nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("wrapped handler must be called for actual (non-preflight) requests")
+	}
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v == "" {
+		t.Error("expected Access-Control-Allow-Origin on actual request response")
+	}
+
+	// Default exposed headers must include X-Olla-* routing and model metadata so
+	// browser dashboards can read them cross-origin.
+	exposed := rr.Header().Get("Access-Control-Expose-Headers")
+	for _, h := range []string{constants.HeaderXOllaModel, constants.HeaderXOllaEndpoint} {
+		if !strings.Contains(exposed, h) {
+			t.Errorf("Access-Control-Expose-Headers must contain %q, got %q", h, exposed)
+		}
+	}
+}
+
+// TestApplyCORSDisabled verifies that when CORS is disabled applyCORS returns the
+// original handler identity — no CORS headers are added regardless of Origin.
+func TestApplyCORSDisabled(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	inner := stubHandler(&called)
+	cfg := config.CorsConfig{Enabled: false}
+
+	wrapped := applyCORS(inner, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/health", nil)
+	req.Header.Set("Origin", "https://example.com")
+
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("original handler must still serve requests when CORS is disabled")
+	}
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("no CORS headers expected when disabled, got Access-Control-Allow-Origin: %q", v)
+	}
+}
+
+// TestApplyCORSNoOriginPassthrough verifies that requests without an Origin header
+// (curl, server-to-server, coding agents) pass through cleanly with no CORS headers.
+// This is the critical non-regression case: CORS must be invisible to non-browser clients.
+func TestApplyCORSNoOriginPassthrough(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	handler := applyCORS(stubHandler(&called), enabledCORSConfig())
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/health", nil)
+	// No Origin header — simulates curl, SDK calls, or server-to-server traffic.
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("handler must be called for requests without an Origin header")
+	}
+	if v := rr.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("no CORS headers expected without Origin header, got %q", v)
+	}
+	if v := rr.Header().Get("Access-Control-Expose-Headers"); v != "" {
+		t.Errorf("no Expose-Headers expected without Origin header, got %q", v)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,17 @@ func DefaultConfig() *Config {
 				TrustedProxyCIDRs:       DefaultLocalNetworkTrustedCIDRs,
 				TrustedProxyCIDRsParsed: nil, // Will be parsed later
 			},
+			// CORS is off by default; operators opt-in when browser clients need access.
+			// ExposedHeaders is empty here — the middleware phase populates the X-Olla-* set.
+			Cors: CorsConfig{
+				Enabled:          false,
+				AllowedOrigins:   []string{"*"},
+				AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
+				AllowedHeaders:   []string{"*"},
+				ExposedHeaders:   nil,
+				AllowCredentials: false,
+				MaxAge:           300,
+			},
 		},
 		Proxy: ProxyConfig{
 			Engine:            DefaultProxyEngine,
@@ -193,6 +204,10 @@ func (c *Config) Validate() error {
 
 	if err := c.Translators.Validate(); err != nil {
 		return fmt.Errorf("translators config invalid: %w", err)
+	}
+
+	if err := c.Server.Cors.Validate(); err != nil {
+		return fmt.Errorf("server.cors config invalid: %w", err)
 	}
 
 	return nil
@@ -408,6 +423,35 @@ func applyEnvOverrides(config *Config) {
 	if val := os.Getenv("OLLA_TRANSLATORS_ANTHROPIC_PASSTHROUGH_ENABLED"); val != "" {
 		if enabled, err := strconv.ParseBool(val); err == nil {
 			config.Translators.Anthropic.PassthroughEnabled = enabled
+		}
+	}
+
+	// CORS overrides — only relevant for browser-based clients; no-op for everything else.
+	if val := os.Getenv("OLLA_SERVER_CORS_ENABLED"); val != "" {
+		if enabled, err := strconv.ParseBool(val); err == nil {
+			config.Server.Cors.Enabled = enabled
+		}
+	}
+	if val := os.Getenv("OLLA_SERVER_CORS_ALLOWED_ORIGINS"); val != "" {
+		config.Server.Cors.AllowedOrigins = strings.Split(val, ",")
+	}
+	if val := os.Getenv("OLLA_SERVER_CORS_ALLOWED_METHODS"); val != "" {
+		config.Server.Cors.AllowedMethods = strings.Split(val, ",")
+	}
+	if val := os.Getenv("OLLA_SERVER_CORS_ALLOWED_HEADERS"); val != "" {
+		config.Server.Cors.AllowedHeaders = strings.Split(val, ",")
+	}
+	if val := os.Getenv("OLLA_SERVER_CORS_EXPOSED_HEADERS"); val != "" {
+		config.Server.Cors.ExposedHeaders = strings.Split(val, ",")
+	}
+	if val := os.Getenv("OLLA_SERVER_CORS_ALLOW_CREDENTIALS"); val != "" {
+		if allow, err := strconv.ParseBool(val); err == nil {
+			config.Server.Cors.AllowCredentials = allow
+		}
+	}
+	if val := os.Getenv("OLLA_SERVER_CORS_MAX_AGE"); val != "" {
+		if age, err := strconv.Atoi(val); err == nil {
+			config.Server.Cors.MaxAge = age
 		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1500,6 +1500,34 @@ func TestCorsConfig_Validate(t *testing.T) {
 			},
 			errContains: "allow_credentials",
 		},
+		{
+			// rs/cors treats a nil slice as allow-all; reject it so the operator
+			// must be explicit rather than accidentally opening up all origins.
+			name: "nil allowed_origins when enabled is rejected",
+			cors: CorsConfig{
+				Enabled:        true,
+				AllowedOrigins: nil,
+			},
+			errContains: "allowed_origins",
+		},
+		{
+			// Same as nil — an empty slice is indistinguishable to rs/cors and
+			// equally surprising to an operator who left the key blank.
+			name: "empty allowed_origins slice when enabled is rejected",
+			cors: CorsConfig{
+				Enabled:        true,
+				AllowedOrigins: []string{},
+			},
+			errContains: "allowed_origins",
+		},
+		{
+			// Disabled CORS skips validation, so a nil origins list is fine.
+			name: "nil allowed_origins when disabled is accepted",
+			cors: CorsConfig{
+				Enabled:        false,
+				AllowedOrigins: nil,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1230,3 +1230,315 @@ func TestConfigValidate_WriteTimeoutZeroAllowed(t *testing.T) {
 		t.Errorf("Expected no error for WriteTimeout == 0 (valid streaming config), got: %v", err)
 	}
 }
+
+// TestDefaultConfig_CorsDefaults verifies the out-of-the-box CORS config:
+// disabled, wildcard origins, safe methods, no credentials, 5-min preflight cache.
+func TestDefaultConfig_CorsDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cors := cfg.Server.Cors
+
+	if cors.Enabled {
+		t.Error("expected CORS disabled by default")
+	}
+	if cors.AllowCredentials {
+		t.Error("expected AllowCredentials false by default")
+	}
+	if cors.MaxAge != 300 {
+		t.Errorf("expected MaxAge 300, got %d", cors.MaxAge)
+	}
+	if len(cors.AllowedOrigins) != 1 || cors.AllowedOrigins[0] != "*" {
+		t.Errorf("expected AllowedOrigins=[\"*\"], got %v", cors.AllowedOrigins)
+	}
+	wantMethods := []string{"GET", "POST", "OPTIONS"}
+	if len(cors.AllowedMethods) != len(wantMethods) {
+		t.Errorf("expected %d AllowedMethods, got %d", len(wantMethods), len(cors.AllowedMethods))
+	}
+	for i, m := range wantMethods {
+		if i < len(cors.AllowedMethods) && cors.AllowedMethods[i] != m {
+			t.Errorf("AllowedMethods[%d]: expected %s, got %s", i, m, cors.AllowedMethods[i])
+		}
+	}
+	if len(cors.AllowedHeaders) != 1 || cors.AllowedHeaders[0] != "*" {
+		t.Errorf("expected AllowedHeaders=[\"*\"], got %v", cors.AllowedHeaders)
+	}
+	if len(cors.ExposedHeaders) != 0 {
+		t.Errorf("expected ExposedHeaders empty by default, got %v", cors.ExposedHeaders)
+	}
+}
+
+// TestCorsConfig_YAMLParsing confirms a full cors block round-trips correctly through YAML.
+func TestCorsConfig_YAMLParsing(t *testing.T) {
+	configYAML := `
+server:
+  host: localhost
+  port: 40114
+  cors:
+    enabled: true
+    allowed_origins:
+      - "http://localhost:3000"
+      - "http://localhost:8080"
+    allowed_methods:
+      - "GET"
+      - "POST"
+      - "PUT"
+      - "OPTIONS"
+    allowed_headers:
+      - "Content-Type"
+      - "Authorization"
+    exposed_headers:
+      - "X-Olla-Request-ID"
+    allow_credentials: true
+    max_age: 600
+`
+	import_tmp, err := os.CreateTemp(t.TempDir(), "olla-cors-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(import_tmp.Name())
+	if _, err := import_tmp.WriteString(configYAML); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	import_tmp.Close()
+
+	cfg, err := Load(import_tmp.Name())
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	cors := cfg.Server.Cors
+	if !cors.Enabled {
+		t.Error("expected CORS enabled")
+	}
+	if !cors.AllowCredentials {
+		t.Error("expected AllowCredentials true")
+	}
+	if cors.MaxAge != 600 {
+		t.Errorf("expected MaxAge 600, got %d", cors.MaxAge)
+	}
+	if len(cors.AllowedOrigins) != 2 {
+		t.Errorf("expected 2 allowed origins, got %d", len(cors.AllowedOrigins))
+	}
+	if cors.AllowedOrigins[0] != "http://localhost:3000" {
+		t.Errorf("expected first origin http://localhost:3000, got %s", cors.AllowedOrigins[0])
+	}
+	if len(cors.AllowedMethods) != 4 {
+		t.Errorf("expected 4 allowed methods, got %d", len(cors.AllowedMethods))
+	}
+	if len(cors.AllowedHeaders) != 2 {
+		t.Errorf("expected 2 allowed headers, got %d", len(cors.AllowedHeaders))
+	}
+	if len(cors.ExposedHeaders) != 1 || cors.ExposedHeaders[0] != "X-Olla-Request-ID" {
+		t.Errorf("expected ExposedHeaders=[\"X-Olla-Request-ID\"], got %v", cors.ExposedHeaders)
+	}
+}
+
+// TestCorsConfig_EnvOverrides checks that each OLLA_SERVER_CORS_* variable is parsed and applied.
+// Not parallel: env vars are process-global; parallel subtests would bleed into each other.
+func TestCorsConfig_EnvOverrides(t *testing.T) {
+	testCases := []struct {
+		name    string
+		envVars map[string]string
+		checkFn func(*Config) bool
+		desc    string
+	}{
+		{
+			name:    "CORS enabled",
+			envVars: map[string]string{"OLLA_SERVER_CORS_ENABLED": "true"},
+			checkFn: func(c *Config) bool { return c.Server.Cors.Enabled },
+			desc:    "Cors.Enabled should be true",
+		},
+		{
+			name:    "CORS disabled via 0",
+			envVars: map[string]string{"OLLA_SERVER_CORS_ENABLED": "0"},
+			checkFn: func(c *Config) bool { return !c.Server.Cors.Enabled },
+			desc:    "Cors.Enabled should be false",
+		},
+		{
+			name:    "allowed origins comma-separated",
+			envVars: map[string]string{"OLLA_SERVER_CORS_ALLOWED_ORIGINS": "http://a.com,http://b.com"},
+			checkFn: func(c *Config) bool {
+				return len(c.Server.Cors.AllowedOrigins) == 2 &&
+					c.Server.Cors.AllowedOrigins[0] == "http://a.com" &&
+					c.Server.Cors.AllowedOrigins[1] == "http://b.com"
+			},
+			desc: "AllowedOrigins should have 2 entries",
+		},
+		{
+			name:    "allowed methods comma-separated",
+			envVars: map[string]string{"OLLA_SERVER_CORS_ALLOWED_METHODS": "GET,POST,DELETE"},
+			checkFn: func(c *Config) bool { return len(c.Server.Cors.AllowedMethods) == 3 },
+			desc:    "AllowedMethods should have 3 entries",
+		},
+		{
+			name:    "allowed headers comma-separated",
+			envVars: map[string]string{"OLLA_SERVER_CORS_ALLOWED_HEADERS": "Content-Type,Authorization"},
+			checkFn: func(c *Config) bool { return len(c.Server.Cors.AllowedHeaders) == 2 },
+			desc:    "AllowedHeaders should have 2 entries",
+		},
+		{
+			name:    "exposed headers comma-separated",
+			envVars: map[string]string{"OLLA_SERVER_CORS_EXPOSED_HEADERS": "X-Olla-Request-ID,X-Olla-Model"},
+			checkFn: func(c *Config) bool { return len(c.Server.Cors.ExposedHeaders) == 2 },
+			desc:    "ExposedHeaders should have 2 entries",
+		},
+		{
+			name: "allow credentials true",
+			envVars: map[string]string{
+				"OLLA_SERVER_CORS_ALLOW_CREDENTIALS": "true",
+				"OLLA_SERVER_CORS_ENABLED":           "true",
+				"OLLA_SERVER_CORS_ALLOWED_ORIGINS":   "http://trusted.example.com",
+			},
+			checkFn: func(c *Config) bool { return c.Server.Cors.AllowCredentials },
+			desc:    "AllowCredentials should be true",
+		},
+		{
+			name:    "max age int",
+			envVars: map[string]string{"OLLA_SERVER_CORS_MAX_AGE": "3600"},
+			checkFn: func(c *Config) bool { return c.Server.Cors.MaxAge == 3600 },
+			desc:    "MaxAge should be 3600",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range tc.envVars {
+					os.Unsetenv(k)
+				}
+			}()
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load failed: %v", err)
+			}
+
+			if !tc.checkFn(cfg) {
+				t.Errorf("%s: check failed for env %v", tc.desc, tc.envVars)
+			}
+		})
+	}
+}
+
+// TestCorsConfig_Validate covers the two error paths and the happy path.
+func TestCorsConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		cors        CorsConfig
+		errContains string
+	}{
+		{
+			name: "disabled config skips validation entirely",
+			cors: CorsConfig{
+				Enabled:          false,
+				AllowedOrigins:   []string{"*"},
+				AllowCredentials: true, // would be invalid if enabled
+				MaxAge:           -1,   // would be invalid if enabled
+			},
+		},
+		{
+			name: "valid enabled config with explicit origins and credentials",
+			cors: CorsConfig{
+				Enabled:          true,
+				AllowedOrigins:   []string{"http://localhost:3000"},
+				AllowedMethods:   []string{"GET", "POST"},
+				AllowCredentials: true,
+				MaxAge:           300,
+			},
+		},
+		{
+			name: "valid enabled config with wildcard and no credentials",
+			cors: CorsConfig{
+				Enabled:          true,
+				AllowedOrigins:   []string{"*"},
+				AllowCredentials: false,
+				MaxAge:           600,
+			},
+		},
+		{
+			name: "credentials with wildcard origin is rejected",
+			cors: CorsConfig{
+				Enabled:          true,
+				AllowedOrigins:   []string{"*"},
+				AllowCredentials: true,
+				MaxAge:           300,
+			},
+			errContains: "allow_credentials",
+		},
+		{
+			name: "negative max_age is rejected",
+			cors: CorsConfig{
+				Enabled:          true,
+				AllowedOrigins:   []string{"http://example.com"},
+				AllowCredentials: false,
+				MaxAge:           -1,
+			},
+			errContains: "max_age",
+		},
+		{
+			name: "zero max_age is accepted",
+			cors: CorsConfig{
+				Enabled:          true,
+				AllowedOrigins:   []string{"http://example.com"},
+				AllowCredentials: false,
+				MaxAge:           0,
+			},
+		},
+		{
+			name: "credentials with mixed origins containing wildcard is rejected",
+			cors: CorsConfig{
+				Enabled:          true,
+				AllowedOrigins:   []string{"http://safe.example.com", "*"},
+				AllowCredentials: true,
+				MaxAge:           300,
+			},
+			errContains: "allow_credentials",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cors.Validate()
+
+			if tc.errContains == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errContains)
+				}
+				if !contains(err.Error(), tc.errContains) {
+					t.Errorf("expected error containing %q, got: %v", tc.errContains, err)
+				}
+			}
+		})
+	}
+}
+
+// TestConfigValidate_CorsInvalidPropagates confirms that a bad CORS config causes
+// Config.Validate() to return an error (i.e. it's wired into the startup gate).
+func TestConfigValidate_CorsInvalidPropagates(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Server.Cors.Enabled = true
+	cfg.Server.Cors.AllowedOrigins = []string{"*"}
+	cfg.Server.Cors.AllowCredentials = true
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for credentials+wildcard, got nil")
+	}
+	if !contains(err.Error(), "allow_credentials") {
+		t.Errorf("expected error to mention allow_credentials, got: %v", err)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -31,15 +31,37 @@ type Config struct {
 	Filename      string              `yaml:"-"`
 	Translators   TranslatorsConfig   `yaml:"translators"`
 	ModelRegistry ModelRegistryConfig `yaml:"model_registry"`
-	Proxy         ProxyConfig         `yaml:"proxy"`
 	Discovery     DiscoveryConfig     `yaml:"discovery"`
+	Proxy         ProxyConfig         `yaml:"proxy"`
 	Server        ServerConfig        `yaml:"server"`
 	Engineering   EngineeringConfig   `yaml:"engineering"`
+}
+
+// CorsConfig controls browser cross-origin access to the Olla API.
+// This matters when a browser-based client (OpenWebUI, a custom dashboard, etc.)
+// calls Olla from a different origin. Non-browser clients (curl, SDKs, other
+// services) ignore CORS headers entirely, so enabling this has no effect on them.
+//
+// Security note: combining AllowCredentials=true with AllowedOrigins=["*"] is
+// forbidden by the CORS spec — the browser will reject the response. Validate()
+// enforces this at startup rather than letting it silently break at runtime.
+//
+// ExposedHeaders is intentionally left empty here; the middleware phase will
+// automatically expose the full X-Olla-* response header set.
+type CorsConfig struct {
+	AllowedOrigins   []string `yaml:"allowed_origins"`
+	AllowedMethods   []string `yaml:"allowed_methods"`
+	AllowedHeaders   []string `yaml:"allowed_headers"`
+	ExposedHeaders   []string `yaml:"exposed_headers"`
+	MaxAge           int      `yaml:"max_age"`
+	Enabled          bool     `yaml:"enabled"`
+	AllowCredentials bool     `yaml:"allow_credentials"`
 }
 
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
 	Host            string              `yaml:"host"`
+	Cors            CorsConfig          `yaml:"cors"`
 	RateLimits      ServerRateLimits    `yaml:"rate_limits"`
 	RequestLimits   ServerRequestLimits `yaml:"request_limits"`
 	Port            int                 `yaml:"port"`
@@ -48,6 +70,27 @@ type ServerConfig struct {
 	IdleTimeout     time.Duration       `yaml:"idle_timeout"`
 	ShutdownTimeout time.Duration       `yaml:"shutdown_timeout"`
 	RequestLogging  bool                `yaml:"request_logging"`
+}
+
+// Validate checks CORS configuration for spec-violating combinations that would
+// silently break browser clients at runtime rather than failing loudly at startup.
+func (c *CorsConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.MaxAge < 0 {
+		return fmt.Errorf("cors.max_age must be non-negative, got %d", c.MaxAge)
+	}
+	// The CORS spec forbids Access-Control-Allow-Origin: * when credentials are in play.
+	// Browsers will refuse the response, so this is a startup error rather than a warning.
+	if c.AllowCredentials {
+		for _, origin := range c.AllowedOrigins {
+			if origin == "*" {
+				return errors.New("cors: allow_credentials=true is incompatible with allowed_origins=[\"*\"]; list explicit origins instead")
+			}
+		}
+	}
+	return nil
 }
 
 // GetAddress returns the server address in host:port format

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -78,6 +78,12 @@ func (c *CorsConfig) Validate() error {
 	if !c.Enabled {
 		return nil
 	}
+	// rs/cors treats an empty AllowedOrigins list as allow-all, which is the
+	// opposite of what an operator expects when they write allowed_origins: [].
+	// Require an explicit ["*"] to opt into allow-all so the intent is unambiguous.
+	if len(c.AllowedOrigins) == 0 {
+		return errors.New("cors: allowed_origins must not be empty when cors is enabled; set [\"*\"] to allow all origins explicitly")
+	}
 	if c.MaxAge < 0 {
 		return fmt.Errorf("cors.max_age must be non-negative, got %d", c.MaxAge)
 	}

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ For Large GPU deployments, Enterprise & Data-Centre use, see [TensorFoundry Foun
 - **🔧 Self-Healing**: Automatic model discovery refresh when endpoints recover
 - **📊 Request Tracking**: Detailed response headers and [statistics](https://thushan.github.io/olla/api-reference/overview/#response-headers)
 - **⚡🔄 Anthropic Messages API**: [Passthrough for backends with native support; automatic translation for others](https://thushan.github.io/olla/integrations/api-translation/anthropic/)
-- **🛡️ Production Ready**: Rate limiting, request size limits, graceful shutdown
+- **🛡️ Production Ready**: Rate limiting, request size limits, optional CORS for browser clients, graceful shutdown
 - **⚡ High Performance**: Sub-millisecond endpoint selection with lock-free atomic stats
 - **🎯 LLM-Optimised**: Streaming-first design with optimised timeouts for long inference
 - **⚙️ High Performance**: Designed to be very [lightweight & efficient](https://thushan.github.io/olla/configuration/practices/performance/), runs on less than 50Mb RAM.


### PR DESCRIPTION
Adds CORS support back into Olla via [rs/cors](https://github.com/rs/cors). Addresses #156 .

CORS is opt in via:

```yaml
server:

  # CORS (Cross-Origin Resource Sharing) for browser-based clients (OpenWebUI, dashboards).
  # Off by default. Non-browser clients (curl, SDKs, coding agents) ignore CORS entirely,
  # so enabling this has no effect on them. When a request carries no Origin header it is
  # passed through untouched.
  #
  # Caveat: allow_credentials: true is incompatible with allowed_origins: ["*"] (the CORS
  # spec forbids it and browsers reject the response). List explicit origins when using
  # credentials. exposed_headers left empty auto-exposes the full X-Olla-* response header
  # set, so browser clients can read routing/model metadata.
  cors:
    enabled: false                   # opt-in: only enable when browser clients need access
    allowed_origins:
      - "*"
    allowed_methods:
      - "GET"
      - "POST"
      - "OPTIONS"
    allowed_headers:
      - "*"
    exposed_headers: []              # empty: auto-exposes the X-Olla-* headers
    allow_credentials: false         # set true only with explicit allowed_origins (not "*")
    max_age: 300                     # preflight cache in seconds (5 minutes)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CORS support for browser-direct connections with configurable allowed origins, methods, headers, exposed headers, credentials support, and preflight caching (disabled by default).

* **Documentation**
  * Updated API reference and added comprehensive CORS configuration guides, security best practices, and troubleshooting FAQs with environment variable overrides.

* **Tests**
  * Added CORS middleware and HTTP service integration tests.

* **Chores**
  * Added CORS middleware dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->