### PR TITLE
feat: backend omlx

### DIFF
--- a/config/profiles/omlx.yaml
+++ b/config/profiles/omlx.yaml
@@ -23,10 +23,15 @@ api:
   # oMLX exposes /v1/messages AND /v1/messages/count_tokens natively,
   # so Anthropic-format requests can be forwarded directly without
   # the Anthropic-to-OpenAI translation layer.
+  #
+  # token_count stays false: oMLX has a native /v1/messages/count_tokens
+  # endpoint, but Olla does not yet forward to it (the token-count handler
+  # always uses the local estimator), so advertising the capability would
+  # be misleading. Flip to true once native count_tokens passthrough lands.
   anthropic_support:
     enabled: true
     messages_path: /v1/messages
-    token_count: true
+    token_count: false
 
   paths:
     # Health endpoint — dedicated path, not model-discovery
@@ -49,6 +54,9 @@ api:
 
     # OpenAI Responses API
     - /v1/responses            # 8: OpenAI Responses API
+
+    # Reranking endpoint (Cohere/Jina-compatible)
+    - /v1/rerank               # 9: reranking API
 
   model_discovery_path: /v1/models
   health_check_path: /health
@@ -89,6 +97,7 @@ path_indices:
   chat_completions: 3
   completions: 4
   embeddings: 5
+  v1_rerank: 9
 
 # Model handling
 models:

--- a/config/profiles/omlx.yaml
+++ b/config/profiles/omlx.yaml
@@ -1,0 +1,137 @@
+# oMLX inference platform profile
+# oMLX (jundot/omlx) is a multi-model Apple Silicon inference server that
+# runs multiple models concurrently via MLX. It is fully OpenAI-compatible
+# on the wire, so we reuse the OpenAI parser/converter rather than writing
+# a custom one. Native Anthropic Messages API support means passthrough is
+# enabled — no translation overhead for Anthropic-format requests.
+name: omlx
+home: "https://github.com/jundot/omlx"
+version: "1.0"
+display_name: "oMLX"
+description: "oMLX multi-model Apple Silicon inference server (MLX-based)"
+
+# Routing configuration
+routing:
+  prefixes:
+    - omlx
+
+# API compatibility
+api:
+  openai_compatible: true
+
+  # Native Anthropic Messages API support (v0.4.2+)
+  # oMLX exposes /v1/messages AND /v1/messages/count_tokens natively,
+  # so Anthropic-format requests can be forwarded directly without
+  # the Anthropic-to-OpenAI translation layer.
+  anthropic_support:
+    enabled: true
+    messages_path: /v1/messages
+    token_count: true
+
+  paths:
+    # Health endpoint — dedicated path, not model-discovery
+    - /health                  # 0: health check
+
+    # Model management
+    - /v1/models               # 1: list models (OpenAI-compatible; owned_by:"omlx")
+    - /v1/models/status        # 2: loaded-model state (oMLX-specific)
+
+    # Text generation endpoints (OpenAI-compatible)
+    - /v1/chat/completions     # 3: chat completions
+    - /v1/completions          # 4: text completions
+
+    # Embeddings
+    - /v1/embeddings           # 5: embeddings API
+
+    # Anthropic Messages API (native)
+    - /v1/messages             # 6: Anthropic Messages API (native passthrough)
+    - /v1/messages/count_tokens # 7: Anthropic token count endpoint
+
+    # OpenAI Responses API
+    - /v1/responses            # 8: OpenAI Responses API
+
+  model_discovery_path: /v1/models
+  health_check_path: /health
+
+# Platform characteristics
+# Apple Silicon servers are single-host; concurrency is constrained by ANE/GPU bandwidth
+characteristics:
+  timeout: 3m
+  max_concurrent_requests: 4
+  default_priority: 75
+  streaming_support: true
+
+# Detection hints for auto-discovery
+detection:
+  path_indicators:
+    - "/v1/models"
+    - "/health"
+    - "/v1/models/status"  # oMLX-specific; most other servers don't expose this
+  default_ports:
+    - 8000
+
+# Request/response handling
+# oMLX is OpenAI-compatible on the wire — reuse the standard OpenAI parser
+request:
+  model_field_paths:
+    - "model"
+  response_format: "openai"
+  parsing_rules:
+    chat_completions_path: "/v1/chat/completions"
+    completions_path: "/v1/completions"
+    model_field_name: "model"
+    supports_streaming: true
+
+# Path indices for specific functions
+path_indices:
+  health: 0
+  models: 1
+  chat_completions: 3
+  completions: 4
+  embeddings: 5
+
+# Model handling
+models:
+  name_format: "{{.Name}}"
+  capability_patterns:
+    chat:
+      - "*-Instruct*"
+      - "*-instruct*"
+      - "*-Chat*"
+      - "*-chat*"
+    embeddings:
+      - "*embedding*"
+      - "*-embed-*"
+
+# Resource management — Apple Silicon has unified memory shared between CPU and GPU
+# oMLX loads multiple models simultaneously so per-model limits are lower
+resources:
+  defaults:
+    min_memory_gb: 4
+    recommended_memory_gb: 8
+    min_gpu_memory_gb: 0    # Unified memory; no discrete GPU
+    requires_gpu: false
+    estimated_load_time_ms: 5000
+
+  concurrency_limits:
+    - min_memory_gb: 0
+      max_concurrent: 4
+
+  timeout_scaling:
+    base_timeout_seconds: 180  # 3 minutes
+    load_time_buffer: true
+
+# Metrics extraction — OpenAI-format responses
+metrics:
+  extraction:
+    enabled: true
+    source: response_body
+    format: json
+    paths:
+      model: "$.model"
+      finish_reason: "$.choices[0].finish_reason"
+      input_tokens: "$.usage.prompt_tokens"
+      output_tokens: "$.usage.completion_tokens"
+      total_tokens: "$.usage.total_tokens"
+    calculations:
+      is_complete: 'len(finish_reason) > 0'

