### PR TITLE
fix: make proxy response_header_timeout configurable

### DIFF
--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -184,6 +184,7 @@ proxy:
 | `connection_timeout` | duration | `30s` | Backend connection timeout |
 | `response_timeout` | duration | `10m` | Response timeout |
 | `read_timeout` | duration | `120s` | Read timeout |
+| `response_header_timeout` | duration | `30s` | Max wait for the backend's first response header. Raise it for backends that load models on demand (e.g. Lemonade), where the first request blocks until the model is resident and the 30s default would abort the cold start. |
 
 Example:
 
@@ -192,6 +193,7 @@ proxy:
   connection_timeout: 45s
   response_timeout: 0s    # Disable for streaming
   read_timeout: 0s
+  response_header_timeout: 180s  # allow slow on-demand model loads
 ```
 
 ### Retry Behaviour

--- a/docs/content/integrations/backend/lemonade.md
+++ b/docs/content/integrations/backend/lemonade.md
@@ -117,6 +117,17 @@ discovery:
 - `model_url`: Endpoint for model discovery (default: `/api/v1/models`)
 - `health_check_url`: Health check endpoint (default: `/api/v1/health`)
 
+> **On-demand model loading:** Lemonade loads a model into memory on the first
+> request for it, which can take longer than the proxy's default 30s
+> `response_header_timeout` and surface as a `502` cold-start failure. If you see
+> this, raise the timeout in the `proxy` block (see
+> [Configuration Reference](../../configuration/reference/)):
+>
+> ```yaml
+> proxy:
+>   response_header_timeout: 180s
+> ```
+
 ### Production Setup: Multiple Instances
 
 Load balance across multiple Lemonade SDK instances:

--- a/internal/adapter/proxy/config.go
+++ b/internal/adapter/proxy/config.go
@@ -29,11 +29,12 @@ type Configuration struct {
 	ProxyPrefix string
 	Profile     string
 
-	ConnectionTimeout   time.Duration
-	ConnectionKeepAlive time.Duration
-	ResponseTimeout     time.Duration
-	ReadTimeout         time.Duration
-	StreamBufferSize    int
+	ConnectionTimeout     time.Duration
+	ConnectionKeepAlive   time.Duration
+	ResponseTimeout       time.Duration
+	ReadTimeout           time.Duration
+	ResponseHeaderTimeout time.Duration
+	StreamBufferSize      int
 
 	// Olla-specific fields for advanced connection pooling
 	IdleConnTimeout time.Duration
@@ -80,6 +81,13 @@ func (c *Configuration) GetReadTimeout() time.Duration {
 		return DefaultReadTimeout
 	}
 	return c.ReadTimeout
+}
+
+// GetResponseHeaderTimeout returns the configured response-header timeout, or 0
+// when unset. The Olla engine applies its own default (DefaultResponseHeaderTimeout)
+// for a zero value, so the raw value is passed through here.
+func (c *Configuration) GetResponseHeaderTimeout() time.Duration {
+	return c.ResponseHeaderTimeout
 }
 
 func (c *Configuration) GetStreamBufferSize() int {

--- a/internal/adapter/proxy/config/unified.go
+++ b/internal/adapter/proxy/config/unified.go
@@ -51,13 +51,26 @@ type ProxyConfig interface {
 
 // BaseProxyConfig contains common configuration fields for all proxy implementations
 type BaseProxyConfig struct {
-	ProxyPrefix         string
-	Profile             string
-	ConnectionTimeout   time.Duration
-	ConnectionKeepAlive time.Duration
-	ResponseTimeout     time.Duration
-	ReadTimeout         time.Duration
-	StreamBufferSize    int
+	ProxyPrefix           string
+	Profile               string
+	ConnectionTimeout     time.Duration
+	ConnectionKeepAlive   time.Duration
+	ResponseTimeout       time.Duration
+	ReadTimeout           time.Duration
+	ResponseHeaderTimeout time.Duration
+	StreamBufferSize      int
+}
+
+// GetResponseHeaderTimeout returns the maximum time the transport waits for a
+// backend's first response header, defaulting to DefaultResponseHeaderTimeout.
+// Raise it for backends that load models on demand (e.g. Lemonade), where the
+// first request blocks until the model is resident and the 30s default would
+// abort a legitimate cold start.
+func (c *BaseProxyConfig) GetResponseHeaderTimeout() time.Duration {
+	if c.ResponseHeaderTimeout == 0 {
+		return DefaultResponseHeaderTimeout
+	}
+	return c.ResponseHeaderTimeout
 }
 
 // GetProxyProfile returns the proxy profile, defaulting to "auto" if not set

--- a/internal/adapter/proxy/factory.go
+++ b/internal/adapter/proxy/factory.go
@@ -65,10 +65,12 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 			GetMaxIdleConns() int
 			GetIdleConnTimeout() time.Duration
 			GetMaxConnsPerHost() int
+			GetResponseHeaderTimeout() time.Duration
 		}); ok {
 			ollaConfig.MaxIdleConns = ollaSpecific.GetMaxIdleConns()
 			ollaConfig.IdleConnTimeout = ollaSpecific.GetIdleConnTimeout()
 			ollaConfig.MaxConnsPerHost = ollaSpecific.GetMaxConnsPerHost()
+			ollaConfig.ResponseHeaderTimeout = ollaSpecific.GetResponseHeaderTimeout()
 		} else {
 			// fallback option with defaults
 			ollaConfig.MaxIdleConns = 200

--- a/internal/adapter/proxy/olla/service.go
+++ b/internal/adapter/proxy/olla/service.go
@@ -218,7 +218,7 @@ func createOptimisedTransport(config *Configuration) *http.Transport {
 		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
 		DisableCompression:    true,
 		ForceAttemptHTTP2:     true,
-		ResponseHeaderTimeout: proxyconfig.DefaultResponseHeaderTimeout,
+		ResponseHeaderTimeout: config.GetResponseHeaderTimeout(),
 		// Olla targets local inference backends; outbound proxy env vars are not
 		// honoured here because they would route credentialled requests through an
 		// intermediary on plain HTTP. Health probes (no credentials) keep the proxy

--- a/internal/adapter/proxy/olla/service_transport_test.go
+++ b/internal/adapter/proxy/olla/service_transport_test.go
@@ -131,3 +131,18 @@ func TestCreateOptimisedTransport_ResponseHeaderTimeout(t *testing.T) {
 		t.Errorf("transport.ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, want)
 	}
 }
+
+// TestCreateOptimisedTransport_ResponseHeaderTimeout_Configurable verifies the
+// transport's ResponseHeaderTimeout is driven by config when set, so cold-loading
+// backends (e.g. Lemonade loading a model on first request) can send their first
+// response header later than the 30s default without the proxy aborting with a 502.
+// The default-when-unset case is covered by TestCreateOptimisedTransport_ResponseHeaderTimeout.
+func TestCreateOptimisedTransport_ResponseHeaderTimeout_Configurable(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Configuration{}
+	cfg.ResponseHeaderTimeout = 180 * time.Second
+	if got := createOptimisedTransport(cfg).ResponseHeaderTimeout; got != 180*time.Second {
+		t.Errorf("configured ResponseHeaderTimeout: want 180s, got %v", got)
+	}
+}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -19,12 +19,13 @@ const (
 
 func updateProxyConfiguration(config *config.Config) *proxy.Configuration {
 	return &proxy.Configuration{
-		ConnectionTimeout:   config.Proxy.ConnectionTimeout,
-		ConnectionKeepAlive: DefaultConnectionKeepAlive,
-		ResponseTimeout:     config.Proxy.ResponseTimeout,
-		ReadTimeout:         config.Proxy.ReadTimeout,
-		ProxyPrefix:         constants.ContextRoutePrefixKey,
-		StreamBufferSize:    getStreamBufferSize(config),
+		ConnectionTimeout:     config.Proxy.ConnectionTimeout,
+		ConnectionKeepAlive:   DefaultConnectionKeepAlive,
+		ResponseTimeout:       config.Proxy.ResponseTimeout,
+		ReadTimeout:           config.Proxy.ReadTimeout,
+		ResponseHeaderTimeout: config.Proxy.ResponseHeaderTimeout,
+		ProxyPrefix:           constants.ContextRoutePrefixKey,
+		StreamBufferSize:      getStreamBufferSize(config),
 	}
 }
 func getStreamBufferSize(config *config.Config) int {

--- a/internal/app/services/proxy.go
+++ b/internal/app/services/proxy.go
@@ -171,12 +171,13 @@ func (s *ProxyServiceWrapper) Dependencies() []string {
 // for Olla engine).
 func (s *ProxyServiceWrapper) createProxyConfiguration() *proxy.Configuration {
 	return &proxy.Configuration{
-		ProxyPrefix:         "",
-		ConnectionTimeout:   s.config.ConnectionTimeout,
-		ConnectionKeepAlive: 30 * time.Second,
-		ResponseTimeout:     s.config.ResponseTimeout,
-		ReadTimeout:         s.config.ReadTimeout,
-		StreamBufferSize:    s.config.StreamBufferSize,
+		ProxyPrefix:           "",
+		ConnectionTimeout:     s.config.ConnectionTimeout,
+		ConnectionKeepAlive:   30 * time.Second,
+		ResponseTimeout:       s.config.ResponseTimeout,
+		ReadTimeout:           s.config.ReadTimeout,
+		ResponseHeaderTimeout: s.config.ResponseHeaderTimeout,
+		StreamBufferSize:      s.config.StreamBufferSize,
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -139,17 +139,18 @@ type StickySessionConfig struct {
 
 // ProxyConfig holds proxy-specific configuration
 type ProxyConfig struct {
-	ProfileFilter     *domain.FilterConfig `yaml:"profile_filter,omitempty"`
-	Engine            string               `yaml:"engine"`
-	LoadBalancer      string               `yaml:"load_balancer"`
-	Profile           string               `yaml:"profile"`
-	StickySessions    StickySessionConfig  `yaml:"sticky_sessions"`
-	ConnectionTimeout time.Duration        `yaml:"connection_timeout"`
-	ResponseTimeout   time.Duration        `yaml:"response_timeout"`
-	ReadTimeout       time.Duration        `yaml:"read_timeout"`
-	RetryBackoff      time.Duration        `yaml:"retry_backoff"` // Deprecated: Use model_registry.routing_strategy instead. TODO: Removal: v0.1.0
-	StreamBufferSize  int                  `yaml:"stream_buffer_size"`
-	MaxRetries        int                  `yaml:"max_retries"` // Deprecated: Use model_registry.routing_strategy instead. TODO: Removal: v0.1.0
+	ProfileFilter         *domain.FilterConfig `yaml:"profile_filter,omitempty"`
+	Engine                string               `yaml:"engine"`
+	LoadBalancer          string               `yaml:"load_balancer"`
+	Profile               string               `yaml:"profile"`
+	StickySessions        StickySessionConfig  `yaml:"sticky_sessions"`
+	ConnectionTimeout     time.Duration        `yaml:"connection_timeout"`
+	ResponseTimeout       time.Duration        `yaml:"response_timeout"`
+	ReadTimeout           time.Duration        `yaml:"read_timeout"`
+	ResponseHeaderTimeout time.Duration        `yaml:"response_header_timeout"`
+	RetryBackoff          time.Duration        `yaml:"retry_backoff"` // Deprecated: Use model_registry.routing_strategy instead. TODO: Removal: v0.1.0
+	StreamBufferSize      int                  `yaml:"stream_buffer_size"`
+	MaxRetries            int                  `yaml:"max_retries"` // Deprecated: Use model_registry.routing_strategy instead. TODO: Removal: v0.1.0
 }
 
 // DiscoveryConfig holds service discovery configuration


### PR DESCRIPTION
Resolves #163

## Problem

The Olla engine hardcodes the transport's `ResponseHeaderTimeout` to `DefaultResponseHeaderTimeout` (30s) with no override. Backends that load models on demand (Lemonade especially) send no response header until the model is resident, so a cold load over 30s aborts with a `502 "request timeout after 30.0s ..."` -- even when `response_timeout` is set much higher (that governs a later deadline and never applies).

## Change

Add a `response_header_timeout` key under `proxy`, threaded through to the Olla transport, defaulting to `DefaultResponseHeaderTimeout` (30s) so existing behaviour is unchanged.

- `config/types.go`: new `response_header_timeout` yaml field.
- `proxy.Configuration` + `BaseProxyConfig`: field + `GetResponseHeaderTimeout()` (defaults to 30s when unset).
- `factory.go`: picked up via the existing olla-specific type-assertion block (no `ports.ProxyConfiguration` interface change).
- `olla/service.go`: transport uses `config.GetResponseHeaderTimeout()` instead of the hardcoded constant.
- Docs: configuration reference + Lemonade backend note.

## Verification

- `make ready` passes (test-race, fmt, vet, golangci-lint 0 issues, better-align).
- New test asserts a configured value is honoured; the existing default test still covers the unset-falls-back-to-30s case.
- Validated against a live Lemonade backend: with `response_header_timeout: 180s`, a cold model load that previously 502'd at 30s now completes.

Independent of #161 (the Lemonade model-state fix); they compose but don't depend on each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable `response_header_timeout` setting for proxy configurations, enabling users to extend header wait times for backends with extended initialisation periods.

* **Documentation**
  * Added configuration reference documentation for the new `response_header_timeout` option.
  * Included integration guidance to prevent cold-start failures for backends with extended model loading times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->