### PR TITLE
fix: route Lemonade models by mapping downloaded to available state

### DIFF
--- a/internal/adapter/registry/profile/lemonade.go
+++ b/internal/adapter/registry/profile/lemonade.go
@@ -24,4 +24,9 @@ type LemonadeModel struct {
 	Checkpoint string `json:"checkpoint"` // HuggingFace model path (e.g., "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx")
 	Recipe     string `json:"recipe"`     // Inference engine (e.g., "oga-cpu", "oga-npu", "llamacpp", "flm")
 	Created    int64  `json:"created"`    // Unix timestamp
+	// Downloaded reports that the model is present on disk and serveable on
+	// demand. Lemonade loads models on demand, so this is the readiness signal
+	// (the equivalent of an Ollama model being pulled) used to mark the model
+	// available for routing.
+	Downloaded bool `json:"downloaded"`
 }

--- a/internal/adapter/registry/profile/lemonade_parser.go
+++ b/internal/adapter/registry/profile/lemonade_parser.go
@@ -73,6 +73,17 @@ func (p *lemonadeParser) Parse(data []byte) ([]*domain.ModelInfo, error) {
 			}
 		}
 
+		// Map Lemonade's `downloaded` flag to an available state. Lemonade loads
+		// models on demand, so a downloaded model is serveable - the equivalent
+		// of a pulled Ollama model. Without this the model has no state, which
+		// the router treats as unknown and excludes from dispatch, making the
+		// Lemonade endpoint unroutable for chat.
+		if model.Downloaded {
+			state := domain.ModelStateAvailable.String()
+			details.State = &state
+			hasDetails = true
+		}
+
 		if hasDetails {
 			modelInfo.Details = details
 		}

--- a/internal/adapter/registry/profile/lemonade_parser_test.go
+++ b/internal/adapter/registry/profile/lemonade_parser_test.go
@@ -390,6 +390,56 @@ func TestLemonadeParser_Parse(t *testing.T) {
 	})
 }
 
+func TestLemonadeParser_DownloadedState(t *testing.T) {
+	parser := &lemonadeParser{}
+
+	// Lemonade reports per-model `downloaded` in /api/v1/models. A downloaded
+	// model is present on disk and serveable on demand, so it must map to an
+	// "available" state - otherwise the router treats it as unknown-state and
+	// excludes the endpoint from dispatch (no chat routing to Lemonade).
+	testCases := []struct {
+		name            string
+		downloadedField string // JSON snippet for the field, "" to omit it entirely
+		expectAvailable bool
+	}{
+		{"downloaded true marks model available", `"downloaded": true,`, true},
+		{"downloaded false leaves state unset", `"downloaded": false,`, false},
+		{"downloaded omitted leaves state unset", ``, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			response := fmt.Sprintf(`{
+				"object": "list",
+				"data": [
+					{
+						"id": "Qwen3-0.6B-GGUF",
+						"object": "model",
+						"created": 1759361710,
+						"owned_by": "lemonade",
+						%s
+						"recipe": "llamacpp"
+					}
+				]
+			}`, tc.downloadedField)
+
+			models, err := parser.Parse([]byte(response))
+			require.NoError(t, err)
+			require.Len(t, models, 1)
+
+			model := models[0]
+			require.NotNil(t, model.Details) // recipe always produces details
+
+			if tc.expectAvailable {
+				require.NotNil(t, model.Details.State)
+				assert.Equal(t, "available", *model.Details.State)
+			} else {
+				assert.Nil(t, model.Details.State)
+			}
+		})
+	}
+}
+
 func TestLemonadeParser_RecipeInference(t *testing.T) {
 	t.Run("infers format correctly for all recipe types", func(t *testing.T) {
 		testCases := []struct {


### PR DESCRIPTION
Resolves #160

## Problem

Endpoints configured with `type: "lemonade"` are health-checked fine, but no model on them is ever routable: the discovery parser drops the per-model `downloaded` flag that Lemonade returns in `/api/v1/models`, so every Lemonade model resolves to `state=unknown`. The router treats unknown-state models as being on unhealthy endpoints and excludes them, so a Lemonade endpoint is unreachable for chat even when it is up and the model is downloaded.

`MapModelState` (`internal/adapter/unifier/model_builder.go`) marks a model `available` when it has a `state`/`loaded` indicator or a non-zero size. `LemonadeModel` declared neither `downloaded` nor `size`, so both were dropped at unmarshal and the model stayed `unknown`.

## Change

Capture Lemonade's `downloaded` flag and map it to `ModelStateAvailable`. This mirrors how a pulled, load-on-demand Ollama model is already treated: present on disk and serveable, so available for routing. Lemonade also loads on demand, and `downloaded: true` is the equivalent readiness signal.

- `lemonade.go`: add `Downloaded bool` to `LemonadeModel` (ordered to satisfy fieldalignment).
- `lemonade_parser.go`: set `Details.State = "available"` when `downloaded` is true.
- `lemonade_parser_test.go`: table-driven test covering downloaded true / false / omitted.

I deliberately did not also capture `size`: Lemonade reports it as a GiB float while Olla's internal size is bytes, so it would need a unit conversion. The routing fix stands on `downloaded` alone; capturing `size` for catalog/concurrency parity can be a separate change if wanted.

## Verification

- `make ready` passes (test-short, test-race, fmt, vet, golangci-lint 0 issues, betteralign clean).
- Validated end-to-end against a live Lemonade SDK backend: before the change a chat request for a downloaded Lemonade-hosted model returns `404 "No openai endpoints available"`; after, the model reports `state: available` and the request routes to the Lemonade endpoint and returns a completion (`X-Olla-Routing-Decision: routed`, `X-Olla-Routing-Reason: model_found`).

## Note

This makes Lemonade models routable via the native `/olla/lemonade/...` path. Reaching the same endpoints through the generic `/olla/openai/...` path needs additional work that is out of scope here (the openai-compatible compatibility check and per-backend path translation); I'll open a separate issue describing that gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented model download status tracking. Models now indicate their availability state based on download completion.

* **Tests**
  * Added test coverage validating model state transitions when download status is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->