--- a/docs/content/api-reference/omlx.md
+++ b/docs/content/api-reference/omlx.md
@@ -1,0 +1,347 @@
+# oMLX API
+
+Proxy endpoints for oMLX inference servers running on Apple Silicon. Available through the `/olla/omlx/` prefix.
+
+oMLX is a multi-model server: a single instance hosts many models concurrently, loading them on demand and evicting the least-recently-used ones under memory pressure. It is OpenAI-compatible on the wire and additionally implements the Anthropic Messages API, a reranking endpoint, and an oMLX-specific model-status endpoint.
+
+## Endpoints Overview
+
+| Method | URI | Description |
+|--------|-----|-------------|
+| GET | `/olla/omlx/health` | Health check |
+| GET | `/olla/omlx/v1/models` | List available models |
+| GET | `/olla/omlx/v1/models/status` | Loaded-model residency state |
+| POST | `/olla/omlx/v1/chat/completions` | Chat completion |
+| POST | `/olla/omlx/v1/completions` | Text completion |
+| POST | `/olla/omlx/v1/embeddings` | Generate embeddings |
+| POST | `/olla/omlx/v1/rerank` | Rerank documents |
+| POST | `/olla/omlx/v1/responses` | OpenAI Responses API |
+
+Anthropic-format requests are served through Olla's Anthropic endpoint (`/olla/anthropic/v1/messages`) in passthrough mode. See the [Anthropic API Reference](anthropic.md).
+
+---
+
+## GET /olla/omlx/health
+
+Check oMLX server health status.
+
+### Request
+
+```bash
+curl -X GET http://localhost:40114/olla/omlx/health
+```
+
+### Response
+
+```json
+{
+  "status": "healthy"
+}
+```
+
+---
+
+## GET /olla/omlx/v1/models
+
+List the models the oMLX server has discovered. The `id` is the configured alias where one is set, otherwise the model's directory name. `max_model_len` reports the effective context window and is preserved by Olla during discovery.
+
+### Request
+
+```bash
+curl -X GET http://localhost:40114/olla/omlx/v1/models
+```
+
+### Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "Qwen2.5-7B-Instruct-4bit",
+      "object": "model",
+      "created": 1705334400,
+      "owned_by": "omlx",
+      "max_model_len": 32768
+    }
+  ]
+}
+```
+
+---
+
+## GET /olla/omlx/v1/models/status
+
+Report which models are currently resident in memory. This oMLX-specific endpoint is keyed by **directory name** (not alias) and is useful for understanding cold-start behaviour. Olla forwards it unchanged.
+
+### Request
+
+```bash
+curl -X GET http://localhost:40114/olla/omlx/v1/models/status
+```
+
+### Response
+
+```json
+{
+  "model_count": 3,
+  "loaded_count": 1,
+  "models": [
+    {
+      "id": "Qwen2.5-7B-Instruct-4bit",
+      "loaded": true,
+      "is_loading": false,
+      "pinned": true,
+      "estimated_size": 4500000000,
+      "last_access": 1705334400.0
+    },
+    {
+      "id": "Llama-3.2-3B-Instruct-4bit",
+      "loaded": false,
+      "is_loading": false,
+      "pinned": false,
+      "estimated_size": 1800000000,
+      "last_access": null
+    }
+  ]
+}
+```
+
+---
+
+## POST /olla/omlx/v1/chat/completions
+
+OpenAI-compatible chat completion. The first request for a model that is not resident triggers a load and may take several seconds.
+
+### Request
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2.5-7B-Instruct-4bit",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are a helpful AI assistant."
+      },
+      {
+        "role": "user",
+        "content": "What is MLX?"
+      }
+    ],
+    "temperature": 0.7,
+    "max_tokens": 300,
+    "stream": false
+  }'
+```
+
+### Response
+
+```json
+{
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "created": 1705334400,
+  "model": "Qwen2.5-7B-Instruct-4bit",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "MLX is an array framework for machine learning on Apple Silicon, built by Apple's machine learning research team. It uses the unified memory architecture of M-series chips for efficient GPU-accelerated computation."
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 25,
+    "completion_tokens": 40,
+    "total_tokens": 65
+  }
+}
+```
+
+### Streaming Response
+
+When `"stream": true`:
+
+```
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1705334400,"model":"Qwen2.5-7B-Instruct-4bit","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1705334400,"model":"Qwen2.5-7B-Instruct-4bit","choices":[{"index":0,"delta":{"content":"MLX"},"finish_reason":null}]}
+
+...
+
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1705334401,"model":"Qwen2.5-7B-Instruct-4bit","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+```
+
+---
+
+## POST /olla/omlx/v1/completions
+
+Text completion.
+
+### Request
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2.5-7B-Instruct-4bit",
+    "prompt": "Apple Silicon is designed for",
+    "max_tokens": 200,
+    "temperature": 0.8,
+    "top_p": 0.95,
+    "stream": false
+  }'
+```
+
+### Response
+
+```json
+{
+  "id": "cmpl-xyz789",
+  "object": "text_completion",
+  "created": 1705334400,
+  "model": "Qwen2.5-7B-Instruct-4bit",
+  "choices": [
+    {
+      "text": " high-performance, energy-efficient computing. The unified memory architecture lets the CPU, GPU, and Neural Engine share one memory pool, removing the overhead of copying data between processors.",
+      "index": 0,
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 6,
+    "completion_tokens": 36,
+    "total_tokens": 42
+  }
+}
+```
+
+---
+
+## POST /olla/omlx/v1/embeddings
+
+Generate embeddings from an embedding model loaded by oMLX.
+
+### Request
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/bge-small-en-v1.5",
+    "input": "MLX is optimised for Apple Silicon",
+    "encoding_format": "float"
+  }'
+```
+
+### Response
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "index": 0,
+      "embedding": [0.0234, -0.0567, 0.0891, ...]
+    }
+  ],
+  "model": "mlx-community/bge-small-en-v1.5",
+  "usage": {
+    "prompt_tokens": 8,
+    "total_tokens": 8
+  }
+}
+```
+
+---
+
+## POST /olla/omlx/v1/rerank
+
+Rerank a set of documents against a query (Cohere/Jina-compatible), using a reranker model loaded by oMLX.
+
+### Request
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/rerank \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/bge-reranker-base",
+    "query": "What is unified memory?",
+    "documents": [
+      "Apple Silicon shares memory between CPU and GPU.",
+      "MLX is an array framework for Apple Silicon.",
+      "Discrete GPUs use separate VRAM."
+    ],
+    "top_n": 2
+  }'
+```
+
+### Response
+
+```json
+{
+  "results": [
+    {"index": 0, "relevance_score": 0.91},
+    {"index": 1, "relevance_score": 0.44}
+  ],
+  "model": "mlx-community/bge-reranker-base",
+  "usage": {
+    "total_tokens": 38
+  }
+}
+```
+
+## Sampling Parameters
+
+Standard OpenAI-compatible sampling parameters are supported.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `temperature` | float | 1.0 | Sampling temperature |
+| `top_p` | float | 1.0 | Nucleus sampling threshold |
+| `top_k` | integer | - | Top-k sampling |
+| `max_tokens` | integer | - | Maximum tokens to generate |
+| `stop` | string/array | - | Stop sequences |
+| `stream` | boolean | false | Enable streaming response |
+| `frequency_penalty` | float | 0.0 | Frequency penalty |
+| `presence_penalty` | float | 0.0 | Presence penalty |
+
+## Configuration Example
+
+```yaml
+endpoints:
+  - url: "http://192.168.0.100:8000"
+    name: "omlx-server"
+    type: "omlx"
+    priority: 75
+    model_url: "/v1/models"
+    health_check_url: "/health"
+    check_interval: 5s
+    check_timeout: 2s
+```
+
+## Request Headers
+
+All requests are forwarded with:
+
+- `X-Olla-Request-ID` - Unique request identifier
+- `X-Forwarded-For` - Client IP address
+- Custom headers from endpoint configuration
+
+## Response Headers
+
+All responses include:
+
+- `X-Olla-Endpoint` - Backend endpoint name (e.g., "omlx-server")
+- `X-Olla-Model` - Model used for the request
+- `X-Olla-Backend-Type` - Always "omlx" for these endpoints
+- `X-Olla-Response-Time` - Total processing time

--- a/docs/content/api-reference/omlx.md
+++ b/docs/content/api-reference/omlx.md
@@ -167,7 +167,7 @@ curl -X POST http://localhost:40114/olla/omlx/v1/chat/completions \
 
 When `"stream": true`:
 
-```
+```text
 data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1705334400,"model":"Qwen2.5-7B-Instruct-4bit","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
 
 data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1705334400,"model":"Qwen2.5-7B-Instruct-4bit","choices":[{"index":0,"delta":{"content":"MLX"},"finish_reason":null}]}

--- a/docs/content/api-reference/overview.md
+++ b/docs/content/api-reference/overview.md
@@ -87,6 +87,12 @@ Proxy endpoints for Lemonade SDK servers with AMD Ryzen AI support.
 - `/olla/lemonade/*` - Lemonade SDK API endpoints
 - Includes ONNX and GGUF model support with hardware acceleration
 
+### [oMLX API](omlx.md)
+Proxy endpoints for oMLX -- the multi-model Apple Silicon (MLX) inference server.
+
+- `/olla/omlx/*` - oMLX API endpoints
+- OpenAI-compatible endpoints with native Anthropic Messages API passthrough
+
 ## Translated APIs
 
 APIs that translate between different formats in real-time.
@@ -153,7 +159,7 @@ All responses include:
 | `X-Olla-Request-ID` | Unique request identifier |
 | `X-Olla-Endpoint` | Backend endpoint name |
 | `X-Olla-Model` | Model used (if applicable) |
