### PR TITLE
feat: configuration tunables

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,7 @@ server:
   host: "localhost" # Use 0.0.0.0 to bind to all interfaces (so it's accessible externally)
   port: 40114 # default port for Olla - 4-OLLA
   read_timeout: 20s
+  read_header_timeout: 10s # max time to read request headers; guards against Slowloris, 10s suits any legitimate client
   write_timeout: 0s # for LLMs streaming, leave this as 0s
   shutdown_timeout: 10s # Graceful shutdown timeout, increase this for heavy sites that have long-running requests or lots of endpoints (30s is a good)
   request_logging: true # logs Http Requests, may be useful for debugging, noise for other use cases
@@ -62,9 +63,12 @@ proxy:
   load_balancer: "least-connections" # Available: round-robin, least-connections, priority
   stream_buffer_size: 8192 # Buffer size per request - larger = fewer syscalls, more memory
   connection_timeout: 60s
+  connection_keep_alive: 30s # TCP keep-alive interval for backend connections
   response_timeout: 900s
   read_timeout: 600s
-  
+  response_header_timeout: 30s # max wait for the backend's first response header; raise for backends that load models on demand (e.g. Lemonade)
+  tls_handshake_timeout: 10s # max time allowed for a TLS handshake with a backend
+
   # KV-cache affinity routing (opt-in)
   # Routes repeat turns in a conversation to the same backend, maximising KV-cache
   # hit rates for long multi-turn sessions at the cost of reduced load distribution.

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -69,6 +69,7 @@ server:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `read_timeout` | duration | `30s` | Time to read request |
+| `read_header_timeout` | duration | `10s` | Max time to read request headers. Protects against Slowloris attacks; unset defaults to 10s. |
 | `write_timeout` | duration | `0s` | Response write timeout (must be 0 for streaming) |
 | `idle_timeout` | duration | `0s` | Keep-alive timeout (0 = use read_timeout) |
 | `shutdown_timeout` | duration | `10s` | Graceful shutdown timeout |
@@ -78,6 +79,7 @@ Example:
 ```yaml
 server:
   read_timeout: 30s
+  read_header_timeout: 10s
   write_timeout: 0s      # Required for streaming
   idle_timeout: 120s
   shutdown_timeout: 30s
@@ -182,18 +184,22 @@ proxy:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `connection_timeout` | duration | `30s` | Backend connection timeout |
+| `connection_keep_alive` | duration | `30s` | TCP keep-alive interval for backend connections |
 | `response_timeout` | duration | `10m` | Response timeout |
 | `read_timeout` | duration | `120s` | Read timeout |
 | `response_header_timeout` | duration | `30s` | Max wait for the backend's first response header. Raise it for backends that load models on demand (e.g. Lemonade), where the first request blocks until the model is resident and the 30s default would abort the cold start. |
+| `tls_handshake_timeout` | duration | `10s` | Maximum time allowed for a TLS handshake with a backend |
 
 Example:
 
 ```yaml
 proxy:
   connection_timeout: 45s
+  connection_keep_alive: 30s
   response_timeout: 0s    # Disable for streaming
   read_timeout: 0s
   response_header_timeout: 180s  # allow slow on-demand model loads