-| `X-Olla-Backend-Type` | Provider type, examples: <br> `ollama/lm-studio/llamacpp/openai/openai-compatible/vllm/sglang/lemonade/lmdeploy` |
+| `X-Olla-Backend-Type` | Provider type, examples: <br> `ollama/lm-studio/llamacpp/openai/openai-compatible/vllm/sglang/lemonade/lmdeploy/omlx` |
 | `X-Olla-Response-Time` | Total processing time |
 | `X-Olla-Routing-Strategy` | Routing strategy used (when model routing is active) |
 | `X-Olla-Routing-Decision` | Routing decision made (routed/fallback/rejected) |

--- a/docs/content/concepts/profile-system.md
+++ b/docs/content/concepts/profile-system.md
@@ -307,6 +307,7 @@ api:
 | llama.cpp | b4847+ | Yes | Only backend with full token counting |
 | LM Studio | v0.4.1+ | No | Desktop inference |
 | Ollama | v0.14.0+ | No | Popular local inference |
+| oMLX | -- | No | Apple Silicon (MLX) multi-model server; passthrough supported, token counting not yet forwarded |
 
 When a client sends a request to `/olla/anthropic/v1/messages` and a backend has `anthropic_support.enabled: true`, Olla will bypass format translation and forward the request directly. This is referred to as **passthrough mode** and has near-zero overhead. See [API Translation](api-translation.md#passthrough-mode) for details.
 
@@ -664,7 +665,9 @@ Don't update versions in natively supported profiles however.
 | lemonade | `lemonade` | `lemonade` | `/v1/models` |
 | llamacpp | `llamacpp` | `llamacpp`, `llama-cpp`, `llama_cpp` | None |
 | vllm | `vllm` | `vllm` | None |
+| vllm-mlx | `vllm-mlx` | `vllm-mlx` | None |
 | sglang | `sglang` | `sglang` | None |
+| omlx | `omlx` | `omlx` | None |
 | openai-compatible | `openai-compatible` (or `openai` — alias) | `openai`, `openai-compatible` | None |
 
 ### Required Fields

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -303,7 +303,7 @@ discovery:
 |-------|------|----------|-------------|
 | `static.endpoints[].url` | string | Yes | Endpoint base URL |
 | `static.endpoints[].name` | string | Yes | Unique endpoint name |
-| `static.endpoints[].type` | string | Yes | Backend type (`ollama`, `lm-studio`, `llamacpp`, `vllm`, `sglang`, `lemonade`, `litellm`, `openai-compatible`). `openai` is accepted as an alias for `openai-compatible`. |
+| `static.endpoints[].type` | string | Yes | Backend type (`ollama`, `lm-studio`, `llamacpp`, `vllm`, `vllm-mlx`, `sglang`, `lemonade`, `litellm`, `lmdeploy`, `docker-model-runner`, `omlx`, `openai-compatible`). `openai` is accepted as an alias for `openai-compatible`. |
 | `static.endpoints[].priority` | int | No | Selection priority (higher=preferred, default: `100`) |
 | `static.endpoints[].preserve_path` | bool | No | Preserve base path in URL when proxying (default: `false`) |
 | `static.endpoints[].health_check_url` | string | No | Health check path (optional, uses profile default if not specified) |

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -10,7 +10,7 @@ keywords: olla faq, troubleshooting, common questions, proxy help
 
 ### What is Olla?
 
-Olla is a high-performance proxy and load balancer specifically designed for LLM infrastructure. It intelligently routes requests across multiple LLM backends (Ollama, LM Studio, LMDeploy, vLLM, SGLang, Lemonade SDK, LiteLLM, and OpenAI-compatible endpoints) while providing load balancing, health checking, and unified model management.
+Olla is a high-performance proxy and load balancer specifically designed for LLM infrastructure. It intelligently routes requests across multiple LLM backends (Ollama, LM Studio, LMDeploy, vLLM, SGLang, Lemonade SDK, LiteLLM, oMLX, and OpenAI-compatible endpoints) while providing load balancing, health checking, and unified model management.
 
 See how Olla compares to [other tools](compare/overview.md) in the ecosystem.
 

--- a/docs/content/getting-started/quickstart.md
+++ b/docs/content/getting-started/quickstart.md
@@ -273,7 +273,7 @@ server:
 
 ### Next Steps
 
-- [Backend Integrations](../integrations/overview.md) - Connect Ollama, LM Studio, llama.cpp, vLLM, SGLang, Lemonade SDK, LiteLLM
+- [Backend Integrations](../integrations/overview.md) - Connect Ollama, LM Studio, llama.cpp, vLLM, SGLang, Lemonade SDK, LiteLLM, oMLX
 - [Architecture Overview](../development/architecture.md) - Deep dive into Olla's design
 - [Development Guide](../development/contributing.md) - Contribute to Olla
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -101,7 +101,7 @@ Olla provides detailed response headers for observability:
 |--------|-------------|
 | `X-Olla-Endpoint` | Backend endpoint name |
 | `X-Olla-Model` | Model used for the request |
-| `X-Olla-Backend-Type` | Backend type (ollama/openai/openai-compatible/lm-studio/llamacpp/vllm/sglang/lemonade/lmdeploy/omlx) |
+| `X-Olla-Backend-Type` | Backend type (ollama/openai/openai-compatible/lm-studio/llamacpp/vllm/sglang/lemonade/lmdeploy/docker-model-runner/omlx) |
 | `X-Olla-Request-ID` | Unique request identifier |
 | `X-Olla-Response-Time` | Total processing time |
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,7 +1,7 @@
 ---
 title: Olla - High-Performance LLM Proxy and Load Balancer
-description: Olla is a high-performance proxy, model unifier and load balancer for Ollama, LM Studio, vLLM, SGLang, Lemonade SDK and OpenAI-compatible LLM backends. Unified model catalogues, intelligent routing, and automatic failover.
-keywords: llm proxy, ollama proxy, lm studio proxy, vllm proxy, sglang, lemonade sdk, model unification, load balancer, ai infrastructure
+description: Olla is a high-performance proxy, model unifier and load balancer for Ollama, LM Studio, vLLM, SGLang, Lemonade SDK, oMLX and OpenAI-compatible LLM backends. Unified model catalogues, intelligent routing, and automatic failover.
+keywords: llm proxy, ollama proxy, lm studio proxy, vllm proxy, sglang, lemonade sdk, omlx, oMLX, model unification, load balancer, ai infrastructure
 ---
 
 <div align="center">
@@ -18,7 +18,8 @@ keywords: llm proxy, ollama proxy, lm studio proxy, vllm proxy, sglang, lemonade
     <a href="https://github.com/BerriAI/litellm"><img src="https://img.shields.io/badge/LiteLLM-native-lightgreen.svg" alt="LiteLLM: Native Support"></a>
     <a href="https://github.com/InternLM/lmdeploy"><img src="https://img.shields.io/badge/LM Deploy-native-lightgreen.svg" alt="LM Deploy: Native Support"></a> <br/> 
     <a href="https://github.com/waybarrios/vllm-mlx/"><img src="https://img.shields.io/badge/vLLM--MLX-native-lightgreen.svg" alt="vLLM-MLX: Native Support"></a>
-    <a href="https://docs.docker.com/ai/model-runner/"><img src="https://img.shields.io/badge/Docker Model Runner-native-lightgreen.svg" alt="Docker Model Runner: Native Support"></a><br/>
+    <a href="https://docs.docker.com/ai/model-runner/"><img src="https://img.shields.io/badge/Docker Model Runner-native-lightgreen.svg" alt="Docker Model Runner: Native Support"></a>
+    <a href="https://github.com/jundot/omlx"><img src="https://img.shields.io/badge/oMLX-native-lightgreen.svg" alt="oMLX: Native Support"></a><br/>
     <a href="https://ollama.com"><img src="https://img.shields.io/badge/Ollama-native-lightgreen.svg" alt="Ollama: Native Support"></a>
     <a href="https://lmstudio.ai/"><img src="https://img.shields.io/badge/LM Studio-native-lightgreen.svg" alt="LM Studio: Native Support"></a>
     <a href="https://github.com/lemonade-sdk/lemonade"><img src="https://img.shields.io/badge/LemonadeSDK-native-lightgreen.svg" alt="LemonadeSDK: Native Support"></a>      
@@ -100,7 +101,7 @@ Olla provides detailed response headers for observability:
 |--------|-------------|
 | `X-Olla-Endpoint` | Backend endpoint name |
 | `X-Olla-Model` | Model used for the request |
-| `X-Olla-Backend-Type` | Backend type (ollama/openai/openai-compatible/lm-studio/llamacpp/vllm/sglang/lemonade/lmdeploy) |
+| `X-Olla-Backend-Type` | Backend type (ollama/openai/openai-compatible/lm-studio/llamacpp/vllm/sglang/lemonade/lmdeploy/omlx) |
 | `X-Olla-Request-ID` | Unique request identifier |
 | `X-Olla-Response-Time` | Total processing time |
 

--- a/docs/content/integrations/api-translation/anthropic.md
+++ b/docs/content/integrations/api-translation/anthropic.md
@@ -59,6 +59,7 @@ Olla's Anthropic API Translation enables Claude-compatible clients (Claude Code,
                 <li>llama.cpp</li>
                 <li>Lemonade SDK</li>
                 <li>LiteLLM</li>
+                <li>oMLX</li>
                 <li>Any OpenAI-compatible endpoint</li>
             </ul>
         </td>

--- a/docs/content/integrations/api-translation/anthropic.md
+++ b/docs/content/integrations/api-translation/anthropic.md
@@ -527,6 +527,7 @@ These backends natively support the Anthropic Messages API and benefit from pass
 | **llama.cpp** | b4847+ | Yes | `api.anthropic_support` in `config/profiles/llamacpp.yaml` |
 | **LM Studio** | v0.4.1+ | No | `api.anthropic_support` in `config/profiles/lmstudio.yaml` |
 | **Ollama** | v0.14.0+ | No | `api.anthropic_support` in `config/profiles/ollama.yaml` |
+| **oMLX** | -- | No | `api.anthropic_support` in `config/profiles/omlx.yaml` |
 
 When using these backends, Olla automatically detects native Anthropic support and forwards requests directly. You can verify passthrough mode is active by checking the `X-Olla-Mode: passthrough` response header.
 

--- a/docs/content/integrations/backend/omlx.md
+++ b/docs/content/integrations/backend/omlx.md
@@ -1,0 +1,522 @@
+---
+title: oMLX Integration - Multi-Model Apple Silicon Inference with Olla
+description: Configure oMLX with Olla proxy for multi-model LLM serving on Apple Silicon. Concurrent models, tiered hot/cold KV cache, native Anthropic Messages API, and OpenAI compatibility.
+keywords: oMLX, Olla proxy, Apple Silicon, MLX, multi-model, KV cache, M1, M2, M3, M4, macOS, Anthropic, Claude Code
+---
+
+# oMLX Integration
+
+<table>
+    <tr>
+        <th>Home</th>
+        <td><a href="https://omlx.ai/">omlx.ai</a> (source: <a href="https://github.com/jundot/omlx">github.com/jundot/omlx</a>)</td>
+    </tr>
+    <tr>
+        <th>Since</th>
+        <td>Olla <code>v0.0.28</code></td>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td><code>omlx</code> (use in <a href="/olla/configuration/overview/#endpoint-configuration">endpoint configuration</a>)</td>
+    </tr>
+    <tr>
+        <th>Profile</th>
+        <td><code>omlx.yaml</code> (see <a href="https://github.com/thushan/olla/blob/main/config/profiles/omlx.yaml">latest</a>)</td>
+    </tr>
+    <tr>
+        <th>Features</th>
+        <td>
+            <ul>
+                <li>Proxy Forwarding</li>
+                <li>Health Check (native)</li>
+                <li>Model Unification</li>
+                <li>Model Detection &amp; Normalisation</li>
+                <li>OpenAI API Compatibility</li>
+                <li>Native Anthropic Messages API</li>
+                <li>Embeddings API</li>
+                <li>Reranking API</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Unsupported</th>
+        <td>
+            <ul>
+                <li>Native Token Counting (Olla uses the local estimator; oMLX's <code>/v1/messages/count_tokens</code> is not yet forwarded)</li>
+                <li>Model Load/Unload Control (oMLX manages residency itself; Olla does not proxy lifecycle endpoints)</li>
+                <li>Prometheus Metrics</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Attributes</th>
+        <td>
+            <ul>
+                <li>Apple Silicon Only (M1/M2/M3/M4, macOS 15.0+)</li>
+                <li>MLX Framework Acceleration</li>
+                <li>Unified Memory Architecture</li>
+                <li>Multi-Model Server (concurrent, lazy-loaded)</li>
+                <li>Tiered KV Cache (hot RAM + cold SSD)</li>
+                <li>LRU/TTL Eviction &amp; Model Pinning</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Prefixes</th>
+        <td>
+            <ul>
+                <li><code>/omlx</code> (see <a href="/olla/concepts/profile-system/#routing-prefixes">Routing Prefixes</a>)</li>
+            </ul>
+        </td>
+    </tr>
+    <tr>
+        <th>Endpoints</th>
+        <td>
+            See <a href="#endpoints-supported">below</a>
+        </td>
+    </tr>
+</table>
+
+oMLX is a multi-model inference server for Apple Silicon, managed from the macOS menu bar. Unlike single-model MLX servers, a single oMLX instance serves many models concurrently, loading them on demand and evicting the least-recently-used ones when memory runs low. Because it is OpenAI-compatible on the wire, Olla reuses the standard OpenAI parser and forwards requests with no translation overhead.
+
+## Configuration
+
+### Basic Setup
+
+Add oMLX to your Olla configuration. A single endpoint exposes every model the server has discovered:
+
+```yaml
+discovery:
+  static:
+    endpoints:
+      - url: "http://localhost:8000"
+        name: "local-omlx"
+        type: "omlx"
+        priority: 75
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
+```
+
+!!! tip "Allow for cold starts"
+    oMLX loads models lazily, so the first request for a model that is not resident triggers a load that can take several seconds. The profile defaults to a 3-minute timeout to absorb this. Pin frequently used models in the oMLX admin panel to avoid cold starts on hot paths.
+
+### Apple Silicon Network Setup
+
+Place multiple Macs behind Olla and balance across them. Because each oMLX instance is multi-model, you do not need one endpoint per model:
+
+```yaml
+discovery:
+  static:
+    endpoints:
+      - url: "http://mac-studio:8000"
+        name: "omlx-studio"
+        type: "omlx"
+        priority: 90
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
+
+      - url: "http://mac-mini:8000"
+        name: "omlx-mini"
+        type: "omlx"
+        priority: 80
+        model_url: "/v1/models"
+        health_check_url: "/health"
+        check_interval: 5s
+        check_timeout: 2s
+
+proxy:
+  engine: "olla"        # High-performance engine
+  load_balancer: "priority"
+```
+
+## Anthropic Messages API Support
+
+oMLX natively implements the Anthropic Messages API, so Olla forwards Anthropic-format requests directly without the Anthropic-to-OpenAI-to-Anthropic translation round trip (passthrough mode).
+
+When Olla detects native Anthropic support (via the `anthropic_support` section in `config/profiles/omlx.yaml`), it bypasses the translation pipeline and sends requests straight to `/v1/messages` on the backend.
+
+**Profile configuration** (from `config/profiles/omlx.yaml`):
+
+```yaml
+api:
+  anthropic_support:
+    enabled: true
+    messages_path: /v1/messages
+    token_count: false
+```
+
+**Key details**:
+
+- Passthrough mode is automatic -- no client-side configuration needed
+- Responses include the `X-Olla-Mode: passthrough` header when passthrough is active
+- Falls back to translation mode if passthrough conditions are not met
+- Token counting (`/v1/messages/count_tokens`): oMLX implements this natively, but Olla currently answers token-count requests with its local estimator rather than forwarding them, so `token_count` is left `false`
+
+oMLX also ships a Claude Code context-scaling mode that rescales reported token counts so auto-compact fires at the right time on smaller-context models. This pairs well with pointing Claude Code at Olla's Anthropic endpoint.
+
+For more information, see [API Translation](../../concepts/api-translation.md#passthrough-mode) and [Anthropic API Reference](../../api-reference/anthropic.md).
+
+## Endpoints Supported
+
+The following endpoints are supported by the oMLX integration profile:
+
+<table>
+  <tr>
+    <th style="text-align: left;">Path</th>
+    <th style="text-align: left;">Description</th>
+  </tr>
+  <tr>
+    <td><code>/health</code></td>
+    <td>Health Check</td>
+  </tr>
+  <tr>
+    <td><code>/v1/models</code></td>
+    <td>List Models (OpenAI format; returns aliases where configured)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/models/status</code></td>
+    <td>Loaded-model state (oMLX-specific: residency, size, last access)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/chat/completions</code></td>
+    <td>Chat Completions (OpenAI format)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/completions</code></td>
+    <td>Text Completions (OpenAI format)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/embeddings</code></td>
+    <td>Embeddings API</td>
+  </tr>
+  <tr>
+    <td><code>/v1/rerank</code></td>
+    <td>Reranking API (Cohere/Jina-compatible)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/messages</code></td>
+    <td>Anthropic Messages API (native passthrough)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/messages/count_tokens</code></td>
+    <td>Anthropic token count (forwarded path; see note above)</td>
+  </tr>
+  <tr>
+    <td><code>/v1/responses</code></td>
+    <td>OpenAI Responses API</td>
+  </tr>
+</table>
+
+## Usage Examples
+
+### Chat Completion
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2.5-7B-Instruct-4bit",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Explain quantum computing in simple terms"}
+    ],
+    "temperature": 0.7,
+    "max_tokens": 500
+  }'
+```
+
+### Streaming Response
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen2.5-7B-Instruct-4bit",
+    "messages": [
+      {"role": "user", "content": "Write a story about a robot"}
+    ],
+    "stream": true,
+    "temperature": 0.8
+  }'
+```
+
+### Anthropic Messages API (Passthrough)
+
+```bash
+curl -X POST http://localhost:40114/olla/anthropic/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: not-needed" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "Qwen2.5-7B-Instruct-4bit",
+    "max_tokens": 500,
+    "messages": [
+      {"role": "user", "content": "Hello!"}
+    ]
+  }'
+```
+
+### Reranking
+
+```bash
+curl -X POST http://localhost:40114/olla/omlx/v1/rerank \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/bge-reranker-base",
+    "query": "What is unified memory?",
+    "documents": [
+      "Apple Silicon shares memory between CPU and GPU.",
+      "MLX is an array framework for Apple Silicon.",
+      "Discrete GPUs use separate VRAM."
+    ],
+    "top_n": 2
+  }'
+```
+
+### Loaded State, Models and Health
+
+```bash
+# List available models (aliases shown where configured)
+curl http://localhost:40114/olla/omlx/v1/models
+
+# Inspect which models are currently resident in memory
+curl http://localhost:40114/olla/omlx/v1/models/status
+
+# Check health status
+curl http://localhost:40114/olla/omlx/health
+```
+
+## oMLX Specifics
+
+### Multi-Model Serving
+
+A single oMLX instance hosts many models at once and manages residency automatically. This is the key difference from single-model MLX servers and shapes how you configure Olla:
+
+- **Lazy loading**: models load on first request. Expect a cold-start delay the first time a model is used after startup or eviction.
+- **LRU eviction**: the least-recently-used model is unloaded automatically when memory runs low.
+- **Model pinning**: pin frequently used models in the admin panel so they stay resident.
+- **Per-model TTL**: set an idle timeout per model to auto-unload after inactivity.
+- **Process memory enforcement**: a total memory ceiling (default: system RAM minus 8GB) prevents system-wide out-of-memory conditions.
+
+Because the server already discovers and exposes every model through `/v1/models`, you typically need **one Olla endpoint per oMLX instance**, not one per model.
+
+### Tiered KV Cache (Hot + Cold)
+
+oMLX keeps KV cache blocks across two tiers: a hot tier in RAM and a cold tier on SSD (safetensors). When the hot cache fills, blocks spill to disk and are restored from a matching prefix on the next request instead of being recomputed -- even after a server restart. This makes multi-turn, tool-heavy workloads (such as coding agents) far cheaper to resume.
+
+### Model Naming and Aliases
+
+oMLX discovers models from subdirectories, so model IDs are directory names such as `Qwen2.5-7B-Instruct-4bit`, or a custom alias configured per model in the admin panel.
+
+!!! note "Aliases vs directory names"
+    `/v1/models` returns the **alias** when one is configured, and requests accept both the alias and the directory name. The oMLX-specific `/v1/models/status` endpoint reports residency keyed by **directory name**. Olla discovers models from `/v1/models`, so the names you see in [unified models](../../concepts/model-unification.md) are the aliases.
+
+### Resource Configuration
+
+The oMLX profile uses Apple Silicon-oriented defaults. Concurrency is deliberately conservative because several models may share unified memory simultaneously:
+
+```yaml
+characteristics:
+  timeout: 3m                 # Absorbs cold-start model loads
+  max_concurrent_requests: 4
+  streaming_support: true
+
+resources:
+  defaults:
+    requires_gpu: false       # Unified memory, no discrete GPU
+```
+
+### Memory Requirements
+
+Unified memory is shared between macOS and every loaded model. Because oMLX holds several models at once, size your Mac for the *sum* of the models you intend to keep resident, plus headroom for the OS:
+
+| Mac unified memory | Comfortable resident set | Notes |
+|--------------------|--------------------------|-------|
+| 16GB | One 7-8B (4bit) model | Pin one model; expect evictions |
+| 32GB | A 7-8B model plus an embedding/rerank model | Good for a single-user coding setup |
+| 64GB | Several 7-13B models, or one 30B (4bit) | Comfortable multi-model |
+| 128GB+ | A 70B (4bit) model with room for helpers | Mac Studio territory |
+
+## Starting oMLX Server
+
+oMLX runs only on Apple Silicon Macs (M1/M2/M3/M4) with macOS 15.0+ (Sequoia) and Python 3.10+.
+
+### macOS App
+
+Download the `.dmg` from [Releases](https://github.com/jundot/omlx/releases), drag oMLX to Applications, and launch it. The welcome flow walks through choosing a model directory, starting the server, and downloading a first model. The server listens on `http://localhost:8000` by default.
+
+### Homebrew
+
+```bash
+brew tap jundot/omlx https://github.com/jundot/omlx
+brew install omlx
+
+# Run as a managed background service (auto-restarts on crash)
+omlx start
+```
+
+### From Source
+
+```bash
+git clone https://github.com/jundot/omlx.git
+cd omlx
+pip install -e .
+
+# Foreground server attached to this terminal
+omlx serve --model-dir ~/models
+```
+
+The server auto-discovers LLMs, VLMs, embedding models, and rerankers from subdirectories of the model directory. Any OpenAI-compatible client can then connect to `http://localhost:8000/v1`.
+
+## Profile Customisation
+
+To customise oMLX behaviour, create `config/profiles/omlx-custom.yaml`. See [Profile Configuration](../../concepts/profile-system.md) for detailed explanations of each section.
+
+### Example Customisation
+
+```yaml
+name: omlx
+version: "1.0"
+
+# Add custom prefixes
+routing:
+  prefixes:
+    - omlx
+    - mlx       # Add an alternate prefix
+
+# Allow longer cold starts for very large models
+characteristics:
+  timeout: 5m
+
+# Raise concurrency on a high-memory Mac
+resources:
+  concurrency_limits:
+    - min_memory_gb: 0
+      max_concurrent: 8
+```
+
+See [Profile Configuration](../../concepts/profile-system.md) for complete customisation options.
+
+## Troubleshooting
+
+### Apple Silicon and macOS Version
+
+**Issue**: oMLX fails to start or install
+
+**Solution**: oMLX requires an Apple Silicon Mac running macOS 15.0+ (Sequoia). It does not run on Intel Macs, Linux, or Windows. Verify your hardware:
+
+```bash
+sysctl -n machdep.cpu.brand_string   # Should show "Apple M1", "Apple M2", etc.
+sw_vers -productVersion              # Should be 15.0 or later
+```
+
+### Cold-Start Latency
+
+**Issue**: The first request to a model is slow or times out
+
+**Solution**: oMLX loads models lazily, so the first request after startup or eviction pays a load cost. Either raise the timeout or keep the model resident:
+
+```yaml
+characteristics:
+  timeout: 5m
+
+resources:
+  timeout_scaling:
+    base_timeout_seconds: 300
+    load_time_buffer: true
+```
+
+Pin the model in the oMLX admin panel so it stays loaded between requests.
+
+### Eviction Thrashing
+
+**Issue**: Models keep unloading and reloading, hurting latency
+
+**Solution**: Too many models are competing for unified memory. Reduce the resident set:
+
+1. Pin only the models you use most
+2. Set a per-model TTL so idle models unload cleanly
+3. Choose smaller quantisations (e.g. 4bit) to fit more models
+4. Raise the process memory ceiling only if you have headroom for macOS
+
+### Model Name Not Found
+
+**Issue**: A request returns a model-not-found error even though the model exists
+
+**Solution**: oMLX accepts both the alias and the directory name, but the name Olla advertises in `/olla/models` is whatever `/v1/models` returns (the alias when configured). List the models through Olla and use the name shown:
+
+```bash
+curl http://localhost:40114/olla/omlx/v1/models
+```
+
+## Best Practices
+
+### 1. One Endpoint per Instance
+
+Because oMLX is multi-model, configure a single Olla endpoint per server and let oMLX manage model residency. Avoid creating one endpoint per model.
+
+### 2. Pin Your Hot Models
+
+Pin the models on your critical paths (for example, the model behind your coding agent) so they never pay a cold-start cost.
+
+### 3. Size for the Resident Set
+
+Plan memory around the *sum* of models you keep loaded, not the largest single model, and leave several GB of headroom for macOS.
+
+### 4. Use the Olla Engine for Multiple Instances
+
+When balancing across several Macs, use the `olla` engine with the `priority` load balancer to prefer your fastest hardware.
+
+## Integration with Tools
+
+### OpenAI SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:40114/olla/omlx/v1",
+    api_key="not-needed"  # oMLX does not require API keys by default
+)
+
+response = client.chat.completions.create(
+    model="Qwen2.5-7B-Instruct-4bit",
+    messages=[
+        {"role": "user", "content": "Hello!"}
+    ]
+)
+```
+
+### Claude Code
+
+```bash
+# Point Claude Code at Olla's Anthropic endpoint
+export ANTHROPIC_BASE_URL="http://localhost:40114/olla/anthropic"
+
+# Requests use passthrough mode to oMLX automatically
+claude
+```
+
+### LangChain
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    base_url="http://localhost:40114/olla/omlx/v1",
+    api_key="not-needed",
+    model="Qwen2.5-7B-Instruct-4bit",
+    temperature=0.7
+)
+```
+
+## Next Steps
+
+- [Profile Configuration](../../concepts/profile-system.md) - Customise oMLX behaviour
+- [Model Unification](../../concepts/model-unification.md) - Understand model management
+- [Load Balancing](../../concepts/load-balancing.md) - Scale with multiple oMLX instances
+- [API Translation](../../concepts/api-translation.md) - Anthropic passthrough and translation modes

--- a/docs/content/integrations/backend/omlx.md
+++ b/docs/content/integrations/backend/omlx.md
@@ -203,7 +203,7 @@ The following endpoints are supported by the oMLX integration profile:
   </tr>
   <tr>
     <td><code>/v1/messages/count_tokens</code></td>
-    <td>Anthropic token count (forwarded path; see note above)</td>
+    <td>Anthropic token count -- forwarded to oMLX via this prefix; the <code>/olla/anthropic</code> route uses Olla's local estimator (<code>token_count: false</code>)</td>
   </tr>
   <tr>
     <td><code>/v1/responses</code></td>

--- a/docs/content/integrations/frontend/claude-code.md
+++ b/docs/content/integrations/frontend/claude-code.md
@@ -1,7 +1,7 @@
 ---
 title: Claude Code + Olla (Anthropic API) Integration
 description: Configure Claude Code to use local LLM models via Olla's Anthropic Messages API translator. Load-balancing, failover, streaming, and model unification for Ollama, LM Studio, vLLM, and other OpenAI-compatible backends.
-keywords: Claude Code, Olla, Anthropic API, Messages API, local LLM, Ollama, vLLM, LM Studio, load balancing, API translation
+keywords: Claude Code, Olla, Anthropic API, Messages API, local LLM, Ollama, vLLM, LM Studio, oMLX, load balancing, API translation
 ---
 
 # Claude Code Integration with Anthropic API