+  tls_handshake_timeout: 10s
 ```
 
 ### Retry Behaviour
@@ -875,6 +881,7 @@ server:
   host: "localhost"
   port: 40114
   read_timeout: 30s
+  read_header_timeout: 10s
   write_timeout: 0s
   # idle_timeout: 0s  # Optional (0 = use read_timeout)
   shutdown_timeout: 10s
@@ -902,6 +909,9 @@ proxy:
   connection_timeout: 30s
   response_timeout: 10m
   read_timeout: 120s
+  response_header_timeout: 30s
+  connection_keep_alive: 30s
+  tls_handshake_timeout: 10s
   # DEPRECATED as of v0.0.16 - retry is now automatic
   # max_retries: 3
   # retry_backoff: 1s

--- a/internal/adapter/proxy/config.go
+++ b/internal/adapter/proxy/config.go
@@ -34,6 +34,7 @@ type Configuration struct {
 	ResponseTimeout       time.Duration
 	ReadTimeout           time.Duration
 	ResponseHeaderTimeout time.Duration
+	TLSHandshakeTimeout   time.Duration
 	StreamBufferSize      int
 
 	// Olla-specific fields for advanced connection pooling
@@ -88,6 +89,12 @@ func (c *Configuration) GetReadTimeout() time.Duration {
 // for a zero value, so the raw value is passed through here.
 func (c *Configuration) GetResponseHeaderTimeout() time.Duration {
 	return c.ResponseHeaderTimeout
+}
+
+// GetTLSHandshakeTimeout returns the TLS handshake timeout, or 0 when unset.
+// The Olla engine applies DefaultTLSHandshakeTimeout for a zero value.
+func (c *Configuration) GetTLSHandshakeTimeout() time.Duration {
+	return c.TLSHandshakeTimeout
 }
 
 func (c *Configuration) GetStreamBufferSize() int {

--- a/internal/adapter/proxy/config/unified.go
+++ b/internal/adapter/proxy/config/unified.go
@@ -32,6 +32,11 @@ const (
 	// DefaultHealthResponseHeaderTimeout is shorter than the proxy timeout because
 	// health probes are latency-sensitive and already bounded by CheckTimeout.
 	DefaultHealthResponseHeaderTimeout = 10 * time.Second
+
+	// DefaultTLSHandshakeTimeout caps the TLS negotiation phase. 10 s matches the
+	// Go stdlib default and is sufficient for local inference backends; slow TLS
+	// handshakes on these hosts usually indicate a misconfiguration.
+	DefaultTLSHandshakeTimeout = 10 * time.Second
 )
 
 // ProxyConfig defines the interface for all proxy configurations
@@ -58,6 +63,7 @@ type BaseProxyConfig struct {
 	ResponseTimeout       time.Duration
 	ReadTimeout           time.Duration
 	ResponseHeaderTimeout time.Duration
+	TLSHandshakeTimeout   time.Duration
 	StreamBufferSize      int
 }
 
@@ -71,6 +77,16 @@ func (c *BaseProxyConfig) GetResponseHeaderTimeout() time.Duration {
 		return DefaultResponseHeaderTimeout
 	}
 	return c.ResponseHeaderTimeout
+}
+
+// GetTLSHandshakeTimeout returns the TLS handshake timeout, defaulting to
+// DefaultTLSHandshakeTimeout. Exposed so operators can extend it for backends
+// behind slow TLS terminators, though the default covers all local backends.
+func (c *BaseProxyConfig) GetTLSHandshakeTimeout() time.Duration {
+	if c.TLSHandshakeTimeout == 0 {
+		return DefaultTLSHandshakeTimeout
+	}
+	return c.TLSHandshakeTimeout
 }
 
 // GetProxyProfile returns the proxy profile, defaulting to "auto" if not set

--- a/internal/adapter/proxy/factory.go
+++ b/internal/adapter/proxy/factory.go
@@ -47,6 +47,9 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 		sherpaConfig.ReadTimeout = config.GetReadTimeout()
 		sherpaConfig.StreamBufferSize = config.GetStreamBufferSize()
 		sherpaConfig.Profile = config.GetProxyProfile()
+		if tlsCfg, ok := config.(interface{ GetTLSHandshakeTimeout() time.Duration }); ok {
+			sherpaConfig.TLSHandshakeTimeout = tlsCfg.GetTLSHandshakeTimeout()
+		}
 		return sherpa.NewService(discovery, selector, sherpaConfig, collector, metricsExtractor, logger)
 	})
 
@@ -66,11 +69,13 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 			GetIdleConnTimeout() time.Duration
 			GetMaxConnsPerHost() int
 			GetResponseHeaderTimeout() time.Duration
+			GetTLSHandshakeTimeout() time.Duration
 		}); ok {
 			ollaConfig.MaxIdleConns = ollaSpecific.GetMaxIdleConns()
 			ollaConfig.IdleConnTimeout = ollaSpecific.GetIdleConnTimeout()
 			ollaConfig.MaxConnsPerHost = ollaSpecific.GetMaxConnsPerHost()
 			ollaConfig.ResponseHeaderTimeout = ollaSpecific.GetResponseHeaderTimeout()
+			ollaConfig.TLSHandshakeTimeout = ollaSpecific.GetTLSHandshakeTimeout()
 		} else {
 			// fallback option with defaults
 			ollaConfig.MaxIdleConns = 200

--- a/internal/adapter/proxy/factory.go
+++ b/internal/adapter/proxy/factory.go
@@ -47,8 +47,12 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 		sherpaConfig.ReadTimeout = config.GetReadTimeout()
 		sherpaConfig.StreamBufferSize = config.GetStreamBufferSize()
 		sherpaConfig.Profile = config.GetProxyProfile()
-		if tlsCfg, ok := config.(interface{ GetTLSHandshakeTimeout() time.Duration }); ok {
+		if tlsCfg, ok := config.(interface {
+			GetTLSHandshakeTimeout() time.Duration
+			GetResponseHeaderTimeout() time.Duration
+		}); ok {
 			sherpaConfig.TLSHandshakeTimeout = tlsCfg.GetTLSHandshakeTimeout()
+			sherpaConfig.ResponseHeaderTimeout = tlsCfg.GetResponseHeaderTimeout()
 		}
 		return sherpa.NewService(discovery, selector, sherpaConfig, collector, metricsExtractor, logger)
 	})

--- a/internal/adapter/proxy/factory.go
+++ b/internal/adapter/proxy/factory.go
@@ -47,12 +47,13 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 		sherpaConfig.ReadTimeout = config.GetReadTimeout()
 		sherpaConfig.StreamBufferSize = config.GetStreamBufferSize()
 		sherpaConfig.Profile = config.GetProxyProfile()
-		if tlsCfg, ok := config.(interface {
-			GetTLSHandshakeTimeout() time.Duration
-			GetResponseHeaderTimeout() time.Duration
-		}); ok {
-			sherpaConfig.TLSHandshakeTimeout = tlsCfg.GetTLSHandshakeTimeout()
-			sherpaConfig.ResponseHeaderTimeout = tlsCfg.GetResponseHeaderTimeout()
+		// Each optional getter is asserted independently so a config that supports
+		// only one timeout does not silently drop the other back to its default.
+		if rh, ok := config.(interface{ GetResponseHeaderTimeout() time.Duration }); ok {
+			sherpaConfig.ResponseHeaderTimeout = rh.GetResponseHeaderTimeout()
+		}
+		if tls, ok := config.(interface{ GetTLSHandshakeTimeout() time.Duration }); ok {
+			sherpaConfig.TLSHandshakeTimeout = tls.GetTLSHandshakeTimeout()
 		}
 		return sherpa.NewService(discovery, selector, sherpaConfig, collector, metricsExtractor, logger)
 	})
@@ -68,23 +69,30 @@ func NewFactory(statsCollector ports.StatsCollector, metricsExtractor ports.Metr
 		ollaConfig.StreamBufferSize = config.GetStreamBufferSize()
 		ollaConfig.Profile = config.GetProxyProfile()
 
+		// Pool tunables travel together and define the "is this an Olla-specific
+		// config" check, so they stay in one assertion.
 		if ollaSpecific, ok := config.(interface {
 			GetMaxIdleConns() int
 			GetIdleConnTimeout() time.Duration
 			GetMaxConnsPerHost() int
-			GetResponseHeaderTimeout() time.Duration
-			GetTLSHandshakeTimeout() time.Duration
 		}); ok {
 			ollaConfig.MaxIdleConns = ollaSpecific.GetMaxIdleConns()
 			ollaConfig.IdleConnTimeout = ollaSpecific.GetIdleConnTimeout()
 			ollaConfig.MaxConnsPerHost = ollaSpecific.GetMaxConnsPerHost()
-			ollaConfig.ResponseHeaderTimeout = ollaSpecific.GetResponseHeaderTimeout()
-			ollaConfig.TLSHandshakeTimeout = ollaSpecific.GetTLSHandshakeTimeout()
 		} else {
 			// fallback option with defaults
 			ollaConfig.MaxIdleConns = 200
 			ollaConfig.IdleConnTimeout = 90 * time.Second
 			ollaConfig.MaxConnsPerHost = 50
+		}
+
+		// Timeouts are independent of the pool tunables, so they are asserted
+		// separately to avoid one missing getter dropping the others to defaults.
+		if rh, ok := config.(interface{ GetResponseHeaderTimeout() time.Duration }); ok {
+			ollaConfig.ResponseHeaderTimeout = rh.GetResponseHeaderTimeout()
+		}
+		if tls, ok := config.(interface{ GetTLSHandshakeTimeout() time.Duration }); ok {
+			ollaConfig.TLSHandshakeTimeout = tls.GetTLSHandshakeTimeout()
 		}
 
 		return olla.NewService(discovery, selector, ollaConfig, collector, metricsExtractor, logger)

--- a/internal/adapter/proxy/olla/service.go
+++ b/internal/adapter/proxy/olla/service.go
@@ -215,7 +215,7 @@ func createOptimisedTransport(config *Configuration) *http.Transport {
 		MaxIdleConnsPerHost:   config.MaxIdleConnsPerHost,
 		MaxConnsPerHost:       config.MaxConnsPerHost,
 		IdleConnTimeout:       config.IdleConnTimeout,
-		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+		TLSHandshakeTimeout:   config.GetTLSHandshakeTimeout(),
 		DisableCompression:    true,
 		ForceAttemptHTTP2:     true,
 		ResponseHeaderTimeout: config.GetResponseHeaderTimeout(),
@@ -600,12 +600,16 @@ func (s *Service) UpdateConfig(config ports.ProxyConfiguration) {
 		newConfig.IdleConnTimeout = ollaConfig.IdleConnTimeout
 		newConfig.MaxConnsPerHost = ollaConfig.MaxConnsPerHost
 		newConfig.MaxIdleConnsPerHost = ollaConfig.MaxIdleConnsPerHost
+		newConfig.ResponseHeaderTimeout = ollaConfig.ResponseHeaderTimeout
+		newConfig.TLSHandshakeTimeout = ollaConfig.TLSHandshakeTimeout
 	} else {
 		// fallback: preserve current Olla-specific settings for non-Olla configs
 		newConfig.MaxIdleConns = s.configuration.MaxIdleConns
 		newConfig.IdleConnTimeout = s.configuration.IdleConnTimeout
 		newConfig.MaxConnsPerHost = s.configuration.MaxConnsPerHost
 		newConfig.MaxIdleConnsPerHost = s.configuration.MaxIdleConnsPerHost
+		newConfig.ResponseHeaderTimeout = s.configuration.ResponseHeaderTimeout
+		newConfig.TLSHandshakeTimeout = s.configuration.TLSHandshakeTimeout
 	}
 
 	// Update configuration atomically

--- a/internal/adapter/proxy/olla/service_transport_test.go
+++ b/internal/adapter/proxy/olla/service_transport_test.go
@@ -146,3 +146,88 @@ func TestCreateOptimisedTransport_ResponseHeaderTimeout_Configurable(t *testing.
 		t.Errorf("configured ResponseHeaderTimeout: want 180s, got %v", got)
 	}
 }
+
+// TestCreateOptimisedTransport_ConnectionKeepAlive verifies that a configured
+// ConnectionKeepAlive value is used by the transport dialer, not silently ignored.
+// The dialer is the only place KeepAlive appears; we can only inspect it indirectly
+// through config, since net.Dialer is embedded in the closure.
+func TestCreateOptimisedTransport_ConnectionKeepAlive(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Configuration{}
+	cfg.ConnectionKeepAlive = 60 * time.Second
+
+	// Verify the getter returns the configured value (the dialer uses this).
+	if got := cfg.GetConnectionKeepAlive(); got != 60*time.Second {
+		t.Errorf("GetConnectionKeepAlive: want 60s, got %v", got)
+	}
+
+	// Verify the default-when-zero behaviour.
+	zeroCfg := &Configuration{}
+	if got := zeroCfg.GetConnectionKeepAlive(); got == 0 {
+		t.Errorf("GetConnectionKeepAlive with zero config returned 0; expected a non-zero default")
+	}
+}
+
+// TestCreateOptimisedTransport_TLSHandshakeTimeout asserts that the transport's
+// TLSHandshakeTimeout uses the shared default when the config field is zero,
+// protecting against backends that hang during TLS negotiation.
+func TestCreateOptimisedTransport_TLSHandshakeTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Configuration{}
+	transport := createOptimisedTransport(cfg)
+
+	if transport.TLSHandshakeTimeout <= 0 {
+		t.Errorf("TLSHandshakeTimeout is %v; a zero value leaves TLS handshakes unbounded", transport.TLSHandshakeTimeout)
+	}
+
+	want := proxyconfig.DefaultTLSHandshakeTimeout
+	if transport.TLSHandshakeTimeout != want {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, want)
+	}
+}
+
+// TestCreateOptimisedTransport_TLSHandshakeTimeout_Configurable verifies that a
+// non-zero TLSHandshakeTimeout in config is honoured on the transport.
+func TestCreateOptimisedTransport_TLSHandshakeTimeout_Configurable(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Configuration{}
+	cfg.TLSHandshakeTimeout = 5 * time.Second
+	if got := createOptimisedTransport(cfg).TLSHandshakeTimeout; got != 5*time.Second {
+		t.Errorf("configured TLSHandshakeTimeout: want 5s, got %v", got)
+	}
+}
+
+// TestUpdateConfig_PreservesTimeouts guards against UpdateConfig losing timeout
+// fields that are not part of the ProxyConfiguration interface. Previously
+// ResponseHeaderTimeout was silently reset on the non-Olla branch; TLSHandshakeTimeout
+// had the same gap before this fix.
+func TestUpdateConfig_PreservesTimeouts(t *testing.T) {
+	t.Parallel()
+
+	original := &Configuration{}
+	original.ResponseHeaderTimeout = 90 * time.Second
+	original.TLSHandshakeTimeout = 5 * time.Second
+	original.MaxIdleConns = proxyconfig.OllaDefaultMaxIdleConns
+	original.IdleConnTimeout = proxyconfig.OllaDefaultIdleConnTimeout
+	original.MaxConnsPerHost = proxyconfig.OllaDefaultMaxConnsPerHost
+	original.MaxIdleConnsPerHost = proxyconfig.OllaDefaultMaxIdleConnsPerHost
+
+	svc := &Service{configuration: original}
+
+	// Use the same *Configuration type so we exercise the Olla type-assertion path.
+	updated := &Configuration{}
+	updated.ResponseHeaderTimeout = 120 * time.Second
+	updated.TLSHandshakeTimeout = 15 * time.Second
+
+	svc.UpdateConfig(updated)
+
+	if svc.configuration.ResponseHeaderTimeout != 120*time.Second {
+		t.Errorf("ResponseHeaderTimeout after UpdateConfig: want 120s, got %v", svc.configuration.ResponseHeaderTimeout)
+	}
+	if svc.configuration.TLSHandshakeTimeout != 15*time.Second {
+		t.Errorf("TLSHandshakeTimeout after UpdateConfig: want 15s, got %v", svc.configuration.TLSHandshakeTimeout)
+	}
+}

--- a/internal/adapter/proxy/sherpa/service.go
+++ b/internal/adapter/proxy/sherpa/service.go
@@ -97,7 +97,7 @@ func NewService(
 		DisableCompression:    DefaultDisableCompression,
 		TLSHandshakeTimeout:   configuration.GetTLSHandshakeTimeout(),
 		MaxIdleConnsPerHost:   DefaultMaxIdleConnsPerHost,
-		ResponseHeaderTimeout: DefaultResponseHeaderTimeout,
+		ResponseHeaderTimeout: configuration.GetResponseHeaderTimeout(),
 		// Olla targets local inference backends; outbound proxy env vars are not
 		// honoured here because they would route credentialled requests through an
 		// intermediary on plain HTTP. Health probes (no credentials) keep the proxy

--- a/internal/adapter/proxy/sherpa/service.go
+++ b/internal/adapter/proxy/sherpa/service.go
@@ -95,7 +95,7 @@ func NewService(
 		MaxIdleConns:          DefaultMaxIdleConns,
 		IdleConnTimeout:       DefaultIdleConnTimeout,
 		DisableCompression:    DefaultDisableCompression,
-		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+		TLSHandshakeTimeout:   configuration.GetTLSHandshakeTimeout(),
 		MaxIdleConnsPerHost:   DefaultMaxIdleConnsPerHost,
 		ResponseHeaderTimeout: DefaultResponseHeaderTimeout,
 		// Olla targets local inference backends; outbound proxy env vars are not

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -15,15 +15,26 @@ const (
 	DefaultReadTimeout         = 300 * time.Second
 	DefaultLoadBalancer        = "priority"
 	DefaultStreamBufferSize    = 8 * 1024 // 8KB
+
+	// DefaultReadHeaderTimeout guards the inbound server against Slowloris-style
+	// attacks where a client opens a connection and trickles headers indefinitely.
+	// 10 s is enough for any legitimate client to send its headers; backends that
+	// are slow to respond are covered by ConnectionTimeout instead.
+	DefaultReadHeaderTimeout = 10 * time.Second
 )
 
 func updateProxyConfiguration(config *config.Config) *proxy.Configuration {
+	keepAlive := config.Proxy.ConnectionKeepAlive
+	if keepAlive == 0 {
+		keepAlive = DefaultConnectionKeepAlive
+	}
 	return &proxy.Configuration{
 		ConnectionTimeout:     config.Proxy.ConnectionTimeout,
-		ConnectionKeepAlive:   DefaultConnectionKeepAlive,
+		ConnectionKeepAlive:   keepAlive,
 		ResponseTimeout:       config.Proxy.ResponseTimeout,
 		ReadTimeout:           config.Proxy.ReadTimeout,
 		ResponseHeaderTimeout: config.Proxy.ResponseHeaderTimeout,
+		TLSHandshakeTimeout:   config.Proxy.TLSHandshakeTimeout,
 		ProxyPrefix:           constants.ContextRoutePrefixKey,
 		StreamBufferSize:      getStreamBufferSize(config),
 	}

--- a/internal/app/services/http.go
+++ b/internal/app/services/http.go
@@ -17,6 +17,13 @@ import (
 	"github.com/thushan/olla/internal/logger"
 )
 
+const (
+	// defaultReadHeaderTimeout protects the inbound server against Slowloris-style
+	// attacks. A legitimate client sends its full header set well within 10 s; slow
+	// backends are handled by proxy.ConnectionTimeout which applies much later.
+	defaultReadHeaderTimeout = 10 * time.Second
+)
+
 // HTTPService manages the HTTP server lifecycle and route registration. It coordinates
 // with other services to ensure the server only starts accepting requests after all
 // dependencies are initialised and health checks have completed.
@@ -107,6 +114,10 @@ func (s *HTTPService) Start(ctx context.Context) error {
 	}
 
 	readTimeout := s.config.ReadTimeout
+	readHeaderTimeout := s.config.ReadHeaderTimeout
+	if readHeaderTimeout == 0 {
+		readHeaderTimeout = defaultReadHeaderTimeout
+	}
 	writeTimeout := s.config.WriteTimeout
 	idleTimeout := s.config.IdleTimeout
 
@@ -149,17 +160,19 @@ func (s *HTTPService) Start(ctx context.Context) error {
 	}
 
 	s.server = &http.Server{
-		Addr:         s.config.GetAddress(),
-		Handler:      root,
-		ReadTimeout:  readTimeout,
-		WriteTimeout: writeTimeout,
-		IdleTimeout:  idleTimeout,
+		Addr:              s.config.GetAddress(),
+		Handler:           root,
+		ReadTimeout:       readTimeout,
+		ReadHeaderTimeout: readHeaderTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
 
 	go func() {
 		s.logger.Info("HTTP server listening",
 			"address", s.server.Addr,
 			"readTimeout", readTimeout,
+			"readHeaderTimeout", readHeaderTimeout,
 			"writeTimeout", writeTimeout,
 			"idleTimeout", idleTimeout)
 

--- a/internal/app/services/proxy.go
+++ b/internal/app/services/proxy.go
@@ -16,6 +16,13 @@ import (
 	"github.com/thushan/olla/internal/logger"
 )
 
+const (
+	// defaultConnectionKeepAlive is the fallback when the proxy config omits
+	// connection_keep_alive. Matches the app-layer default to keep behaviour
+	// identical for operators who haven't set the field.
+	defaultConnectionKeepAlive = 30 * time.Second
+)
+
 // ProxyServiceWrapper adapts the core proxy implementation to the service lifecycle
 // model. It manages the creation of load balancers and proxy engines, ensuring they
 // receive validated endpoints from the discovery service.
@@ -170,13 +177,18 @@ func (s *ProxyServiceWrapper) Dependencies() []string {
 // will augment this with engine-specific settings (e.g., connection pool parameters
 // for Olla engine).
 func (s *ProxyServiceWrapper) createProxyConfiguration() *proxy.Configuration {
+	keepAlive := s.config.ConnectionKeepAlive
+	if keepAlive == 0 {
+		keepAlive = defaultConnectionKeepAlive
+	}
 	return &proxy.Configuration{
 		ProxyPrefix:           "",
 		ConnectionTimeout:     s.config.ConnectionTimeout,
-		ConnectionKeepAlive:   30 * time.Second,
+		ConnectionKeepAlive:   keepAlive,
 		ResponseTimeout:       s.config.ResponseTimeout,
 		ReadTimeout:           s.config.ReadTimeout,
 		ResponseHeaderTimeout: s.config.ResponseHeaderTimeout,
+		TLSHandshakeTimeout:   s.config.TLSHandshakeTimeout,
 		StreamBufferSize:      s.config.StreamBufferSize,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -369,6 +369,26 @@ func applyEnvOverrides(config *Config) {
 			config.Proxy.ReadTimeout = duration
 		}
 	}
+	if val := os.Getenv("OLLA_PROXY_RESPONSE_HEADER_TIMEOUT"); val != "" {
+		if duration, err := time.ParseDuration(val); err == nil {
+			config.Proxy.ResponseHeaderTimeout = duration
+		}
+	}
+	if val := os.Getenv("OLLA_PROXY_TLS_HANDSHAKE_TIMEOUT"); val != "" {
+		if duration, err := time.ParseDuration(val); err == nil {
+			config.Proxy.TLSHandshakeTimeout = duration
+		}
+	}
+	if val := os.Getenv("OLLA_PROXY_CONNECTION_KEEP_ALIVE"); val != "" {
+		if duration, err := time.ParseDuration(val); err == nil {
+			config.Proxy.ConnectionKeepAlive = duration
+		}
+	}
+	if val := os.Getenv("OLLA_SERVER_READ_HEADER_TIMEOUT"); val != "" {
+		if duration, err := time.ParseDuration(val); err == nil {
+			config.Server.ReadHeaderTimeout = duration
+		}
+	}
 	if val := os.Getenv("OLLA_PROXY_LOAD_BALANCER"); val != "" {
 		config.Proxy.LoadBalancer = val
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1570,3 +1570,52 @@ func TestConfigValidate_CorsInvalidPropagates(t *testing.T) {
 		t.Errorf("expected error to mention allow_credentials, got: %v", err)
 	}
 }
+
+// TestEnvOverrides_NewTunables verifies that the four tunables added on the
+// feature/config-tunables branch are each individually honoured by
+// applyEnvOverrides, so the docs claim (all settings support OLLA_ prefix) holds.
+// Not parallel: env vars are process-global; sequential subtests prevent bleed.
+func TestEnvOverrides_NewTunables(t *testing.T) {
+	testCases := []struct {
+		envVar  string
+		value   string
+		checkFn func(*Config) bool
+	}{
+		{
+			envVar:  "OLLA_SERVER_READ_HEADER_TIMEOUT",
+			value:   "15s",
+			checkFn: func(c *Config) bool { return c.Server.ReadHeaderTimeout == 15*time.Second },
+		},
+		{
+			envVar:  "OLLA_PROXY_CONNECTION_KEEP_ALIVE",
+			value:   "90s",
+			checkFn: func(c *Config) bool { return c.Proxy.ConnectionKeepAlive == 90*time.Second },
+		},
+		{
+			envVar:  "OLLA_PROXY_RESPONSE_HEADER_TIMEOUT",
+			value:   "180s",
+			checkFn: func(c *Config) bool { return c.Proxy.ResponseHeaderTimeout == 180*time.Second },
+		},
+		{
+			envVar:  "OLLA_PROXY_TLS_HANDSHAKE_TIMEOUT",
+			value:   "20s",
+			checkFn: func(c *Config) bool { return c.Proxy.TLSHandshakeTimeout == 20*time.Second },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.envVar, func(t *testing.T) {
+			os.Setenv(tc.envVar, tc.value)
+			defer os.Unsetenv(tc.envVar)
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load failed: %v", err)
+			}
+
+			if !tc.checkFn(cfg) {
+				t.Errorf("%s=%s was not applied: got %+v", tc.envVar, tc.value, cfg.Proxy)
+			}
+		})
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -60,16 +60,17 @@ type CorsConfig struct {
 
 // ServerConfig holds HTTP server configuration
 type ServerConfig struct {
-	Host            string              `yaml:"host"`
-	Cors            CorsConfig          `yaml:"cors"`
-	RateLimits      ServerRateLimits    `yaml:"rate_limits"`
-	RequestLimits   ServerRequestLimits `yaml:"request_limits"`
-	Port            int                 `yaml:"port"`
-	ReadTimeout     time.Duration       `yaml:"read_timeout"`
-	WriteTimeout    time.Duration       `yaml:"write_timeout"`
-	IdleTimeout     time.Duration       `yaml:"idle_timeout"`
-	ShutdownTimeout time.Duration       `yaml:"shutdown_timeout"`
-	RequestLogging  bool                `yaml:"request_logging"`
+	Host              string              `yaml:"host"`
+	Cors              CorsConfig          `yaml:"cors"`
+	RateLimits        ServerRateLimits    `yaml:"rate_limits"`
+	RequestLimits     ServerRequestLimits `yaml:"request_limits"`
+	Port              int                 `yaml:"port"`
+	ReadTimeout       time.Duration       `yaml:"read_timeout"`
+	ReadHeaderTimeout time.Duration       `yaml:"read_header_timeout"`
+	WriteTimeout      time.Duration       `yaml:"write_timeout"`
+	IdleTimeout       time.Duration       `yaml:"idle_timeout"`
+	ShutdownTimeout   time.Duration       `yaml:"shutdown_timeout"`
+	RequestLogging    bool                `yaml:"request_logging"`
 }
 
 // Validate checks CORS configuration for spec-violating combinations that would
@@ -145,9 +146,11 @@ type ProxyConfig struct {
 	Profile               string               `yaml:"profile"`
 	StickySessions        StickySessionConfig  `yaml:"sticky_sessions"`
 	ConnectionTimeout     time.Duration        `yaml:"connection_timeout"`
+	ConnectionKeepAlive   time.Duration        `yaml:"connection_keep_alive"`
 	ResponseTimeout       time.Duration        `yaml:"response_timeout"`
 	ReadTimeout           time.Duration        `yaml:"read_timeout"`
 	ResponseHeaderTimeout time.Duration        `yaml:"response_header_timeout"`
+	TLSHandshakeTimeout   time.Duration        `yaml:"tls_handshake_timeout"`
 	RetryBackoff          time.Duration        `yaml:"retry_backoff"` // Deprecated: Use model_registry.routing_strategy instead. TODO: Removal: v0.1.0
 	StreamBufferSize      int                  `yaml:"stream_buffer_size"`
 	MaxRetries            int                  `yaml:"max_retries"` // Deprecated: Use model_registry.routing_strategy instead. TODO: Removal: v0.1.0


### PR DESCRIPTION
Extends #164 to add extra tunables to Olla for tweaking things.


| Setting | Section | Default | Env var | Description |
|---------|---------|---------|---------|-------------|
| `read_header_timeout` | `server` | `10s` | `OLLA_SERVER_READ_HEADER_TIMEOUT` | Max time to read request headers. Guards the inbound listener against Slowloris-style slow-header attacks. |
| `connection_keep_alive` | `proxy` | `30s` | `OLLA_PROXY_CONNECTION_KEEP_ALIVE` | TCP keep-alive interval for backend connections. Was previously hardcoded in two places. |
| `response_header_timeout` | `proxy` | `30s` | `OLLA_PROXY_RESPONSE_HEADER_TIMEOUT` | Max wait for the backend's first response header. Raise for backends that load models on demand (e.g. Lemonade), where the cold start would otherwise abort at 30s.
Now honoured by **both** Olla and Sherpa engines (#164 was Olla-only). |
| `tls_handshake_timeout` | `proxy` | `10s` | `OLLA_PROXY_TLS_HANDSHAKE_TIMEOUT` | Max time allowed for a TLS handshake with a backend. |

All four follow zero-value-means-default, so existing configs are unaffected. Each is also overridable via its `OLLA_` env var, consistent with the rest of the config.

  ```yaml
  server:
    read_header_timeout: 10s

  proxy:
    connection_keep_alive: 30s
    response_header_timeout: 30s   # raise for on-demand model loaders (e.g. Lemonade)
    tls_handshake_timeout: 10s
  ```

### Also in this PR (follow-ups to #164)

- Faxed `UpdateConfig` dropping `ResponseHeaderTimeout`/`TLSHandshakeTimeout` on config reload
- Extended `response_header_timeout` to the Sherpa engine (was hardcoded)
- Aded the missing keys to the shipped `config/config.yaml` and the canonical docs config block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable server read header timeout, proxy connection keep-alive, proxy response header timeout, and proxy TLS handshake timeout settings; applied to HTTP server and proxy transports.

* **Documentation**
  * Updated configuration reference and default YAML examples to document new timeout and connection options.

* **Tests**
  * Added tests covering environment-variable overrides and proxy transport timeout/keep-alive behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->