@@ -129,7 +129,7 @@ Before starting, ensure you have:
 
 3. **At Least One Backend**
    
-      * Ollama, LM Studio, vLLM, SGLang, llama.cpp or any OpenAI-compatible endpoint
+      * Ollama, LM Studio, vLLM, SGLang, llama.cpp, oMLX or any OpenAI-compatible endpoint
       * With at least one model loaded/available
 
 4. **Docker & Docker Compose** (for examples)

--- a/docs/content/integrations/overview.md
+++ b/docs/content/integrations/overview.md
@@ -24,6 +24,7 @@ Olla natively supports the following backends:
 | [Lemonade SDK](./backend/lemonade.md) | `lemonade` | Native support for [Lemonade SDK](https://lemonade-server.ai/), AMD's local inference solution with Ryzen AI optimisation, including model unification |
 | [LiteLLM](./backend/litellm.md) | `litellm` | Native support for [LiteLLM](https://github.com/BerriAI/litellm), providing unified gateway to 100+ LLM providers |
 | [Docker Model Runner](./backend/docker-model-runner.md) | `docker-model-runner` | Native support for [Docker Model Runner](https://docs.docker.com/ai/model-runner/), Docker Desktop's built-in LLM inference server with multi-engine support (llama.cpp and vLLM), OCI model distribution, and native Anthropic Messages API |
+| [oMLX](./backend/omlx.md) | `omlx` | Native support for [oMLX](https://github.com/jundot/omlx), a multi-model Apple Silicon (MLX) inference server managed from the macOS menu bar, with native Anthropic Messages API passthrough |
 | [OpenAI Compatible](https://platform.openai.com/docs/overview) | `openai` | Generic support for any OpenAI-compatible API |
 
 You can use the `type` in [Endpoint Configurations](/olla/configuration/overview/#endpoint-configuration) when adding new endpoints.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -129,7 +129,7 @@ server:
 
 ## How Olla is Used
 
-Olla sits between your applications and local AI runtimes (eg. Ollama, LM Studio, vLLM etc) to:
+Olla sits between your applications and local AI runtimes (eg. Ollama, LM Studio, vLLM, oMLX etc) to:
 
 * **Unify multiple local backends** under one consistent API.
 * **Route intelligently** between models based on size, speed, and task fit.
@@ -232,7 +232,7 @@ claude
 - ✅ **Streaming**: Real-time responses with Server-Sent Events
 - ✅ **Tool Use**: Function calling and tool integration
 - ✅ **Vision**: Multi-modal image input support
-- ✅ **Local Models**: Use Ollama, LM Studio, vLLM, llama.cpp
+- ✅ **Local Models**: Use Ollama, LM Studio, vLLM, llama.cpp, oMLX
 - ✅ **Load Balancing**: Automatic failover across backends
 
 ### Integration Guides

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
             - LiteLLM: integrations/backend/litellm.md
             - llama.cpp: integrations/backend/llamacpp.md
             - Docker Model Runner: integrations/backend/docker-model-runner.md
+            - oMLX: integrations/backend/omlx.md
         - Frontends:
             - OpenWebUI + Ollama: integrations/frontend/openwebui.md
             - OpenWebUI + OpenAI: integrations/frontend/openwebui-openai.md
@@ -201,6 +202,7 @@ nav:
           - LiteLLM: api-reference/litellm.md
           - llama.cpp: api-reference/llamacpp.md
           - Docker Model Runner: api-reference/docker-model-runner.md
+          - oMLX: api-reference/omlx.md
           - OpenAI: api-reference/openai.md
       - Translated APIs:
           - Anthropic Messages: api-reference/anthropic.md

--- a/internal/adapter/discovery/http_client.go
+++ b/internal/adapter/discovery/http_client.go
@@ -101,6 +101,7 @@ func (c *HTTPModelDiscoveryClient) discoverWithAutoDetection(ctx context.Context
 		domain.ProfileLlamaCpp,
 		domain.ProfileLmStudio,
 		domain.ProfileVLLM,
+		domain.ProfileOMLX,             // Apple Silicon only; tried after other common servers
 		domain.ProfileOpenAICompatible, /* last ditch effort */
 	}
 

--- a/internal/adapter/registry/profile/openai_compatible.go
+++ b/internal/adapter/registry/profile/openai_compatible.go
@@ -8,8 +8,9 @@ type OpenAICompatibleResponse struct {
 
 // OpenAICompatibleModel represents a model in OpenAI-compatible response
 type OpenAICompatibleModel struct {
-	Created *int64  `json:"created,omitempty"`
-	OwnedBy *string `json:"owned_by,omitempty"`
-	ID      string  `json:"id"`
-	Object  string  `json:"object"`
+	Created     *int64  `json:"created,omitempty"`
+	OwnedBy     *string `json:"owned_by,omitempty"`
+	MaxModelLen *int64  `json:"max_model_len,omitempty"`
+	ID          string  `json:"id"`
+	Object      string  `json:"object"`
 }

--- a/internal/adapter/registry/profile/openai_compatible_parser_test.go
+++ b/internal/adapter/registry/profile/openai_compatible_parser_test.go
@@ -178,4 +178,53 @@ func TestOpenAIParser_Parse(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse OpenAI-compatible response")
 	})
+
+	t.Run("owned_by is mapped to Publisher", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+					"object": "model",
+					"owned_by": "omlx"
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		m := models[0]
+		require.NotNil(t, m.Details)
+		require.NotNil(t, m.Details.Publisher)
+		assert.Equal(t, "omlx", *m.Details.Publisher)
+	})
+
+	t.Run("empty owned_by does not set Publisher", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "some-model",
+					"object": "model",
+					"owned_by": ""
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		// empty string must not produce a Details entry or a Publisher pointer
+		m := models[0]
+		if m.Details != nil {
+			assert.Nil(t, m.Details.Publisher)
+		}
+	})
 }

--- a/internal/adapter/registry/profile/openai_compatible_parser_test.go
+++ b/internal/adapter/registry/profile/openai_compatible_parser_test.go
@@ -1,0 +1,181 @@
+package profile
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIParser_Parse(t *testing.T) {
+	t.Parallel()
+
+	parser := &openAIParser{}
+
+	t.Run("captures max_model_len into MaxContextLength", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+					"object": "model",
+					"created": 1700000000,
+					"owned_by": "omlx",
+					"max_model_len": 32768
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		m := models[0]
+		assert.Equal(t, "mlx-community/Qwen2.5-7B-Instruct-4bit", m.Name)
+		require.NotNil(t, m.Details)
+		require.NotNil(t, m.Details.MaxContextLength)
+		assert.Equal(t, int64(32768), *m.Details.MaxContextLength)
+	})
+
+	t.Run("max_model_len coexists with created timestamp", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "some-model",
+					"object": "model",
+					"created": 1677610602,
+					"owned_by": "provider",
+					"max_model_len": 131072
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		m := models[0]
+		require.NotNil(t, m.Details)
+		require.NotNil(t, m.Details.MaxContextLength)
+		assert.Equal(t, int64(131072), *m.Details.MaxContextLength)
+		// created timestamp must still be mapped
+		require.NotNil(t, m.Details.ModifiedAt)
+		assert.Equal(t, time.Unix(1677610602, 0), *m.Details.ModifiedAt)
+	})
+
+	t.Run("absence of max_model_len leaves details unaffected", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "gpt-3.5-turbo",
+					"object": "model",
+					"created": 1677610602,
+					"owned_by": "openai"
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		m := models[0]
+		// Details may exist (due to created), but MaxContextLength must be nil
+		if m.Details != nil {
+			assert.Nil(t, m.Details.MaxContextLength)
+		}
+	})
+
+	t.Run("model without any metadata has nil details", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "bare-model",
+					"object": "model"
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		assert.Nil(t, models[0].Details)
+	})
+
+	t.Run("zero max_model_len does not set MaxContextLength", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"id": "zero-context-model",
+					"object": "model",
+					"max_model_len": 0
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+
+		// Neither details nor MaxContextLength should be set for a zero value
+		m := models[0]
+		if m.Details != nil {
+			assert.Nil(t, m.Details.MaxContextLength)
+		}
+	})
+
+	t.Run("skips models without ID", func(t *testing.T) {
+		t.Parallel()
+
+		response := `{
+			"object": "list",
+			"data": [
+				{
+					"object": "model",
+					"max_model_len": 4096
+				},
+				{
+					"id": "valid-model",
+					"object": "model"
+				}
+			]
+		}`
+
+		models, err := parser.Parse([]byte(response))
+		require.NoError(t, err)
+		require.Len(t, models, 1)
+		assert.Equal(t, "valid-model", models[0].Name)
+	})
+
+	t.Run("handles empty body", func(t *testing.T) {
+		t.Parallel()
+
+		models, err := parser.Parse([]byte{})
+		require.NoError(t, err)
+		assert.Empty(t, models)
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parser.Parse([]byte(`{"data": [invalid`))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse OpenAI-compatible response")
+	})
+}

--- a/internal/adapter/registry/profile/parsers.go
+++ b/internal/adapter/registry/profile/parsers.go
@@ -245,6 +245,10 @@ func (p *openAIParser) Parse(data []byte) ([]*domain.ModelInfo, error) {
 				details.MaxContextLength = model.MaxModelLen
 			}
 
+			if model.OwnedBy != nil && *model.OwnedBy != "" {
+				details.Publisher = model.OwnedBy
+			}
+
 			modelInfo.Details = details
 		}
 

--- a/internal/adapter/registry/profile/parsers.go
+++ b/internal/adapter/registry/profile/parsers.go
@@ -227,13 +227,22 @@ func (p *openAIParser) Parse(data []byte) ([]*domain.ModelInfo, error) {
 			LastSeen: now,
 		}
 
-		// openai is stingy with metadata
-		if (model.Created != nil && *model.Created > 0) || model.OwnedBy != nil {
+		// openai is stingy with metadata, but some compatible backends (e.g. oMLX)
+		// include max_model_len which is worth surfacing
+		hasDetails := (model.Created != nil && *model.Created > 0) ||
+			model.OwnedBy != nil ||
+			(model.MaxModelLen != nil && *model.MaxModelLen > 0)
+
+		if hasDetails {
 			details := &domain.ModelDetails{}
 
 			if model.Created != nil && *model.Created > 0 {
 				createdTime := time.Unix(*model.Created, 0)
 				details.ModifiedAt = &createdTime
+			}
+
+			if model.MaxModelLen != nil && *model.MaxModelLen > 0 {
+				details.MaxContextLength = model.MaxModelLen
 			}
 
 			modelInfo.Details = details

--- a/internal/app/handlers/handler_common.go
+++ b/internal/app/handlers/handler_common.go
@@ -86,6 +86,7 @@ func (a *Application) isProviderSupported(provider string) bool {
 		constants.ProviderTypeOpenAI:   true,
 		constants.ProviderTypeSGLang:   true,
 		constants.ProviderTypeVLLM:     true,
+		constants.ProviderTypeOMLX:     true,
 	}
 	return staticProviders[normalised]
 }

--- a/internal/app/handlers/handler_common_test.go
+++ b/internal/app/handlers/handler_common_test.go
@@ -123,6 +123,7 @@ func TestIsProviderSupported(t *testing.T) {
 			{"lm_studio supported", "lm_studio", true},
 			{"openai supported", "openai", true},
 			{"vllm supported", "vllm", true},
+			{"omlx supported", "omlx", true},
 			{"unknown not supported", "unknown", false},
 			{"empty not supported", "", false},
 		}

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -40,10 +40,12 @@ func (a *Application) createProviderProfile(providerType string) *domain.Request
 				}
 			}
 		} else {
-			// Tests get a minimal set without full profile loading
+			// Test/static fallback — must track the openai-compatible types in
+			// isProviderSupported (handler_common.go) and getStaticProviders (server_routes.go)
 			profile.AddSupportedProfile(constants.ProviderTypeOpenAI)
 			profile.AddSupportedProfile(constants.ProviderTypeVLLM)
 			profile.AddSupportedProfile(constants.ProviderTypeLemonade)
+			profile.AddSupportedProfile(constants.ProviderTypeOMLX)
 		}
 	} else {
 		// Non-OpenAI providers only route to their specific backend type

--- a/internal/app/handlers/handler_provider_compatibility_test.go
+++ b/internal/app/handlers/handler_provider_compatibility_test.go
@@ -138,6 +138,25 @@ func TestProviderCompatibility(t *testing.T) {
 			providerType: "lemonade",
 			compatible:   false,
 		},
+		// oMLX provider should only accept omlx endpoints
+		{
+			name:         "omlx provider accepts omlx",
+			endpointType: "omlx",
+			providerType: "omlx",
+			compatible:   true,
+		},
+		{
+			name:         "omlx provider rejects ollama",
+			endpointType: "ollama",
+			providerType: "omlx",
+			compatible:   false,
+		},
+		{
+			name:         "omlx provider rejects vllm",
+			endpointType: "vllm",
+			providerType: "omlx",
+			compatible:   false,
+		},
 		// Unknown provider should reject everything
 		{
 			name:         "unknown provider rejects ollama",
@@ -215,6 +234,26 @@ func TestProviderCompatibility_RealFactory(t *testing.T) {
 			providerType: "openai-compatible",
 			endpointType: "openai",
 			wantCompat:   true,
+		},
+		// oMLX is OpenAI-compatible — openai provider must include it
+		{
+			name:         "openai provider accepts omlx-typed endpoint",
+			providerType: "openai",
+			endpointType: "omlx",
+			wantCompat:   true,
+		},
+		// oMLX provider stays scoped to its own endpoints
+		{
+			name:         "omlx provider accepts omlx-typed endpoint",
+			providerType: "omlx",
+			endpointType: "omlx",
+			wantCompat:   true,
+		},
+		{
+			name:         "omlx provider rejects ollama-typed endpoint",
+			providerType: "omlx",
+			endpointType: "ollama",
+			wantCompat:   false,
 		},
 		// Provider-specific routes must stay scoped.
 		{

--- a/internal/app/handlers/server_routes.go
+++ b/internal/app/handlers/server_routes.go
@@ -340,6 +340,13 @@ func getStaticProviders(a *Application) map[string]staticProvider {
 				{path: "", handler: a.providerProxyHandler, description: "vLLM proxy", isProxy: true},
 			},
 		},
+		constants.ProviderTypeOMLX: {
+			prefixes: []string{constants.ProviderPrefixOMLX},
+			routes: []staticRoute{
+				{path: "v1/models", handler: a.genericProviderModelsHandler(constants.ProviderTypeOMLX, constants.ProviderTypeOpenAI), description: "oMLX models (OpenAI format)", method: "GET"},
+				{path: "", handler: a.providerProxyHandler, description: "oMLX proxy", isProxy: true},
+			},
+		},
 	}
 }
 

--- a/internal/core/constants/providers.go
+++ b/internal/core/constants/providers.go
@@ -12,6 +12,7 @@ const (
 	ProviderTypeVLLM         = "vllm"
 	ProviderTypeVLLMMLX      = "vllm-mlx"
 	ProviderTypeDockerMR     = "docker-model-runner"
+	ProviderTypeOMLX         = "omlx"
 
 	// Provider display names
 	ProviderDisplayOllama   = "Ollama"
@@ -24,6 +25,7 @@ const (
 	ProviderDisplayVLLM     = "vLLM"
 	ProviderDisplayVLLMMLX  = "vLLM-MLX"
 	ProviderDisplayDockerMR = "Docker Model Runner"
+	ProviderDisplayOMLX     = "oMLX"
 
 	// Common provider prefixes
 	// llama.cpp provider prefixes
@@ -38,4 +40,6 @@ const (
 	ProviderPrefixVLLMMLX2 = "vllmmlx"
 	// Docker Model Runner provider prefix
 	ProviderPrefixDockerMR = "dmr"
+	// oMLX provider prefix
+	ProviderPrefixOMLX = "omlx"
 )

--- a/internal/core/constants/providers_test.go
+++ b/internal/core/constants/providers_test.go
@@ -6,6 +6,42 @@ import (
 	"github.com/thushan/olla/internal/core/constants"
 )
 
+func TestOMLXProviderConstants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("provider type constant", func(t *testing.T) {
+		t.Parallel()
+		expected := "omlx"
+		if constants.ProviderTypeOMLX != expected {
+			t.Errorf("ProviderTypeOMLX: expected %q, got %q", expected, constants.ProviderTypeOMLX)
+		}
+	})
+
+	t.Run("display name constant", func(t *testing.T) {
+		t.Parallel()
+		expected := "oMLX"
+		if constants.ProviderDisplayOMLX != expected {
+			t.Errorf("ProviderDisplayOMLX: expected %q, got %q", expected, constants.ProviderDisplayOMLX)
+		}
+	})
+
+	t.Run("routing prefix", func(t *testing.T) {
+		t.Parallel()
+		expected := "omlx"
+		if constants.ProviderPrefixOMLX != expected {
+			t.Errorf("ProviderPrefixOMLX: expected %q, got %q", expected, constants.ProviderPrefixOMLX)
+		}
+	})
+
+	t.Run("type and prefix match", func(t *testing.T) {
+		t.Parallel()
+		// oMLX uses a single prefix that matches the type directly — no alias variations needed
+		if constants.ProviderTypeOMLX != constants.ProviderPrefixOMLX {
+			t.Errorf("ProviderTypeOMLX %q should equal ProviderPrefixOMLX %q", constants.ProviderTypeOMLX, constants.ProviderPrefixOMLX)
+		}
+	})
+}
+
 func TestLlamaCppProviderConstants(t *testing.T) {
 	t.Run("provider type constant", func(t *testing.T) {
 		expected := "llamacpp"

--- a/internal/core/domain/profile.go
+++ b/internal/core/domain/profile.go
@@ -15,6 +15,7 @@ const (
 	ProfileOpenAI           = "openai"
 	ProfileOpenAICompatible = "openai-compatible"
 	ProfileDockerMR         = "docker-model-runner"
+	ProfileOMLX             = "omlx"
 	ProfileAuto             = "auto"
 )
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -39,6 +39,7 @@ var (
 		"llamacpp",
 		"lmdeploy",
 		"lm_studio",
+		"omlx",
 		"sglang",
 		"vllm",
 		"vllm-mlx",


### PR DESCRIPTION
Adds native support for [oMLX](https://github.com/jundot/omlx) backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added oMLX local AI runtime backend support with native Anthropic Messages API passthrough
  * OpenAI‑compatible backends now surface maximum context length information

* **Documentation**
  * Comprehensive oMLX docs and API reference added, including setup, examples (streaming/chat/embeddings), headers, and troubleshooting guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->