### PR TITLE
feat: olla hardening June  2026

### DIFF
--- a/internal/adapter/proxy/core/base.go
+++ b/internal/adapter/proxy/core/base.go
@@ -54,9 +54,6 @@ type BaseProxyComponents struct {
 	EventBus         *eventbus.EventBus[ProxyEvent]
 
 	Stats ProxyStats
-
-	// Atomic counters for request tracking
-	totalRequests atomic.Int64
 }
 
 // NewBaseProxyComponents creates a new BaseProxyComponents instance
@@ -79,7 +76,6 @@ func NewBaseProxyComponents(
 
 // IncrementRequests increments the total request counter
 func (b *BaseProxyComponents) IncrementRequests() {
-	b.totalRequests.Add(1)
 	atomic.AddInt64(&b.Stats.TotalRequests, 1)
 }
 

--- a/internal/adapter/proxy/core/common.go
+++ b/internal/adapter/proxy/core/common.go
@@ -221,7 +221,14 @@ func CopyResponseHeaders(dst http.Header, src http.Header, endpoint *domain.Endp
 	}
 
 	for key, values := range src {
-		if _, blocked := deny[http.CanonicalHeaderKey(key)]; blocked {
+		canonical := http.CanonicalHeaderKey(key)
+		if _, blocked := deny[canonical]; blocked {
+			continue
+		}
+		// Strip any X-Olla-* header the backend tries to inject. Olla is the sole
+		// authority for these headers; a spoofed value from a compromised backend
+		// would confuse clients relying on them for routing or session affinity.
+		if strings.HasPrefix(canonical, constants.HeaderXOllaPrefix) {
 			continue
 		}
 		for _, v := range values {

--- a/internal/adapter/proxy/core/common_test.go
+++ b/internal/adapter/proxy/core/common_test.go
@@ -963,6 +963,73 @@ func TestCopyResponseHeaders_PassesThroughUndeniedHeader(t *testing.T) {
 	}
 }
 
+// TestCopyResponseHeaders_StripsBackendSpoofedXOllaHeaders verifies that any
+// X-Olla-* header a backend injects into its response is stripped before it
+// reaches the client. Olla is the sole authority for X-Olla-* response headers;
+// a spoofed value from a compromised backend would mislead clients relying on
+// them for routing decisions or session affinity.
+func TestCopyResponseHeaders_StripsBackendSpoofedXOllaHeaders(t *testing.T) {
+	t.Parallel()
+
+	spoofedHeaders := []string{
+		"X-Olla-Endpoint",
+		"X-Olla-Model",
+		"X-Olla-Backend-Type",
+		"X-Olla-Request-ID",
+		"X-Olla-Response-Time",
+		"X-Olla-Routing-Strategy",
+		"X-Olla-Sticky-Session",
+		"X-Olla-Mode",
+		"X-Olla-Custom-Unknown", // unknown future header, must also be stripped
+	}
+
+	for _, header := range spoofedHeaders {
+
+		t.Run("strips_"+header, func(t *testing.T) {
+			t.Parallel()
+
+			src := http.Header{}
+			src.Set(header, "spoofed-value")
+			src.Set("Content-Type", "application/json") // safe header must pass through
+
+			dst := http.Header{}
+			CopyResponseHeaders(dst, src, nil)
+
+			if got := dst.Get(header); got != "" {
+				t.Errorf("CopyResponseHeaders forwarded spoofed %q = %q to client, want empty", header, got)
+			}
+			if got := dst.Get("Content-Type"); got == "" {
+				t.Error("CopyResponseHeaders stripped safe Content-Type header")
+			}
+		})
+	}
+}
+
+// TestCopyResponseHeaders_OllaSetsThenCopiesAreNotDoubled proves that when Olla
+// sets its own X-Olla-Endpoint on dst before calling CopyResponseHeaders, the
+// backend spoof does not create a second value (dst.Add would append; stripping
+// prevents this entirely).
+func TestCopyResponseHeaders_OllaSetsThenCopiesAreNotDoubled(t *testing.T) {
+	t.Parallel()
+
+	src := http.Header{}
+	src.Set("X-Olla-Endpoint", "spoofed-backend")
+	src.Set("Content-Type", "application/json")
+
+	dst := http.Header{}
+	dst.Set("X-Olla-Endpoint", "olla-real-value")
+
+	CopyResponseHeaders(dst, src, nil)
+
+	vals := dst.Values("X-Olla-Endpoint")
+	if len(vals) != 1 {
+		t.Errorf("expected exactly 1 X-Olla-Endpoint value, got %d: %v", len(vals), vals)
+	}
+	if vals[0] != "olla-real-value" {
+		t.Errorf("X-Olla-Endpoint = %q, want %q", vals[0], "olla-real-value")
+	}
+}
+
 // BenchmarkSetResponseHeaders benchmarks the SetResponseHeaders function
 func BenchmarkSetResponseHeaders(b *testing.B) {
 	stats := &ports.RequestStats{

--- a/internal/adapter/proxy/core/common_test.go
+++ b/internal/adapter/proxy/core/common_test.go
@@ -1023,7 +1023,7 @@ func TestCopyResponseHeaders_OllaSetsThenCopiesAreNotDoubled(t *testing.T) {
 
 	vals := dst.Values("X-Olla-Endpoint")
 	if len(vals) != 1 {
-		t.Errorf("expected exactly 1 X-Olla-Endpoint value, got %d: %v", len(vals), vals)
+		t.Fatalf("expected exactly 1 X-Olla-Endpoint value, got %d: %v", len(vals), vals)
 	}
 	if vals[0] != "olla-real-value" {
 		t.Errorf("X-Olla-Endpoint = %q, want %q", vals[0], "olla-real-value")

--- a/internal/adapter/proxy/olla/benchmark_url_building_test.go
+++ b/internal/adapter/proxy/olla/benchmark_url_building_test.go
@@ -40,7 +40,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.Load().GetProxyPrefix())
 			if targetURL.Path != "/v1/chat/completions" {
 				b.Fatalf("unexpected path: %s", targetURL.Path)
 			}
@@ -64,7 +64,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.Load().GetProxyPrefix())
 			if targetURL.Path != "/v1/completions" {
 				b.Fatalf("unexpected path: %s", targetURL.Path)
 			}
@@ -85,7 +85,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.Load().GetProxyPrefix())
 			if targetURL.Path != "/api/tags" {
 				b.Fatalf("unexpected path: %s", targetURL.Path)
 			}
@@ -109,7 +109,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.Load().GetProxyPrefix())
 			// ResolveReference should join paths correctly
 			if targetURL.Host != "localhost:8000" {
 				b.Fatalf("unexpected host: %s", targetURL.Host)

--- a/internal/adapter/proxy/olla/benchmark_url_building_test.go
+++ b/internal/adapter/proxy/olla/benchmark_url_building_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thushan/olla/internal/adapter/proxy/common"
 	"github.com/thushan/olla/internal/core/domain"
 )
 
@@ -39,7 +40,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := service.buildTargetURL(req, endpoint)
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
 			if targetURL.Path != "/v1/chat/completions" {
 				b.Fatalf("unexpected path: %s", targetURL.Path)
 			}
@@ -63,7 +64,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := service.buildTargetURL(req, endpoint)
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
 			if targetURL.Path != "/v1/completions" {
 				b.Fatalf("unexpected path: %s", targetURL.Path)
 			}
@@ -84,7 +85,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := service.buildTargetURL(req, endpoint)
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
 			if targetURL.Path != "/api/tags" {
 				b.Fatalf("unexpected path: %s", targetURL.Path)
 			}
@@ -108,7 +109,7 @@ func BenchmarkBuildTargetURL(b *testing.B) {
 		b.ReportAllocs()
 
 		for range b.N {
-			targetURL := service.buildTargetURL(req, endpoint)
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
 			// ResolveReference should join paths correctly
 			if targetURL.Host != "localhost:8000" {
 				b.Fatalf("unexpected host: %s", targetURL.Host)

--- a/internal/adapter/proxy/olla/service.go
+++ b/internal/adapter/proxy/olla/service.go
@@ -66,7 +66,7 @@ type Service struct {
 	bufferPool *pool.Pool[*[]byte]
 
 	transport     *http.Transport
-	configuration *Configuration
+	configuration atomic.Pointer[Configuration]
 	retryHandler  *core.RetryHandler
 
 	cleanupTicker *time.Ticker
@@ -140,13 +140,13 @@ func NewService(
 		BaseProxyComponents: base,
 		bufferPool:          bufferPool,
 		transport:           transport,
-		configuration:       configuration,
 		retryHandler:        core.NewRetryHandler(discoveryService, logger),
 		circuitBreakers:     *xsync.NewMap[string, *circuitBreaker](),
 		endpointPools:       *xsync.NewMap[string, *connectionPool](),
 		cleanupTicker:       time.NewTicker(5 * time.Minute),
 		cleanupStop:         make(chan struct{}),
 	}
+	service.configuration.Store(configuration)
 
 	// Start cleanup goroutine
 	go service.cleanupLoop()
@@ -192,36 +192,33 @@ func createOptimisedTransport(config *Configuration) *http.Transport {
 	}
 }
 
-// getOrCreateEndpointPool returns a connection pool for the endpoint
+// getOrCreateEndpointPool returns a connection pool for the endpoint.
+// LoadOrCompute guarantees the transport is constructed at most once per endpoint key,
+// preventing wasted allocations when multiple goroutines race on first use.
 func (s *Service) getOrCreateEndpointPool(endpoint string) *connectionPool {
-	if pool, ok := s.endpointPools.Load(endpoint); ok {
-		atomic.StoreInt64(&pool.lastUsed, time.Now().UnixNano())
-		return pool
-	}
-
-	newPool := &connectionPool{
-		transport: createOptimisedTransport(s.configuration),
-		lastUsed:  time.Now().UnixNano(),
-		healthy:   1,
-	}
-
-	actual, _ := s.endpointPools.LoadOrStore(endpoint, newPool)
-	return actual
+	cfg := s.configuration.Load()
+	pool, _ := s.endpointPools.LoadOrCompute(endpoint, func() (*connectionPool, bool) {
+		return &connectionPool{
+			transport: createOptimisedTransport(cfg),
+			lastUsed:  time.Now().UnixNano(),
+			healthy:   1,
+		}, false
+	})
+	atomic.StoreInt64(&pool.lastUsed, time.Now().UnixNano())
+	return pool
 }
 
-// GetCircuitBreaker returns the circuit breaker for an endpoint (exported for testing)
+// GetCircuitBreaker returns the circuit breaker for an endpoint (exported for testing).
+// LoadOrCompute guarantees exactly one circuitBreaker is created per endpoint even
+// under concurrent first-use, avoiding a redundant allocation race.
 func (s *Service) GetCircuitBreaker(endpoint string) *circuitBreaker {
-	if cb, ok := s.circuitBreakers.Load(endpoint); ok {
-		return cb
-	}
-
-	newCB := &circuitBreaker{
-		threshold: circuitBreakerThreshold,
-		state:     0, // closed
-	}
-
-	actual, _ := s.circuitBreakers.LoadOrStore(endpoint, newCB)
-	return actual
+	cb, _ := s.circuitBreakers.LoadOrCompute(endpoint, func() (*circuitBreaker, bool) {
+		return &circuitBreaker{
+			threshold: circuitBreakerThreshold,
+			state:     0, // closed
+		}, false
+	})
+	return cb
 }
 
 // Circuit breaker methods
@@ -301,18 +298,23 @@ func (s *Service) prepareProxyRequest(ctx context.Context, r *http.Request, targ
 // streamResponse performs buffered streaming with backpressure handling
 func (s *Service) streamResponse(clientCtx, upstreamCtx context.Context, w http.ResponseWriter, resp *http.Response, buffer []byte, rlog logger.StyledLogger) (int, []byte, error) {
 	state := &streamState{}
+	// Snapshot configuration once for the lifetime of this stream so all reads
+	// within the loop see a coherent config even if UpdateConfig runs concurrently.
+	cfg := s.configuration.Load()
+	readTimeout := cfg.GetReadTimeout()
+
 	// Use http.ResponseController for modern flush handling (Go 1.20+)
 	// Provides better error handling and cleaner API than type assertion
 	rc := http.NewResponseController(w)
-	isStreaming := core.AutoDetectStreamingMode(clientCtx, resp, s.configuration.GetProxyProfile())
+	isStreaming := core.AutoDetectStreamingMode(clientCtx, resp, cfg.GetProxyProfile())
 
 	// Pre-allocate timer to avoid allocations in hot path
-	readDeadline := time.NewTimer(s.configuration.GetReadTimeout())
+	readDeadline := time.NewTimer(readTimeout)
 	defer readDeadline.Stop()
 
 	for {
 		// Check for context cancellation
-		if err := s.checkContexts(clientCtx, upstreamCtx, readDeadline, state, rlog); err != nil {
+		if err := s.checkContexts(clientCtx, upstreamCtx, readDeadline, readTimeout, state, rlog); err != nil {
 			return state.totalBytes, state.lastChunk, err
 		}
 
@@ -326,7 +328,7 @@ func (s *Service) streamResponse(clientCtx, upstreamCtx context.Context, w http.
 			default:
 			}
 		}
-		readDeadline.Reset(s.configuration.GetReadTimeout())
+		readDeadline.Reset(readTimeout)
 
 		// Read and process data
 		if err := s.processStreamData(resp, buffer, state, w, isStreaming, rc, rlog); err != nil {
@@ -344,7 +346,9 @@ func (s *Service) GetStats(ctx context.Context) (ports.ProxyStats, error) {
 	return s.GetProxyStats(), nil
 }
 
-// UpdateConfig updates the proxy configuration
+// UpdateConfig updates the proxy configuration.
+// The swap is atomic so in-flight requests always read a complete, consistent
+// snapshot — never a partially-written config.
 func (s *Service) UpdateConfig(config ports.ProxyConfiguration) {
 	newConfig := &Configuration{}
 	newConfig.ProxyPrefix = config.GetProxyPrefix()
@@ -354,6 +358,11 @@ func (s *Service) UpdateConfig(config ports.ProxyConfiguration) {
 	newConfig.ReadTimeout = config.GetReadTimeout()
 	newConfig.StreamBufferSize = config.GetStreamBufferSize()
 	newConfig.Profile = config.GetProxyProfile()
+
+	// Snapshot the current config once before deciding what to preserve.
+	// This single Load ensures the fallback branch reads a coherent value
+	// even if another UpdateConfig is racing concurrently.
+	current := s.configuration.Load()
 
 	// we try to get Olla-specific fields from incoming config if it's an *olla.Configuration
 	if ollaConfig, ok := config.(*Configuration); ok && ollaConfig != nil {
@@ -365,16 +374,15 @@ func (s *Service) UpdateConfig(config ports.ProxyConfiguration) {
 		newConfig.TLSHandshakeTimeout = ollaConfig.TLSHandshakeTimeout
 	} else {
 		// fallback: preserve current Olla-specific settings for non-Olla configs
-		newConfig.MaxIdleConns = s.configuration.MaxIdleConns
-		newConfig.IdleConnTimeout = s.configuration.IdleConnTimeout
-		newConfig.MaxConnsPerHost = s.configuration.MaxConnsPerHost
-		newConfig.MaxIdleConnsPerHost = s.configuration.MaxIdleConnsPerHost
-		newConfig.ResponseHeaderTimeout = s.configuration.ResponseHeaderTimeout
-		newConfig.TLSHandshakeTimeout = s.configuration.TLSHandshakeTimeout
+		newConfig.MaxIdleConns = current.MaxIdleConns
+		newConfig.IdleConnTimeout = current.IdleConnTimeout
+		newConfig.MaxConnsPerHost = current.MaxConnsPerHost
+		newConfig.MaxIdleConnsPerHost = current.MaxIdleConnsPerHost
+		newConfig.ResponseHeaderTimeout = current.ResponseHeaderTimeout
+		newConfig.TLSHandshakeTimeout = current.TLSHandshakeTimeout
 	}
 
-	// Update configuration atomically
-	s.configuration = newConfig
+	s.configuration.Store(newConfig)
 }
 
 // cleanupLoop periodically cleans up unused endpoint pools and circuit breakers

--- a/internal/adapter/proxy/olla/service.go
+++ b/internal/adapter/proxy/olla/service.go
@@ -29,8 +29,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"runtime"
-	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,10 +38,8 @@ import (
 	"github.com/puzpuzpuz/xsync/v4"
 
 	"github.com/thushan/olla/internal/adapter/health"
-	"github.com/thushan/olla/internal/adapter/proxy/common"
 	proxyconfig "github.com/thushan/olla/internal/adapter/proxy/config"
 	"github.com/thushan/olla/internal/adapter/proxy/core"
-	"github.com/thushan/olla/internal/app/middleware"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 	"github.com/thushan/olla/internal/logger"
@@ -66,10 +62,8 @@ const (
 type Service struct {
 	*core.BaseProxyComponents
 
-	// Object pools for zero-allocation operations
-	bufferPool  *pool.Pool[*[]byte]
-	requestPool *pool.Pool[*requestContext]
-	errorPool   *pool.Pool[*errorContext]
+	// Buffer pool for streaming
+	bufferPool *pool.Pool[*[]byte]
 
 	transport     *http.Transport
 	configuration *Configuration
@@ -99,38 +93,6 @@ type circuitBreaker struct {
 	lastFailure int64 // atomic
 	state       int64 // atomic: 0=closed, 1=open, 2=half-open
 	threshold   int64
-}
-
-// requestContext contains per-request data from our object pool
-type requestContext struct {
-	requestID string
-	startTime time.Time
-	endpoint  string
-	targetURL string
-}
-
-func (r *requestContext) Reset() {
-	r.requestID = ""
-	r.startTime = time.Time{}
-	r.endpoint = ""
-	r.targetURL = ""
-}
-
-// errorContext provides rich error information without allocations
-type errorContext struct {
-	err       error
-	context   string
-	duration  time.Duration
-	code      int
-	allocated bool
-}
-
-func (e *errorContext) Reset() {
-	e.err = nil
-	e.context = ""
-	e.duration = 0
-	e.code = 0
-	e.allocated = false
 }
 
 // NewService creates a new Olla proxy service
@@ -172,27 +134,11 @@ func NewService(
 		return nil, fmt.Errorf("failed to create buffer pool: %w", err)
 	}
 
-	requestPool, err := pool.NewLitePool(func() *requestContext {
-		return &requestContext{}
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request pool: %w", err)
-	}
-
-	errorPool, err := pool.NewLitePool(func() *errorContext {
-		return &errorContext{}
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create error pool: %w", err)
-	}
-
 	transport := createOptimisedTransport(configuration)
 
 	service := &Service{
 		BaseProxyComponents: base,
 		bufferPool:          bufferPool,
-		requestPool:         requestPool,
-		errorPool:           errorPool,
 		transport:           transport,
 		configuration:       configuration,
 		retryHandler:        core.NewRetryHandler(discoveryService, logger),
@@ -327,50 +273,6 @@ func (s *Service) ProxyRequestToEndpoints(ctx context.Context, w http.ResponseWr
 	return s.ProxyRequestToEndpointsWithRetry(ctx, w, r, endpoints, stats, rlog)
 }
 
-// handlePanic handles panic recovery in proxy requests
-func (s *Service) handlePanic(ctx context.Context, w http.ResponseWriter, r *http.Request, stats *ports.RequestStats, rlog logger.StyledLogger, rec interface{}, err *error) {
-	s.RecordFailure(ctx, nil, time.Since(stats.StartTime), fmt.Errorf("panic: %v", rec))
-
-	*err = fmt.Errorf("proxy panic recovered after %.1fs: %v", time.Since(stats.StartTime).Seconds(), rec)
-	rlog.Error("proxy request panic recovered",
-		"panic", rec,
-		"method", r.Method,
-		"path", r.URL.Path,
-		"stack", string(debug.Stack()))
-
-	if w.Header().Get(constants.HeaderContentType) == "" {
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-	}
-}
-
-// selectEndpointWithCircuitBreaker selects an endpoint that has a healthy circuit breaker
-func (s *Service) selectEndpointWithCircuitBreaker(endpoints []*domain.Endpoint, rlog logger.StyledLogger) (*domain.Endpoint, *circuitBreaker) {
-	for _, ep := range endpoints {
-		cb := s.GetCircuitBreaker(ep.Name)
-		stateBefore := atomic.LoadInt64(&cb.state)
-		if !cb.IsOpen() {
-			stateAfter := atomic.LoadInt64(&cb.state)
-			// Log state transition if it changed (Open -> Half-open)
-			if stateBefore == 1 && stateAfter == 2 {
-				rlog.Info("Circuit breaker entering half-open state",
-					"endpoint", ep.Name,
-					"timeout", health.DefaultCircuitBreakerTimeout)
-			}
-			return ep, cb
-		}
-		// Log when skipping endpoint due to open circuit breaker
-		rlog.Debug("Skipping endpoint due to open circuit breaker",
-			"endpoint", ep.Name,
-			"failures", atomic.LoadInt64(&cb.failures))
-	}
-	return nil, nil
-}
-
-// buildTargetURL builds the target URL for the proxy request
-func (s *Service) buildTargetURL(r *http.Request, endpoint *domain.Endpoint) *url.URL {
-	return common.BuildTargetURL(r, endpoint, s.configuration.GetProxyPrefix())
-}
-
 // prepareProxyRequest creates and prepares the proxy request with headers.
 // endpoint is passed through so CopyHeaders can apply per-endpoint auth and custom headers.
 func (s *Service) prepareProxyRequest(ctx context.Context, r *http.Request, targetURL *url.URL, endpoint *domain.Endpoint, stats *ports.RequestStats) (*http.Request, error) {
@@ -394,147 +296,6 @@ func (s *Service) prepareProxyRequest(ctx context.Context, r *http.Request, targ
 	stats.RequestProcessingMs = time.Since(stats.StartTime).Milliseconds()
 
 	return proxyReq, nil
-}
-
-// executeBackendRequest executes the request to the backend
-func (s *Service) executeBackendRequest(ctx context.Context, endpoint *domain.Endpoint, proxyReq *http.Request, cb *circuitBreaker, stats *ports.RequestStats, rlog logger.StyledLogger) (*http.Response, error) {
-	// Get connection pool for this endpoint
-	pool := s.getOrCreateEndpointPool(endpoint.Name)
-
-	// Execute request
-	rlog.Debug("making round-trip request", "target", proxyReq.URL.String())
-	backendStart := time.Now()
-	resp, err := pool.transport.RoundTrip(proxyReq)
-	stats.BackendResponseMs = time.Since(backendStart).Milliseconds()
-
-	if err != nil {
-		// Record failure and check if circuit breaker opened
-		failuresBefore := atomic.LoadInt64(&cb.failures)
-		cb.RecordFailure()
-		failuresAfter := atomic.LoadInt64(&cb.failures)
-
-		// Log if circuit breaker just opened (critical for monitoring)
-		if failuresBefore < cb.threshold && failuresAfter >= cb.threshold {
-			rlog.Warn("Circuit breaker opened",
-				"endpoint", endpoint.Name,
-				"failures", failuresAfter,
-				"threshold", cb.threshold,
-				"error", err)
-		}
-
-		rlog.Error("round-trip failed", "error", err)
-		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), err)
-
-		// Publish circuit breaker event if opened
-		if cb.IsOpen() {
-			s.PublishEvent(core.ProxyEvent{
-				Type:      core.EventTypeCircuitBreaker,
-				RequestID: stats.RequestID,
-				Endpoint:  endpoint.Name,
-				Error:     err,
-				Duration:  time.Since(stats.StartTime),
-			})
-		}
-
-		duration := time.Since(stats.StartTime)
-		return nil, common.MakeUserFriendlyError(err, duration, "backend", s.configuration.GetResponseTimeout())
-	}
-
-	return resp, nil
-}
-
-// handleSuccessfulResponse handles the successful response from the backend
-func (s *Service) handleSuccessfulResponse(ctx context.Context, w http.ResponseWriter, r *http.Request, resp *http.Response, endpoint *domain.Endpoint, cb *circuitBreaker, stats *ports.RequestStats, rlog logger.StyledLogger) error {
-	// Get context logger for this function scope
-	ctxLogger := middleware.GetLogger(ctx)
-	// Circuit breaker success
-	stateBefore := atomic.LoadInt64(&cb.state)
-	cb.RecordSuccess()
-	stateAfter := atomic.LoadInt64(&cb.state)
-
-	// Log state transition if circuit breaker closed
-	if stateBefore != 0 && stateAfter == 0 {
-		rlog.Info("Circuit breaker closed after successful request",
-			"endpoint", endpoint.Name,
-			"previous_state", map[int64]string{1: "open", 2: "half-open"}[stateBefore])
-	}
-
-	rlog.Debug("round-trip success", "status", resp.StatusCode)
-
-	core.SetResponseHeaders(w, stats, endpoint)
-	core.SetStickySessionHeaders(w, r)
-
-	// Copy response headers, stripping any sensitive headers the upstream may reflect
-	core.CopyResponseHeaders(w.Header(), resp.Header, endpoint)
-
-	w.WriteHeader(resp.StatusCode)
-
-	// start streaming the response body
-	rlog.Debug("starting response stream")
-	streamStart := time.Now()
-	stats.FirstDataMs = time.Since(stats.StartTime).Milliseconds()
-
-	buffer := s.bufferPool.Get()
-	defer s.bufferPool.Put(buffer)
-
-	// Separate client and upstream contexts for proper cancellation handling
-	// Only create a different context if needed to avoid allocations
-	upstreamCtx := ctx
-	if resp != nil && resp.Request != nil {
-		upstreamCtx = resp.Request.Context()
-	}
-
-	// Use r.Context() for client context and upstreamCtx for upstream context
-	bytesWritten, lastChunk, streamErr := s.streamResponse(r.Context(), upstreamCtx, w, resp, *buffer, rlog)
-	stats.StreamingMs = time.Since(streamStart).Milliseconds()
-	stats.TotalBytes = bytesWritten
-
-	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
-		rlog.Debug("streaming error", "error", streamErr, "bytes_written", bytesWritten)
-		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), streamErr)
-		return common.MakeUserFriendlyError(streamErr, time.Since(stats.StartTime), "streaming", s.configuration.GetResponseTimeout())
-	}
-
-	// Extract metrics from response if available
-	core.ExtractProviderMetrics(ctx, s.MetricsExtractor, lastChunk, endpoint, stats, rlog, "Olla")
-
-	// stats update
-	duration := time.Since(stats.StartTime)
-	s.RecordSuccess(endpoint, duration.Milliseconds(), int64(bytesWritten))
-
-	stats.EndTime = time.Now()
-	stats.Latency = duration.Milliseconds()
-
-	// Log detailed completion metrics at Debug level to reduce redundancy
-	if ctxLogger != nil {
-		ctxLogger.Debug("Olla proxy metrics",
-			"endpoint", endpoint.Name,
-			"latency_ms", stats.Latency,
-			"processing_ms", stats.RequestProcessingMs,
-			"backend_ms", stats.BackendResponseMs,
-			"first_data_ms", stats.FirstDataMs,
-			"streaming_ms", stats.StreamingMs,
-			"selection_ms", stats.SelectionMs,
-			"header_ms", stats.HeaderProcessingMs,
-			"total_bytes", stats.TotalBytes,
-			"bytes_formatted", middleware.FormatBytes(int64(stats.TotalBytes)),
-			"status", resp.StatusCode,
-			"request_id", middleware.GetRequestID(ctx))
-	} else {
-		rlog.Debug("proxy request completed",
-			"endpoint", endpoint.Name,
-			"latency_ms", stats.Latency,
-			"processing_ms", stats.RequestProcessingMs,
-			"backend_ms", stats.BackendResponseMs,
-			"first_data_ms", stats.FirstDataMs,
-			"streaming_ms", stats.StreamingMs,
-			"selection_ms", stats.SelectionMs,
-			"header_ms", stats.HeaderProcessingMs,
-			"total_bytes", stats.TotalBytes,
-			"status", resp.StatusCode)
-	}
-
-	return nil
 }
 
 // streamResponse performs buffered streaming with backpressure handling
@@ -700,9 +461,6 @@ func (s *Service) Cleanup() {
 		s.circuitBreakers.Clear()
 
 		s.BaseProxyComponents.Shutdown()
-
-		// force GC to clean up
-		runtime.GC()
 
 		s.Logger.Debug("Olla proxy service cleaned up")
 	})

--- a/internal/adapter/proxy/olla/service_concurrency_test.go
+++ b/internal/adapter/proxy/olla/service_concurrency_test.go
@@ -1,0 +1,159 @@
+package olla
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/thushan/olla/internal/adapter/proxy/core"
+)
+
+// TestUpdateConfig_ConcurrentReadWrite verifies that concurrent UpdateConfig calls
+// and configuration reads do not produce a data race. The race detector catches
+// torn pointer reads, so this test is only meaningful under -race.
+func TestUpdateConfig_ConcurrentReadWrite(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{
+		BaseProxyComponents: &core.BaseProxyComponents{
+			Logger: createTestLogger(),
+		},
+		endpointPools:   *xsync.NewMap[string, *connectionPool](),
+		circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
+	}
+	initial := &Configuration{}
+	initial.ReadTimeout = 10 * time.Second
+	initial.ResponseTimeout = 20 * time.Second
+	s.configuration.Store(initial)
+
+	const (
+		writers = 4
+		readers = 8
+		iters   = 500
+	)
+
+	var wg sync.WaitGroup
+
+	// Writers: repeatedly swap in a new config
+	for w := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := range iters {
+				cfg := &Configuration{}
+				// Alternate between two timeout values so readers can verify
+				// they always see a valid (non-zero) value, never a partial write.
+				if (id+i)%2 == 0 {
+					cfg.ReadTimeout = 10 * time.Second
+					cfg.ResponseTimeout = 20 * time.Second
+				} else {
+					cfg.ReadTimeout = 30 * time.Second
+					cfg.ResponseTimeout = 60 * time.Second
+				}
+				s.UpdateConfig(cfg)
+			}
+		}(w)
+	}
+
+	// Readers: load the config and assert it is coherent (both fields set together)
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iters {
+				cfg := s.configuration.Load()
+				rt := cfg.GetReadTimeout()
+				rsp := cfg.GetResponseTimeout()
+				// A torn write would produce a mix from two different configs
+				// that cannot appear as a valid pair from either generation.
+				// We validate that read timeout is always a recognised value.
+				if rt != 10*time.Second && rt != 30*time.Second {
+					t.Errorf("GetReadTimeout returned unexpected value %v — possible torn read", rt)
+				}
+				if rsp != 20*time.Second && rsp != 60*time.Second {
+					t.Errorf("GetResponseTimeout returned unexpected value %v — possible torn read", rsp)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestGetOrCreateEndpointPool_ComputeOnce verifies that concurrent first-use of
+// getOrCreateEndpointPool for the same key returns the same *connectionPool to all
+// callers. Before LoadOrCompute, losing goroutines allocated a transport that was
+// silently discarded; this test proves exactly one instance wins.
+func TestGetOrCreateEndpointPool_ComputeOnce(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{
+		BaseProxyComponents: &core.BaseProxyComponents{
+			Logger: createTestLogger(),
+		},
+		endpointPools:   *xsync.NewMap[string, *connectionPool](),
+		circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
+	}
+	cfg := &Configuration{}
+	cfg.MaxIdleConns = 10
+	cfg.MaxConnsPerHost = 5
+	cfg.IdleConnTimeout = 30 * time.Second
+	s.configuration.Store(cfg)
+
+	const goroutines = 50
+	results := make([]*connectionPool, goroutines)
+	var wg sync.WaitGroup
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = s.getOrCreateEndpointPool("test-endpoint")
+		}(i)
+	}
+	wg.Wait()
+
+	// All goroutines must have received the exact same pointer.
+	first := results[0]
+	for i, p := range results {
+		if p != first {
+			t.Errorf("goroutine %d received a different *connectionPool (%p vs %p) — compute-once violated", i, p, first)
+		}
+	}
+}
+
+// TestGetCircuitBreaker_ComputeOnce verifies that concurrent first-use of
+// GetCircuitBreaker for the same key returns the same *circuitBreaker to all callers.
+func TestGetCircuitBreaker_ComputeOnce(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{
+		BaseProxyComponents: &core.BaseProxyComponents{
+			Logger: createTestLogger(),
+		},
+		endpointPools:   *xsync.NewMap[string, *connectionPool](),
+		circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
+	}
+	s.configuration.Store(&Configuration{})
+
+	const goroutines = 50
+	results := make([]*circuitBreaker, goroutines)
+	var wg sync.WaitGroup
+
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = s.GetCircuitBreaker("test-endpoint")
+		}(i)
+	}
+	wg.Wait()
+
+	first := results[0]
+	for i, cb := range results {
+		if cb != first {
+			t.Errorf("goroutine %d received a different *circuitBreaker (%p vs %p) — compute-once violated", i, cb, first)
+		}
+	}
+}

--- a/internal/adapter/proxy/olla/service_leak_test.go
+++ b/internal/adapter/proxy/olla/service_leak_test.go
@@ -23,18 +23,16 @@ func TestEndpointPoolCleanup_NoMemoryLeak(t *testing.T) {
 		BaseProxyComponents: &core.BaseProxyComponents{
 			Logger: createTestLogger(),
 		},
-		configuration: func() *Configuration {
-			c := &Configuration{}
-			c.MaxIdleConns = 10
-			c.MaxConnsPerHost = 5
-			c.IdleConnTimeout = 30 * time.Second
-			return c
-		}(),
 		endpointPools:   *xsync.NewMap[string, *connectionPool](),
 		circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
 		cleanupTicker:   time.NewTicker(100 * time.Millisecond), // Fast cleanup for testing
 		cleanupStop:     make(chan struct{}),
 	}
+	cfg := &Configuration{}
+	cfg.MaxIdleConns = 10
+	cfg.MaxConnsPerHost = 5
+	cfg.IdleConnTimeout = 30 * time.Second
+	s.configuration.Store(cfg)
 
 	// Start cleanup loop
 	go s.cleanupLoop()
@@ -89,12 +87,12 @@ func TestCircuitBreakerCleanup_NoMemoryLeak(t *testing.T) {
 		BaseProxyComponents: &core.BaseProxyComponents{
 			Logger: createTestLogger(),
 		},
-		configuration:   &Configuration{},
 		endpointPools:   *xsync.NewMap[string, *connectionPool](),
 		circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
 		cleanupTicker:   time.NewTicker(100 * time.Millisecond),
 		cleanupStop:     make(chan struct{}),
 	}
+	s.configuration.Store(&Configuration{})
 
 	// Start cleanup loop
 	go s.cleanupLoop()
@@ -149,12 +147,12 @@ func TestCleanupLoop_ExitsCleanly(t *testing.T) {
 			BaseProxyComponents: &core.BaseProxyComponents{
 				Logger: createTestLogger(),
 			},
-			configuration:   &Configuration{},
 			endpointPools:   *xsync.NewMap[string, *connectionPool](),
 			circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
 			cleanupTicker:   time.NewTicker(50 * time.Millisecond),
 			cleanupStop:     make(chan struct{}),
 		}
+		s.configuration.Store(&Configuration{})
 
 		// Start cleanup loop
 		go s.cleanupLoop()
@@ -301,12 +299,12 @@ func TestCleanup_DoubleInvoke(t *testing.T) {
 		BaseProxyComponents: &core.BaseProxyComponents{
 			Logger: createTestLogger(),
 		},
-		configuration:   &Configuration{},
 		endpointPools:   *xsync.NewMap[string, *connectionPool](),
 		circuitBreakers: *xsync.NewMap[string, *circuitBreaker](),
 		cleanupTicker:   time.NewTicker(time.Hour),
 		cleanupStop:     make(chan struct{}),
 	}
+	s.configuration.Store(&Configuration{})
 
 	go s.cleanupLoop()
 

--- a/internal/adapter/proxy/olla/service_leak_test.go
+++ b/internal/adapter/proxy/olla/service_leak_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/core/ports"
 	"github.com/thushan/olla/internal/logger"
-	"github.com/thushan/olla/pkg/pool"
 )
 
 // TestEndpointPoolCleanup_NoMemoryLeak verifies endpoint pools are cleaned up
@@ -180,80 +179,6 @@ func TestCleanupLoop_ExitsCleanly(t *testing.T) {
 	if leaked > 2 { // Allow small variance
 		t.Errorf("Goroutine leak detected: initial=%d, final=%d, leaked=%d",
 			initialGoroutines, finalGoroutines, leaked)
-	}
-}
-
-// TestRequestContextPool_Reset verifies request context is properly reset
-func TestRequestContextPool_Reset(t *testing.T) {
-	reqPool, err := pool.NewLitePool(func() *requestContext {
-		return &requestContext{}
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Get a context and set fields
-	ctx := reqPool.Get()
-	ctx.requestID = "test-123"
-	ctx.startTime = time.Now()
-	ctx.endpoint = "test-endpoint"
-	ctx.targetURL = "http://example.com"
-
-	// Return to pool
-	reqPool.Put(ctx)
-
-	// Get it again - should be reset
-	ctx2 := reqPool.Get()
-	if ctx2.requestID != "" {
-		t.Errorf("requestID not reset: %s", ctx2.requestID)
-	}
-	if !ctx2.startTime.IsZero() {
-		t.Errorf("startTime not reset: %v", ctx2.startTime)
-	}
-	if ctx2.endpoint != "" {
-		t.Errorf("endpoint not reset: %s", ctx2.endpoint)
-	}
-	if ctx2.targetURL != "" {
-		t.Errorf("targetURL not reset: %s", ctx2.targetURL)
-	}
-}
-
-// TestErrorContextPool_Reset verifies error context is properly reset
-func TestErrorContextPool_Reset(t *testing.T) {
-	errorPool, err := pool.NewLitePool(func() *errorContext {
-		return &errorContext{}
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Get a context and set fields
-	ctx := errorPool.Get()
-	ctx.err = errors.New("test error")
-	ctx.context = "test context"
-	ctx.duration = 5 * time.Second
-	ctx.code = 500
-	ctx.allocated = true
-
-	// Return to pool
-	errorPool.Put(ctx)
-
-	// Get it again - should be reset
-	ctx2 := errorPool.Get()
-	if ctx2.err != nil {
-		t.Errorf("err not reset: %v", ctx2.err)
-	}
-	if ctx2.context != "" {
-		t.Errorf("context not reset: %s", ctx2.context)
-	}
-	if ctx2.duration != 0 {
-		t.Errorf("duration not reset: %v", ctx2.duration)
-	}
-	if ctx2.code != 0 {
-		t.Errorf("code not reset: %d", ctx2.code)
-	}
-	if ctx2.allocated {
-		t.Errorf("allocated not reset")
 	}
 }
 

--- a/internal/adapter/proxy/olla/service_preserve_path_test.go
+++ b/internal/adapter/proxy/olla/service_preserve_path_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/adapter/proxy/common"
 	"github.com/thushan/olla/internal/adapter/proxy/config"
 	"github.com/thushan/olla/internal/core/domain"
 )
@@ -195,7 +196,7 @@ func TestService_buildTargetURL_PreservePath(t *testing.T) {
 			require.NoError(t, err)
 
 			// Build the target URL
-			targetURL := s.buildTargetURL(req, tt.endpoint)
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
 
 			// Assert the path is as expected
 			assert.Equal(t, tt.expectedPath, targetURL.Path, tt.description)
@@ -394,7 +395,7 @@ func TestService_buildTargetURL_EdgeCases(t *testing.T) {
 			require.NoError(t, err)
 
 			// Build the target URL
-			targetURL := s.buildTargetURL(req, tt.endpoint)
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
 
 			// Assert the path is as expected
 			assert.Equal(t, tt.expectedPath, targetURL.Path, tt.description)
@@ -508,7 +509,7 @@ func TestService_buildTargetURL_QueryString(t *testing.T) {
 			req, err := http.NewRequest("GET", tt.requestPath, nil)
 			require.NoError(t, err)
 
-			targetURL := s.buildTargetURL(req, tt.endpoint)
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
 
 			assert.Equal(t, tt.expectedPath, targetURL.Path, tt.description)
 			assert.Equal(t, tt.expectedQuery, targetURL.RawQuery, "Query string: "+tt.description)
@@ -660,7 +661,7 @@ func TestService_buildTargetURL_RealWorldScenarios(t *testing.T) {
 			req, err := http.NewRequest("POST", tt.requestPath, nil)
 			require.NoError(t, err)
 
-			targetURL := s.buildTargetURL(req, tt.endpoint)
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
 
 			assert.Equal(t, tt.expectedPath, targetURL.Path,
 				"Provider: %s - %s", tt.provider, tt.description)
@@ -732,7 +733,7 @@ func BenchmarkService_buildTargetURL(b *testing.B) {
 			b.ReportAllocs()
 
 			for range b.N {
-				_ = s.buildTargetURL(req, scenario.endpoint)
+				_ = common.BuildTargetURL(req, scenario.endpoint, s.configuration.GetProxyPrefix())
 			}
 		})
 	}

--- a/internal/adapter/proxy/olla/service_preserve_path_test.go
+++ b/internal/adapter/proxy/olla/service_preserve_path_test.go
@@ -181,22 +181,21 @@ func TestService_buildTargetURL_PreservePath(t *testing.T) {
 			t.Parallel()
 
 			// Create a minimal service with configuration
-			s := &Service{
-				configuration: &Configuration{
-					OllaConfig: config.OllaConfig{
-						BaseProxyConfig: config.BaseProxyConfig{
-							ProxyPrefix: tt.proxyPrefix,
-						},
+			s := &Service{}
+			s.configuration.Store(&Configuration{
+				OllaConfig: config.OllaConfig{
+					BaseProxyConfig: config.BaseProxyConfig{
+						ProxyPrefix: tt.proxyPrefix,
 					},
 				},
-			}
+			})
 
 			// Create a test request
 			req, err := http.NewRequest("POST", tt.requestPath, nil)
 			require.NoError(t, err)
 
 			// Build the target URL
-			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.Load().GetProxyPrefix())
 
 			// Assert the path is as expected
 			assert.Equal(t, tt.expectedPath, targetURL.Path, tt.description)
@@ -380,22 +379,21 @@ func TestService_buildTargetURL_EdgeCases(t *testing.T) {
 			t.Parallel()
 
 			// Create a minimal service with configuration
-			s := &Service{
-				configuration: &Configuration{
-					OllaConfig: config.OllaConfig{
-						BaseProxyConfig: config.BaseProxyConfig{
-							ProxyPrefix: tt.proxyPrefix,
-						},
+			s := &Service{}
+			s.configuration.Store(&Configuration{
+				OllaConfig: config.OllaConfig{
+					BaseProxyConfig: config.BaseProxyConfig{
+						ProxyPrefix: tt.proxyPrefix,
 					},
 				},
-			}
+			})
 
 			// Create a test request
 			req, err := http.NewRequest("POST", tt.requestPath, nil)
 			require.NoError(t, err)
 
 			// Build the target URL
-			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.Load().GetProxyPrefix())
 
 			// Assert the path is as expected
 			assert.Equal(t, tt.expectedPath, targetURL.Path, tt.description)
@@ -496,20 +494,19 @@ func TestService_buildTargetURL_QueryString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := &Service{
-				configuration: &Configuration{
-					OllaConfig: config.OllaConfig{
-						BaseProxyConfig: config.BaseProxyConfig{
-							ProxyPrefix: "/olla/proxy",
-						},
+			s := &Service{}
+			s.configuration.Store(&Configuration{
+				OllaConfig: config.OllaConfig{
+					BaseProxyConfig: config.BaseProxyConfig{
+						ProxyPrefix: "/olla/proxy",
 					},
 				},
-			}
+			})
 
 			req, err := http.NewRequest("GET", tt.requestPath, nil)
 			require.NoError(t, err)
 
-			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.Load().GetProxyPrefix())
 
 			assert.Equal(t, tt.expectedPath, targetURL.Path, tt.description)
 			assert.Equal(t, tt.expectedQuery, targetURL.RawQuery, "Query string: "+tt.description)
@@ -648,20 +645,19 @@ func TestService_buildTargetURL_RealWorldScenarios(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			s := &Service{
-				configuration: &Configuration{
-					OllaConfig: config.OllaConfig{
-						BaseProxyConfig: config.BaseProxyConfig{
-							ProxyPrefix: "/olla/proxy",
-						},
+			s := &Service{}
+			s.configuration.Store(&Configuration{
+				OllaConfig: config.OllaConfig{
+					BaseProxyConfig: config.BaseProxyConfig{
+						ProxyPrefix: "/olla/proxy",
 					},
 				},
-			}
+			})
 
 			req, err := http.NewRequest("POST", tt.requestPath, nil)
 			require.NoError(t, err)
 
-			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, tt.endpoint, s.configuration.Load().GetProxyPrefix())
 
 			assert.Equal(t, tt.expectedPath, targetURL.Path,
 				"Provider: %s - %s", tt.provider, tt.description)
@@ -717,15 +713,14 @@ func BenchmarkService_buildTargetURL(b *testing.B) {
 
 	for _, scenario := range scenarios {
 		b.Run(scenario.name, func(b *testing.B) {
-			s := &Service{
-				configuration: &Configuration{
-					OllaConfig: config.OllaConfig{
-						BaseProxyConfig: config.BaseProxyConfig{
-							ProxyPrefix: "/olla/proxy",
-						},
+			s := &Service{}
+			s.configuration.Store(&Configuration{
+				OllaConfig: config.OllaConfig{
+					BaseProxyConfig: config.BaseProxyConfig{
+						ProxyPrefix: "/olla/proxy",
 					},
 				},
-			}
+			})
 
 			req, _ := http.NewRequest("POST", scenario.requestPath, nil)
 
@@ -733,7 +728,7 @@ func BenchmarkService_buildTargetURL(b *testing.B) {
 			b.ReportAllocs()
 
 			for range b.N {
-				_ = common.BuildTargetURL(req, scenario.endpoint, s.configuration.GetProxyPrefix())
+				_ = common.BuildTargetURL(req, scenario.endpoint, s.configuration.Load().GetProxyPrefix())
 			}
 		})
 	}

--- a/internal/adapter/proxy/olla/service_retry.go
+++ b/internal/adapter/proxy/olla/service_retry.go
@@ -53,6 +53,10 @@ func (s *Service) ProxyRequestToEndpointsWithRetry(ctx context.Context, w http.R
 func (s *Service) proxyToSingleEndpoint(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoint *domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) error {
 	stats.EndpointName = endpoint.Name
 
+	// Snapshot config once for this request so all reads below are coherent even
+	// if UpdateConfig races concurrently.
+	cfg := s.configuration.Load()
+
 	// Check circuit breaker first
 	cb := s.GetCircuitBreaker(endpoint.Name)
 	if cb != nil && cb.IsOpen() {
@@ -63,7 +67,7 @@ func (s *Service) proxyToSingleEndpoint(ctx context.Context, w http.ResponseWrit
 	}
 
 	// Build target URL using common function that respects preserve_path
-	targetURL := common.BuildTargetURL(r, endpoint, s.configuration.GetProxyPrefix())
+	targetURL := common.BuildTargetURL(r, endpoint, cfg.GetProxyPrefix())
 	stats.TargetUrl = targetURL.String()
 
 	// Log request dispatch after target URL is computed
@@ -110,7 +114,7 @@ func (s *Service) proxyToSingleEndpoint(ctx context.Context, w http.ResponseWrit
 		}
 		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), err)
 		duration := time.Since(stats.StartTime)
-		return common.MakeUserFriendlyError(err, duration, "backend", s.configuration.GetResponseTimeout())
+		return common.MakeUserFriendlyError(err, duration, "backend", cfg.GetResponseTimeout())
 	}
 	defer resp.Body.Close()
 
@@ -152,7 +156,7 @@ func (s *Service) proxyToSingleEndpoint(ctx context.Context, w http.ResponseWrit
 	if streamErr != nil && !errors.Is(streamErr, context.Canceled) {
 		rlog.Error("streaming failed", "error", streamErr)
 		s.RecordFailure(ctx, endpoint, time.Since(stats.StartTime), streamErr)
-		return common.MakeUserFriendlyError(streamErr, time.Since(stats.StartTime), "streaming", s.configuration.GetResponseTimeout())
+		return common.MakeUserFriendlyError(streamErr, time.Since(stats.StartTime), "streaming", cfg.GetResponseTimeout())
 	}
 
 	// We've successfully written the response

--- a/internal/adapter/proxy/olla/service_transport_test.go
+++ b/internal/adapter/proxy/olla/service_transport_test.go
@@ -215,7 +215,8 @@ func TestUpdateConfig_PreservesTimeouts(t *testing.T) {
 	original.MaxConnsPerHost = proxyconfig.OllaDefaultMaxConnsPerHost
 	original.MaxIdleConnsPerHost = proxyconfig.OllaDefaultMaxIdleConnsPerHost
 
-	svc := &Service{configuration: original}
+	svc := &Service{}
+	svc.configuration.Store(original)
 
 	// Use the same *Configuration type so we exercise the Olla type-assertion path.
 	updated := &Configuration{}
@@ -224,10 +225,11 @@ func TestUpdateConfig_PreservesTimeouts(t *testing.T) {
 
 	svc.UpdateConfig(updated)
 
-	if svc.configuration.ResponseHeaderTimeout != 120*time.Second {
-		t.Errorf("ResponseHeaderTimeout after UpdateConfig: want 120s, got %v", svc.configuration.ResponseHeaderTimeout)
+	got := svc.configuration.Load()
+	if got.ResponseHeaderTimeout != 120*time.Second {
+		t.Errorf("ResponseHeaderTimeout after UpdateConfig: want 120s, got %v", got.ResponseHeaderTimeout)
 	}
-	if svc.configuration.TLSHandshakeTimeout != 15*time.Second {
-		t.Errorf("TLSHandshakeTimeout after UpdateConfig: want 15s, got %v", svc.configuration.TLSHandshakeTimeout)
+	if got.TLSHandshakeTimeout != 15*time.Second {
+		t.Errorf("TLSHandshakeTimeout after UpdateConfig: want 15s, got %v", got.TLSHandshakeTimeout)
 	}
 }

--- a/internal/adapter/proxy/olla/service_url_test.go
+++ b/internal/adapter/proxy/olla/service_url_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thushan/olla/internal/adapter/proxy/common"
 	"github.com/thushan/olla/internal/core/domain"
 )
 
@@ -126,7 +127,7 @@ func TestBuildTargetURL(t *testing.T) {
 				t.Fatalf("failed to create request: %v", err)
 			}
 
-			targetURL := service.buildTargetURL(req, endpoint)
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
 
 			// Verify path
 			if targetURL.Path != tt.expectedPath {
@@ -193,7 +194,7 @@ func TestBuildTargetURL_PathHandling(t *testing.T) {
 
 	for _, path := range testPaths {
 		req, _ := http.NewRequest("GET", path+"?test=true", nil)
-		targetURL := service.buildTargetURL(req, endpoint)
+		targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
 
 		// Verify URL is valid
 		if targetURL.Host == "" {

--- a/internal/adapter/proxy/olla/service_url_test.go
+++ b/internal/adapter/proxy/olla/service_url_test.go
@@ -127,7 +127,7 @@ func TestBuildTargetURL(t *testing.T) {
 				t.Fatalf("failed to create request: %v", err)
 			}
 
-			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
+			targetURL := common.BuildTargetURL(req, endpoint, service.configuration.Load().GetProxyPrefix())
 
 			// Verify path
 			if targetURL.Path != tt.expectedPath {
@@ -194,7 +194,7 @@ func TestBuildTargetURL_PathHandling(t *testing.T) {
 
 	for _, path := range testPaths {
 		req, _ := http.NewRequest("GET", path+"?test=true", nil)
-		targetURL := common.BuildTargetURL(req, endpoint, service.configuration.GetProxyPrefix())
+		targetURL := common.BuildTargetURL(req, endpoint, service.configuration.Load().GetProxyPrefix())
 
 		// Verify URL is valid
 		if targetURL.Host == "" {

--- a/internal/adapter/proxy/olla/streaming_helpers.go
+++ b/internal/adapter/proxy/olla/streaming_helpers.go
@@ -64,8 +64,10 @@ func shouldStopAfterDisconnect(bytesAfterDisconnect int, disconnectTime time.Tim
 		time.Since(disconnectTime) > ClientDisconnectionTimeThreshold
 }
 
-// checkContexts checks for context cancellation and timeout
-func (s *Service) checkContexts(clientCtx, upstreamCtx context.Context, readDeadline *time.Timer, state *streamState, rlog logger.StyledLogger) error {
+// checkContexts checks for context cancellation and timeout.
+// readTimeout is passed in (snapshotted from config at stream start) so this
+// method has no dependency on s.configuration and stays off the atomic path.
+func (s *Service) checkContexts(clientCtx, upstreamCtx context.Context, readDeadline *time.Timer, readTimeout time.Duration, state *streamState, rlog logger.StyledLogger) error {
 	select {
 	case <-clientCtx.Done():
 		s.handleClientDisconnect(state, rlog)
@@ -74,7 +76,7 @@ func (s *Service) checkContexts(clientCtx, upstreamCtx context.Context, readDead
 	case <-upstreamCtx.Done():
 		return upstreamCtx.Err()
 	case <-readDeadline.C:
-		return fmt.Errorf("read timeout after %v", s.configuration.GetReadTimeout())
+		return fmt.Errorf("read timeout after %v", readTimeout)
 	default:
 		return nil
 	}

--- a/internal/adapter/security/factory.go
+++ b/internal/adapter/security/factory.go
@@ -73,12 +73,15 @@ func (sa *Adapters) CreateRateLimitMiddleware() func(http.Handler) http.Handler 
 	}
 }
 
-// CreateSizeMiddleware returns a middleware that enforces request-size limits.
-// Exposed separately so non-proxy routes (status, health, etc.) get body-size
-// validation even though they intentionally bypass the full security chain.
+// CreateSizeMiddleware returns a middleware that enforces request-size limits
+// for non-proxy routes (status, health, stats). Unlike CreateMiddleware, this
+// variant actively drains chunked bodies (Content-Length == -1) up to the cap
+// so that oversized requests are rejected even when the handler never reads the
+// body. Proxy routes must not use this path — they stream large bodies and must
+// not be buffered.
 func (sa *Adapters) CreateSizeMiddleware() func(http.Handler) http.Handler {
 	if sa.SizeValidation != nil {
-		return sa.SizeValidation.CreateMiddleware()
+		return sa.SizeValidation.CreateNonProxyMiddleware()
 	}
 	return func(next http.Handler) http.Handler {
 		return next

--- a/internal/adapter/security/factory.go
+++ b/internal/adapter/security/factory.go
@@ -72,3 +72,15 @@ func (sa *Adapters) CreateRateLimitMiddleware() func(http.Handler) http.Handler 
 		return next
 	}
 }
+
+// CreateSizeMiddleware returns a middleware that enforces request-size limits.
+// Exposed separately so non-proxy routes (status, health, etc.) get body-size
+// validation even though they intentionally bypass the full security chain.
+func (sa *Adapters) CreateSizeMiddleware() func(http.Handler) http.Handler {
+	if sa.SizeValidation != nil {
+		return sa.SizeValidation.CreateMiddleware()
+	}
+	return func(next http.Handler) http.Handler {
+		return next
+	}
+}

--- a/internal/adapter/security/request_size_limit.go
+++ b/internal/adapter/security/request_size_limit.go
@@ -10,8 +10,10 @@ package security
 */
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -114,28 +116,7 @@ func (sv *SizeValidator) CreateMiddleware() func(http.Handler) http.Handler {
 			}
 
 			if !result.Allowed {
-				if sv.metrics != nil {
-					violationType := constants.ViolationSizeLimit
-					size := req.BodySize
-					if strings.Contains(result.Reason, "headers too large") {
-						size = req.HeaderSize
-					}
-
-					violation := ports.SecurityViolation{
-						ClientID:      util.GetClientIP(r, false, nil),
-						ViolationType: violationType,
-						Endpoint:      r.URL.Path,
-						Size:          size,
-						Timestamp:     time.Now(),
-					}
-					_ = sv.metrics.RecordViolation(r.Context(), violation)
-				}
-
-				sv.logger.Warn("Request rejected",
-					"reason", result.Reason,
-					"method", r.Method,
-					"path", r.URL.Path,
-					"remote_addr", r.RemoteAddr)
+				sv.recordViolation(r, req, result)
 
 				if r.ContentLength > sv.maxBodySize {
 					http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
@@ -152,6 +133,108 @@ func (sv *SizeValidator) CreateMiddleware() func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// CreateNonProxyMiddleware is like CreateMiddleware but also rejects chunked
+// (Content-Length == -1) requests whose bodies exceed the configured limit.
+// It is intended for non-proxy routes (status, health, stats) that never read
+// the body themselves, so MaxBytesReader alone would never fire for them.
+//
+// The approach: drain up to maxBodySize+1 bytes through MaxBytesReader before
+// calling next. If the read hits the limit the reader returns an error and we
+// return 413. Otherwise we restore the buffered bytes as the request body so
+// a handler that does read the body still receives the full content.
+//
+// Proxy routes must NOT use this middleware — they stream large bodies
+// legitimately and must not be buffered. Use CreateMiddleware for those paths.
+func (sv *SizeValidator) CreateNonProxyMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req := ports.SecurityRequest{
+				Endpoint:   r.URL.Path,
+				Method:     r.Method,
+				BodySize:   r.ContentLength,
+				HeaderSize: estimateHeaderSize(r.Header, r.Method, r.URL.RequestURI(), r.Proto),
+				Headers:    r.Header,
+			}
+
+			result, err := sv.Validate(r.Context(), req)
+			if err != nil {
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			if !result.Allowed {
+				sv.recordViolation(r, req, result)
+
+				if r.ContentLength > sv.maxBodySize {
+					http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				} else {
+					http.Error(w, "Request headers too large", http.StatusRequestHeaderFieldsTooLarge)
+				}
+				return
+			}
+
+			// For chunked requests (ContentLength == -1), drain the body up to the
+			// cap now. Handlers on non-proxy routes never read the body themselves, so
+			// MaxBytesReader installed on r.Body would silently never trigger; we must
+			// enforce the limit here before passing control to the handler.
+			if sv.maxBodySize > 0 && r.ContentLength < 0 && r.Body != nil {
+				limited := http.MaxBytesReader(w, r.Body, sv.maxBodySize)
+				buf, readErr := io.ReadAll(limited)
+				if readErr != nil {
+					// MaxBytesReader returns an error (and writes a 413 header via the
+					// ResponseWriter) when the body exceeds the limit.
+					sv.logger.Warn("Chunked request body too large",
+						"method", r.Method,
+						"path", r.URL.Path,
+						"remote_addr", r.RemoteAddr)
+					http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+					return
+				}
+				// Restore the buffered body so downstream handlers that do read it
+				// still get the content.
+				r.Body = io.NopCloser(bytes.NewReader(buf))
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// recordViolation emits a security violation metric. Factored out so both
+// CreateMiddleware and CreateNonProxyMiddleware share the same reporting path
+// without duplicating the metric-construction logic.
+func (sv *SizeValidator) recordViolation(r *http.Request, req ports.SecurityRequest, result ports.SecurityResult) {
+	if sv.metrics == nil {
+		sv.logger.Warn("Request rejected",
+			"reason", result.Reason,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+		return
+	}
+
+	violationType := constants.ViolationSizeLimit
+	size := req.BodySize
+	if strings.Contains(result.Reason, "headers too large") {
+		size = req.HeaderSize
+	}
+
+	violation := ports.SecurityViolation{
+		ClientID:      util.GetClientIP(r, false, nil),
+		ViolationType: violationType,
+		Endpoint:      r.URL.Path,
+		Size:          size,
+		Timestamp:     time.Now(),
+	}
+	_ = sv.metrics.RecordViolation(r.Context(), violation)
+
+	sv.logger.Warn("Request rejected",
+		"reason", result.Reason,
+		"method", r.Method,
+		"path", r.URL.Path,
+		"remote_addr", r.RemoteAddr)
 }
 
 func estimateHeaderSize(headers http.Header, method, uri, proto string) int64 {

--- a/internal/adapter/security/request_size_limit.go
+++ b/internal/adapter/security/request_size_limit.go
@@ -183,12 +183,21 @@ func (sv *SizeValidator) CreateNonProxyMiddleware() func(http.Handler) http.Hand
 				limited := http.MaxBytesReader(w, r.Body, sv.maxBodySize)
 				buf, readErr := io.ReadAll(limited)
 				if readErr != nil {
-					// MaxBytesReader returns an error (and writes a 413 header via the
-					// ResponseWriter) when the body exceeds the limit.
-					sv.logger.Warn("Chunked request body too large",
-						"method", r.Method,
-						"path", r.URL.Path,
-						"remote_addr", r.RemoteAddr)
+					// Treat chunked overflow identically to known-Content-Length overflow so
+					// security metrics capture both paths. Report size as limit+1 — the actual
+					// byte count is unknown for chunked transfers, but limit+1 conveys "exceeded".
+					overflowReq := ports.SecurityRequest{
+						Endpoint:   r.URL.Path,
+						Method:     r.Method,
+						BodySize:   sv.maxBodySize + 1,
+						HeaderSize: req.HeaderSize,
+						Headers:    r.Header,
+					}
+					overflowResult := ports.SecurityResult{
+						Allowed: false,
+						Reason:  fmt.Sprintf("Request body too large: chunked body exceeds limit %d", sv.maxBodySize),
+					}
+					sv.recordViolation(r, overflowReq, overflowResult)
 					http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
 					return
 				}

--- a/internal/adapter/security/request_size_limit_test.go
+++ b/internal/adapter/security/request_size_limit_test.go
@@ -2,6 +2,9 @@ package security
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -415,5 +418,115 @@ func TestSizeValidator_Validate_MultiValueHeaders(t *testing.T) {
 	}
 	if result.Allowed {
 		t.Error("Large multi-value headers should exceed limit")
+	}
+}
+
+// TestCreateNonProxyMiddleware_ChunkedOversizedBody confirms that an oversized
+// chunked request (Content-Length == -1) to a non-proxy route is rejected with
+// 413. This is the regression guard for P1: MaxBytesReader alone never fires on
+// routes that don't read the body, so CreateNonProxyMiddleware must drain the
+// body itself.
+func TestCreateNonProxyMiddleware_ChunkedOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	const cap = 10
+
+	validator := createTestSizeLimitValidator(config.ServerRequestLimits{
+		MaxBodySize:   cap,
+		MaxHeaderSize: 0,
+	})
+
+	reached := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := validator.CreateNonProxyMiddleware()(next)
+
+	body := strings.Repeat("x", cap+1)
+	req := httptest.NewRequest(http.MethodPost, "/internal/status", strings.NewReader(body))
+	// Simulate chunked: no Content-Length header
+	req.ContentLength = -1
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413 for oversized chunked body, got %d", rr.Code)
+	}
+	if reached {
+		t.Error("handler must not be reached when oversized chunked body is rejected")
+	}
+}
+
+// TestCreateNonProxyMiddleware_ChunkedSmallBody confirms that a small chunked
+// body passes through and the handler still receives the body content intact.
+func TestCreateNonProxyMiddleware_ChunkedSmallBody(t *testing.T) {
+	t.Parallel()
+
+	const cap = 100
+
+	validator := createTestSizeLimitValidator(config.ServerRequestLimits{
+		MaxBodySize:   cap,
+		MaxHeaderSize: 0,
+	})
+
+	var receivedBody string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		receivedBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := validator.CreateNonProxyMiddleware()(next)
+
+	body := "hello"
+	req := httptest.NewRequest(http.MethodPost, "/internal/status", strings.NewReader(body))
+	req.ContentLength = -1
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 for small chunked body, got %d", rr.Code)
+	}
+	if receivedBody != body {
+		t.Errorf("handler received wrong body: want %q, got %q", body, receivedBody)
+	}
+}
+
+// TestCreateNonProxyMiddleware_KnownLengthOversized confirms that the fast-path
+// Content-Length rejection still works in CreateNonProxyMiddleware.
+func TestCreateNonProxyMiddleware_KnownLengthOversized(t *testing.T) {
+	t.Parallel()
+
+	const cap = 10
+
+	validator := createTestSizeLimitValidator(config.ServerRequestLimits{
+		MaxBodySize:   cap,
+		MaxHeaderSize: 0,
+	})
+
+	reached := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := validator.CreateNonProxyMiddleware()(next)
+
+	body := strings.Repeat("x", cap+1)
+	req := httptest.NewRequest(http.MethodPost, "/internal/status", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413 for known-length oversized body, got %d", rr.Code)
+	}
+	if reached {
+		t.Error("handler must not be reached when oversized known-length body is rejected")
 	}
 }

--- a/internal/adapter/security/request_size_limit_test.go
+++ b/internal/adapter/security/request_size_limit_test.go
@@ -460,6 +460,41 @@ func TestCreateNonProxyMiddleware_ChunkedOversizedBody(t *testing.T) {
 	}
 }
 
+// TestCreateNonProxyMiddleware_ChunkedOversizedBody_RecordsViolation confirms
+// that an oversized chunked body produces a security-metrics violation, matching
+// the behaviour of the known-Content-Length rejection path.
+func TestCreateNonProxyMiddleware_ChunkedOversizedBody_RecordsViolation(t *testing.T) {
+	t.Parallel()
+
+	const cap = 10
+
+	log := createTestSizeLogger()
+	statsCollector := createTestStatsCollector(log)
+	metricsAdapter := NewSecurityMetricsAdapter(statsCollector, log)
+	validator := NewSizeValidator(config.ServerRequestLimits{
+		MaxBodySize:   cap,
+		MaxHeaderSize: 0,
+	}, metricsAdapter, log)
+
+	handler := validator.CreateNonProxyMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	body := strings.Repeat("x", cap+1)
+	req := httptest.NewRequest(http.MethodPost, "/internal/status", strings.NewReader(body))
+	req.ContentLength = -1
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	metrics, err := metricsAdapter.GetMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("GetMetrics failed: %v", err)
+	}
+	if metrics.SizeLimitViolations != 1 {
+		t.Errorf("expected 1 size-limit violation recorded for chunked overflow, got %d", metrics.SizeLimitViolations)
+	}
+}
+
 // TestCreateNonProxyMiddleware_ChunkedSmallBody confirms that a small chunked
 // body passes through and the handler still receives the body content intact.
 func TestCreateNonProxyMiddleware_ChunkedSmallBody(t *testing.T) {

--- a/internal/adapter/unifier/lifecycle_unifier.go
+++ b/internal/adapter/unifier/lifecycle_unifier.go
@@ -208,21 +208,6 @@ func (u *LifecycleUnifier) stateTransitionLogger() {
 	}
 }
 
-func (u *LifecycleUnifier) recordStateTransition(from, to, reason string, err error) {
-	transition := domain.StateTransition{
-		From:      from,
-		To:        to,
-		Timestamp: time.Now(),
-		Reason:    reason,
-		Error:     err,
-	}
-
-	select {
-	case u.stateTransitions <- transition:
-	default:
-	}
-}
-
 func (u *LifecycleUnifier) UnifyModel(ctx context.Context, sourceModel *domain.ModelInfo, endpoint *domain.Endpoint) (*domain.UnifiedModel, error) {
 	models := []*domain.ModelInfo{sourceModel}
 	unified, err := u.UnifyModels(ctx, models, endpoint)

--- a/internal/app/handlers/application.go
+++ b/internal/app/handlers/application.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thushan/olla/internal/adapter/inspector"
 	"github.com/thushan/olla/internal/adapter/registry"
 	"github.com/thushan/olla/internal/adapter/registry/profile"
+	"github.com/thushan/olla/internal/adapter/security"
 	"github.com/thushan/olla/internal/adapter/translator"
 	"github.com/thushan/olla/internal/adapter/translator/anthropic"
 	"github.com/thushan/olla/internal/app/middleware"
@@ -23,8 +24,9 @@ import (
 
 // SecurityAdapters provides middleware for security chain
 type SecurityAdapters struct {
-	securityChain *ports.SecurityChain
-	logger        logger.StyledLogger
+	securityChain    *ports.SecurityChain
+	securityAdapters *security.Adapters // nil when security is not configured
+	logger           logger.StyledLogger
 }
 
 // CreateChainMiddleware creates middleware that applies the full security chain with enhanced logging
@@ -67,6 +69,16 @@ func (s *SecurityAdapters) CreateRateLimitMiddleware() func(http.Handler) http.H
 		withAccessLogging := middleware.AccessLoggingMiddleware(s.logger)(withLogging)
 		return withAccessLogging
 	}
+}
+
+// CreateSizeMiddleware returns a middleware that enforces request-size limits on
+// non-proxy routes. Delegates to the real security adapter when available; returns
+// a pass-through when security is not configured (e.g. in tests).
+func (s *SecurityAdapters) CreateSizeMiddleware() func(http.Handler) http.Handler {
+	if s.securityAdapters != nil {
+		return s.securityAdapters.CreateSizeMiddleware()
+	}
+	return func(next http.Handler) http.Handler { return next }
 }
 
 // Application holds all the dependencies needed for the HTTP handlers
@@ -227,6 +239,15 @@ func (a *Application) GetProfileLookup() translator.ProfileLookup {
 // Called by HTTPService when sticky sessions are enabled.
 func (a *Application) SetStickyStatsFn(fn func() *balancer.StickyStats) {
 	a.stickyStatsFn = fn
+}
+
+// SetSecurityAdapters wires the real security.Adapters into the handlers-layer
+// SecurityAdapters so non-proxy routes gain size validation. Called by HTTPService
+// after the SecurityService has finished initialising.
+func (a *Application) SetSecurityAdapters(adapters *security.Adapters) {
+	if a.securityAdapters != nil {
+		a.securityAdapters.securityAdapters = adapters
+	}
 }
 
 func (a *Application) RegisterRoutes() {

--- a/internal/app/handlers/handler_status.go
+++ b/internal/app/handlers/handler_status.go
@@ -89,8 +89,6 @@ type StatusResponse struct {
 	System    SystemSummary      `json:"system"`
 }
 
-var issuesPool = make([]string, 0, 4)
-
 func (a *Application) statusHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	now := time.Now()
@@ -255,30 +253,30 @@ func (a *Application) buildSecuritySummary(stats ports.SecurityStats) SecuritySu
 }
 
 func (a *Application) getEndpointIssues(endpoint *domain.Endpoint, stats ports.EndpointStats, hasStats bool, successRate float64) string {
-	issuesPool = issuesPool[:0]
+	issues := make([]string, 0, 4)
 
 	if endpoint.ConsecutiveFailures > 3 {
-		issuesPool = append(issuesPool, "consecutive failures")
+		issues = append(issues, "consecutive failures")
 	}
 
 	if hasStats {
 		if successRate < 90.0 && stats.TotalRequests > 10 {
-			issuesPool = append(issuesPool, "low success rate")
+			issues = append(issues, "low success rate")
 		}
 		if stats.AverageLatency > 5000 {
-			issuesPool = append(issuesPool, "high latency")
+			issues = append(issues, "high latency")
 		}
 	}
 
 	if endpoint.Status == domain.StatusOffline || endpoint.Status == domain.StatusUnhealthy {
-		issuesPool = append(issuesPool, "unavailable")
+		issues = append(issues, "unavailable")
 	}
 
-	if len(issuesPool) == 0 {
+	if len(issues) == 0 {
 		return emptyString
 	}
 
-	return strings.Join(issuesPool, ", ")
+	return strings.Join(issues, ", ")
 }
 
 func (a *Application) getEndpointCounts(ctx context.Context) (all, healthy, routable []*domain.Endpoint, err error) {

--- a/internal/app/handlers/handler_status_models.go
+++ b/internal/app/handlers/handler_status_models.go
@@ -51,18 +51,6 @@ type ModelStatusResponse struct {
 	TotalEndpoints int                 `json:"total_endpoints"`
 }
 
-// these are pooled to avoid allocations
-var (
-	modelSummaryPool  = make([]ModelSummary, 0, maxModelsCapacity)
-	endpointNamesPool = make(map[string]string, maxEndpointNamesLength)
-	familyGroupPool   = make(map[string][]string, 16)
-	uniqueModelsPool  = make(map[string]*ModelSummary, maxModelsCapacity)
-	endpointSetPool   = make(map[string]struct{}, 8)
-	capabilitiesPool  = make([]string, 0, 4)
-	stringSlicePool   = make([]string, 0, 8)
-	modelGroupPool    = make([]ModelGroupSummary, 0, 16)
-)
-
 func (a *Application) modelsStatusHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -81,14 +69,12 @@ func (a *Application) modelsStatusHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	for k := range endpointNamesPool {
-		delete(endpointNamesPool, k)
-	}
+	endpointNames := make(map[string]string, len(endpoints))
 	for _, ep := range endpoints {
-		endpointNamesPool[ep.URLString] = ep.Name
+		endpointNames[ep.URLString] = ep.Name
 	}
 
-	allModels := a.buildModelSummaries(modelMap, endpointNamesPool)
+	allModels := a.buildModelSummaries(modelMap, endpointNames)
 
 	response := ModelStatusResponse{
 		Timestamp:      time.Now(),
@@ -110,9 +96,7 @@ func (a *Application) modelsStatusHandler(w http.ResponseWriter, r *http.Request
 }
 
 func (a *Application) buildModelSummaries(modelMap map[string]*domain.EndpointModels, endpointNames map[string]string) []ModelSummary {
-	for k := range uniqueModelsPool {
-		delete(uniqueModelsPool, k)
-	}
+	uniqueModels := make(map[string]*ModelSummary, maxModelsCapacity)
 
 	for endpointURL, endpointModels := range modelMap {
 		endpointName := endpointNames[endpointURL]
@@ -121,22 +105,11 @@ func (a *Application) buildModelSummaries(modelMap map[string]*domain.EndpointMo
 		}
 
 		for _, model := range endpointModels.Models {
-			existing, exists := uniqueModelsPool[model.Name]
+			existing, exists := uniqueModels[model.Name]
 			if !exists {
-				stringSlicePool = stringSlicePool[:0]
-				stringSlicePool = append(stringSlicePool, endpointName)
-				endpoints := make([]string, len(stringSlicePool))
-				copy(endpoints, stringSlicePool)
-
-				stringSlicePool = stringSlicePool[:0]
-				stringSlicePool = append(stringSlicePool, endpointURL)
-				endpointURLs := make([]string, len(stringSlicePool))
-				copy(endpointURLs, stringSlicePool)
-
-				uniqueModelsPool[model.Name] = a.createModelSummary(model, endpointURLs)
+				uniqueModels[model.Name] = a.createModelSummary(model, []string{endpointName})
 			} else {
 				existing.Endpoints = append(existing.Endpoints, endpointName)
-				// existing.EndpointURLs = append(existing.EndpointURLs, endpointURL)
 
 				if model.LastSeen.Unix() > parseTimeAgoOptimised(existing.LastSeen) {
 					existing.LastSeen = format.TimeAgo(model.LastSeen)
@@ -145,16 +118,12 @@ func (a *Application) buildModelSummaries(modelMap map[string]*domain.EndpointMo
 		}
 	}
 
-	modelSummaryPool = modelSummaryPool[:0]
-	if cap(modelSummaryPool) < len(uniqueModelsPool) {
-		modelSummaryPool = make([]ModelSummary, 0, len(uniqueModelsPool))
+	summaries := make([]ModelSummary, 0, len(uniqueModels))
+	for _, summary := range uniqueModels {
+		summaries = append(summaries, *summary)
 	}
 
-	for _, summary := range uniqueModelsPool {
-		modelSummaryPool = append(modelSummaryPool, *summary)
-	}
-
-	return modelSummaryPool
+	return summaries
 }
 
 func (a *Application) createModelSummary(model *domain.ModelInfo, endpoints []string) *ModelSummary {
@@ -186,23 +155,21 @@ func (a *Application) createModelSummary(model *domain.ModelInfo, endpoints []st
 }
 
 func (a *Application) groupModelsByFamily(models []ModelSummary) map[string][]string {
-	for k := range familyGroupPool {
-		delete(familyGroupPool, k)
-	}
+	familyGroup := make(map[string][]string, 16)
 
 	for i := range models {
 		family := models[i].Family
 		if family == "" {
 			family = familyUnknown
 		}
-		familyGroupPool[family] = append(familyGroupPool[family], models[i].Name)
+		familyGroup[family] = append(familyGroup[family], models[i].Name)
 	}
 
-	for family := range familyGroupPool {
-		sort.Strings(familyGroupPool[family])
+	for family := range familyGroup {
+		sort.Strings(familyGroup[family])
 	}
 
-	return familyGroupPool
+	return familyGroup
 }
 
 func (a *Application) groupModelsByFamilyWithDetails(models []ModelSummary) []ModelGroupSummary {
@@ -216,56 +183,45 @@ func (a *Application) groupModelsByFamilyWithDetails(models []ModelSummary) []Mo
 		familyMap[family] = append(familyMap[family], models[i])
 	}
 
-	modelGroupPool = modelGroupPool[:0]
-	if cap(modelGroupPool) < len(familyMap) {
-		modelGroupPool = make([]ModelGroupSummary, 0, len(familyMap))
-	}
+	modelGroups := make([]ModelGroupSummary, 0, len(familyMap))
 
 	for family, familyModels := range familyMap {
-		for k := range endpointSetPool {
-			delete(endpointSetPool, k)
-		}
-
+		endpointSet := make(map[string]struct{}, 8)
 		for i := range familyModels {
 			for j := range familyModels[i].Endpoints {
-				endpointSetPool[familyModels[i].Endpoints[j]] = struct{}{}
+				endpointSet[familyModels[i].Endpoints[j]] = struct{}{}
 			}
 		}
 
-		stringSlicePool = stringSlicePool[:0]
-		for ep := range endpointSetPool {
-			stringSlicePool = append(stringSlicePool, ep)
+		epSlice := make([]string, 0, len(endpointSet))
+		for ep := range endpointSet {
+			epSlice = append(epSlice, ep)
 		}
-		sort.Strings(stringSlicePool)
-
-		endpoints := make([]string, len(stringSlicePool))
-		copy(endpoints, stringSlicePool)
+		sort.Strings(epSlice)
 
 		sort.Slice(familyModels, func(i, j int) bool {
 			return familyModels[i].Name < familyModels[j].Name
 		})
 
-		group := ModelGroupSummary{
+		modelGroups = append(modelGroups, ModelGroupSummary{
 			Family:     family,
 			ModelCount: len(familyModels),
 			Models:     familyModels,
-			Endpoints:  endpoints,
-		}
-
-		modelGroupPool = append(modelGroupPool, group)
+			Endpoints:  epSlice,
+		})
 	}
 
-	sort.Slice(modelGroupPool, func(i, j int) bool {
-		if modelGroupPool[i].Family == familyUnknown {
+	sort.Slice(modelGroups, func(i, j int) bool {
+		if modelGroups[i].Family == familyUnknown {
 			return false
 		}
-		if modelGroupPool[j].Family == familyUnknown {
+		if modelGroups[j].Family == familyUnknown {
 			return true
 		}
-		return modelGroupPool[i].Family < modelGroupPool[j].Family
+		return modelGroups[i].Family < modelGroups[j].Family
 	})
 
-	return modelGroupPool
+	return modelGroups
 }
 
 func (a *Application) getRecentModels(models []ModelSummary, limit int) []ModelSummary {
@@ -282,36 +238,34 @@ func (a *Application) getRecentModels(models []ModelSummary, limit int) []ModelS
 const modelTypeEmbeddings = "embeddings"
 
 func (a *Application) inferCapabilities(details *domain.ModelDetails) []string {
-	capabilitiesPool = capabilitiesPool[:0]
+	caps := make([]string, 0, 4)
 
 	if details.Type != nil {
 		switch *details.Type {
 		case "vlm":
-			capabilitiesPool = append(capabilitiesPool, "vision", "multimodal")
+			caps = append(caps, "vision", "multimodal")
 		case modelTypeEmbeddings:
-			capabilitiesPool = append(capabilitiesPool, "embeddings", "vector_search")
+			caps = append(caps, "embeddings", "vector_search")
 		case "llm":
-			capabilitiesPool = append(capabilitiesPool, "text_generation", "chat")
+			caps = append(caps, "text_generation", "chat")
 		}
 	}
 
 	if details.MaxContextLength != nil && *details.MaxContextLength > 100000 {
-		capabilitiesPool = append(capabilitiesPool, "long_context")
+		caps = append(caps, "long_context")
 	}
 
 	if details.QuantizationLevel != nil {
 		quant := *details.QuantizationLevel
 		if strings.Contains(quant, "fp16") || strings.Contains(quant, "bf16") {
-			capabilitiesPool = append(capabilitiesPool, "high_precision")
+			caps = append(caps, "high_precision")
 		}
 	}
 
-	if len(capabilitiesPool) == 0 {
+	if len(caps) == 0 {
 		return nil
 	}
-	result := make([]string, len(capabilitiesPool))
-	copy(result, capabilitiesPool)
-	return result
+	return caps
 }
 
 // from Scout

--- a/internal/app/handlers/handler_status_models_test.go
+++ b/internal/app/handlers/handler_status_models_test.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+// TestBuildModelSummaries_EndpointNamesConsistent pins the v0.0.28 contract:
+// ModelSummary.Endpoints must contain endpoint NAMES (not URLs) for all
+// occurrences — first and subsequent — when a model appears on multiple
+// endpoints.
+//
+// Prior to the Phase 1 pool-removal refactor the first occurrence received the
+// endpoint URL while duplicates received the name. The new code is consistent
+// (always names). This test exists to lock that contract so it cannot silently
+// drift back.
+func TestBuildModelSummaries_EndpointNamesConsistent(t *testing.T) {
+	t.Parallel()
+
+	app := &Application{}
+
+	now := time.Now()
+
+	modelMap := map[string]*domain.EndpointModels{
+		"http://localhost:11434": {
+			Models: []*domain.ModelInfo{
+				{Name: "llama3", LastSeen: now},
+				{Name: "mistral", LastSeen: now},
+			},
+		},
+		"http://localhost:8080": {
+			Models: []*domain.ModelInfo{
+				// llama3 appears on both endpoints — the duplicate path was the
+				// original source of the inconsistency.
+				{Name: "llama3", LastSeen: now.Add(-time.Minute)},
+			},
+		},
+	}
+
+	// endpointNames maps URL → human-readable name, mirroring what modelsStatusHandler builds.
+	endpointNames := map[string]string{
+		"http://localhost:11434": "ollama-local",
+		"http://localhost:8080":  "lmstudio-local",
+	}
+
+	summaries := app.buildModelSummaries(modelMap, endpointNames)
+
+	// Build a lookup by model name for assertion convenience.
+	byName := make(map[string]ModelSummary, len(summaries))
+	for _, s := range summaries {
+		byName[s.Name] = s
+	}
+
+	// mistral lives on exactly one endpoint — straightforward name check.
+	mistral, ok := byName["mistral"]
+	if !ok {
+		t.Fatal("expected 'mistral' in summaries")
+	}
+	if len(mistral.Endpoints) != 1 {
+		t.Fatalf("mistral: expected 1 endpoint, got %d: %v", len(mistral.Endpoints), mistral.Endpoints)
+	}
+	if mistral.Endpoints[0] != "ollama-local" {
+		t.Errorf("mistral: Endpoints[0] should be name 'ollama-local', got %q", mistral.Endpoints[0])
+	}
+
+	// llama3 lives on two endpoints — this is where old code put a URL for the
+	// first occurrence. Both entries must be names.
+	llama, ok := byName["llama3"]
+	if !ok {
+		t.Fatal("expected 'llama3' in summaries")
+	}
+	if len(llama.Endpoints) != 2 {
+		t.Fatalf("llama3: expected 2 endpoints, got %d: %v", len(llama.Endpoints), llama.Endpoints)
+	}
+
+	sort.Strings(llama.Endpoints)
+	wantEndpoints := []string{"lmstudio-local", "ollama-local"}
+	sort.Strings(wantEndpoints)
+
+	for i, got := range llama.Endpoints {
+		if got != wantEndpoints[i] {
+			t.Errorf("llama3: Endpoints[%d] = %q, want %q (must be a name, not a URL)", i, got, wantEndpoints[i])
+		}
+	}
+
+	// Paranoia: verify none of the endpoint strings look like URLs.
+	for _, s := range summaries {
+		for _, ep := range s.Endpoints {
+			if len(ep) > 4 && ep[:4] == "http" {
+				t.Errorf("model %q: endpoint %q looks like a URL, expected an endpoint name", s.Name, ep)
+			}
+		}
+	}
+}
+
+// TestBuildModelSummaries_FallbackToURL confirms that when a URL has no name
+// mapping (e.g. a newly-discovered endpoint not yet in the repository snapshot),
+// buildModelSummaries falls back to the URL so the model is not silently
+// dropped. The URL-as-fallback is an explicit code path (endpointName = endpointURL).
+func TestBuildModelSummaries_FallbackToURL(t *testing.T) {
+	t.Parallel()
+
+	app := &Application{}
+
+	modelMap := map[string]*domain.EndpointModels{
+		"http://192.168.1.50:11434": {
+			Models: []*domain.ModelInfo{
+				{Name: "phi3", LastSeen: time.Now()},
+			},
+		},
+	}
+
+	// No entry for this URL — triggers the fallback to URL path.
+	endpointNames := map[string]string{}
+
+	summaries := app.buildModelSummaries(modelMap, endpointNames)
+
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	if summaries[0].Name != "phi3" {
+		t.Fatalf("unexpected model name %q", summaries[0].Name)
+	}
+	if len(summaries[0].Endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint entry, got %d", len(summaries[0].Endpoints))
+	}
+	// The fallback value is the URL itself — this is acceptable and documented behaviour.
+	if summaries[0].Endpoints[0] != "http://192.168.1.50:11434" {
+		t.Errorf("expected URL as fallback endpoint, got %q", summaries[0].Endpoints[0])
+	}
+}

--- a/internal/app/handlers/handler_status_race_test.go
+++ b/internal/app/handlers/handler_status_race_test.go
@@ -1,0 +1,187 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/domain"
+)
+
+// TestModelsStatusHandler_Concurrent verifies that concurrent requests to
+// /internal/status/models produce valid, independent responses with no data
+// races. The race detector must flag any shared-state violation on the slices
+// and maps that were previously package-level globals.
+func TestModelsStatusHandler_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []*domain.Endpoint{
+		{
+			Name:      "ollama-local",
+			Type:      "ollama",
+			URLString: "http://localhost:11434",
+			Status:    domain.StatusHealthy,
+			Priority:  1,
+		},
+		{
+			Name:      "lmstudio-local",
+			Type:      "lm-studio",
+			URLString: "http://localhost:1234",
+			Status:    domain.StatusHealthy,
+			Priority:  2,
+		},
+	}
+
+	// Populate the model registry with a couple of models so the code paths
+	// that build summaries and group by family are exercised.
+	family := "llama"
+	paramSize := "7B"
+	quant := "Q4_K_M"
+	modelInfo := &domain.ModelInfo{
+		Name: "llama3:7b",
+		Type: "llm",
+		Size: 4_000_000_000,
+		Details: &domain.ModelDetails{
+			Family:            &family,
+			ParameterSize:     &paramSize,
+			QuantizationLevel: &quant,
+		},
+	}
+
+	registry := &mockStatusModelRegistry{
+		endpointModels: map[string]*domain.EndpointModels{
+			"http://localhost:11434": {
+				Models: []*domain.ModelInfo{modelInfo},
+			},
+			"http://localhost:1234": {
+				Models: []*domain.ModelInfo{modelInfo},
+			},
+		},
+	}
+
+	repo := &mockStatusEndpointRepository{endpoints: endpoints}
+	stats := &mockStatusStatsCollector{}
+
+	app := &Application{
+		repository:     repo,
+		statsCollector: stats,
+		modelRegistry:  registry,
+	}
+
+	const goroutines = 40
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			req := httptest.NewRequest(http.MethodGet, "/internal/status/models?detailed=true&group=family", nil)
+			w := httptest.NewRecorder()
+
+			app.modelsStatusHandler(w, req)
+
+			if w.Code != http.StatusOK {
+				errs <- assert.AnError
+				return
+			}
+
+			var resp ModelStatusResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				errs <- err
+				return
+			}
+
+			// Basic sanity: both endpoints expose the same model so we expect 1 unique entry.
+			if resp.TotalModels != 1 {
+				errs <- assert.AnError
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "concurrent /internal/status/models request failed")
+	}
+}
+
+// TestStatusHandler_Concurrent verifies that concurrent requests to
+// /internal/status produce valid independent responses. The issuesPool was a
+// package-level var that could be corrupted across goroutines.
+func TestStatusHandler_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []*domain.Endpoint{
+		{
+			Name:                "ep-healthy",
+			Type:                "ollama",
+			URLString:           "http://localhost:11434",
+			Status:              domain.StatusHealthy,
+			Priority:            1,
+			ConsecutiveFailures: 0,
+		},
+		{
+			Name:                "ep-unhealthy",
+			Type:                "openai",
+			URLString:           "http://localhost:8080",
+			Status:              domain.StatusUnhealthy,
+			Priority:            2,
+			ConsecutiveFailures: 5,
+		},
+	}
+
+	app := &Application{
+		repository:     &mockStatusEndpointRepository{endpoints: endpoints},
+		statsCollector: &mockStatusStatsCollector{},
+		modelRegistry:  &mockStatusModelRegistry{},
+		StartTime:      time.Now(),
+		Config:         &config.Config{},
+	}
+
+	const goroutines = 40
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			req := httptest.NewRequest(http.MethodGet, "/internal/status", nil)
+			w := httptest.NewRecorder()
+
+			app.statusHandler(w, req)
+
+			if w.Code != http.StatusOK {
+				errs <- assert.AnError
+				return
+			}
+
+			var resp StatusResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				errs <- err
+				return
+			}
+
+			if len(resp.Endpoints) != 2 {
+				errs <- assert.AnError
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err, "concurrent /internal/status request failed")
+	}
+}

--- a/internal/app/handlers/handler_translation.go
+++ b/internal/app/handlers/handler_translation.go
@@ -667,8 +667,13 @@ func (a *Application) handleStreamingBackendError(
 		"status_code", streamRecorder.status,
 		"translator", trans.Name())
 
-	// Read error response from pipe
-	errorBody, _ := io.ReadAll(pipeReader)
+	// Cap the error-body read so a misbehaving backend cannot exhaust the heap.
+	// Anything beyond MaxUpstreamErrorBodyBytes is silently discarded; legitimate
+	// error messages are far smaller than this limit.
+	// After the limited read, close the reader with an error so the proxy goroutine's
+	// blocked pipe write is unblocked rather than hanging forever.
+	errorBody, _ := io.ReadAll(io.LimitReader(pipeReader, constants.MaxUpstreamErrorBodyBytes))
+	pipeReader.CloseWithError(io.ErrClosedPipe)
 
 	// try to parse OpenAI error format and extract message
 	errorMsg := a.parseStreamingErrorMessage(errorBody)

--- a/internal/app/handlers/handler_translation_security_test.go
+++ b/internal/app/handlers/handler_translation_security_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+// Regression tests for Phase 3 security hardening items:
+//   2. Upstream error-body read is capped at MaxUpstreamErrorBodyBytes.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/thushan/olla/internal/adapter/inspector"
+	"github.com/thushan/olla/internal/adapter/translator"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// TestStreamingBackendError_ErrorBodyCapped verifies that handleStreamingBackendError
+// does not deadlock when the upstream sends more than MaxUpstreamErrorBodyBytes.
+// Without io.LimitReader the handler would read indefinitely; with it, reading stops
+// at the cap and the pipeReader is closed to unblock the proxy goroutine.
+func TestStreamingBackendError_ErrorBodyCapped(t *testing.T) {
+	t.Parallel()
+
+	proxyFunc := func(
+		_ context.Context,
+		w http.ResponseWriter,
+		_ *http.Request,
+		_ []*domain.Endpoint,
+		_ *ports.RequestStats,
+		_ logger.StyledLogger,
+	) error {
+		w.WriteHeader(http.StatusInternalServerError)
+		// Write exactly the cap so we sit on the LimitReader boundary.
+		// The write may be cut short when the reader closes the pipe; that is
+		// intentional — the proxy error is discarded in the error path.
+		buf := make([]byte, constants.MaxUpstreamErrorBodyBytes)
+		copy(buf, `{"error":{"message":"big-error"}}`)
+		_, _ = w.Write(buf)
+		return nil
+	}
+
+	trans := &mockTranslator{
+		name:                  "cap-test-translator",
+		implementsErrorWriter: true,
+		writeErrorFunc: func(w http.ResponseWriter, err error, statusCode int) {
+			w.WriteHeader(statusCode)
+		},
+		transformRequestFunc: func(_ context.Context, _ *http.Request) (*translator.TransformedRequest, error) {
+			return &translator.TransformedRequest{
+				OpenAIRequest: map[string]interface{}{
+					"model":    "test-model",
+					"stream":   true,
+					"messages": []interface{}{map[string]interface{}{"role": "user", "content": "hi"}},
+				},
+				ModelName:   "test-model",
+				IsStreaming: true,
+			}, nil
+		},
+	}
+
+	app := &Application{
+		logger:           &mockStyledLogger{},
+		proxyService:     &mockProxyService{proxyFunc: proxyFunc},
+		statsCollector:   &mockStatsCollector{},
+		repository:       &mockEndpointRepository{},
+		inspectorChain:   inspector.NewChain(&mockStyledLogger{}),
+		profileFactory:   &mockProfileFactory{},
+		discoveryService: &mockDiscoveryServiceForTranslation{},
+		Config:           &config.Config{},
+	}
+
+	reqBody := `{"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}`
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(reqBody))
+	req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
+
+	// Run the handler in a goroutine so we can apply a local deadline. A deadlock
+	// (missing LimitReader + CloseWithError) would hang here indefinitely.
+	type result struct {
+		code int
+	}
+	ch := make(chan result, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		app.translationHandler(trans).ServeHTTP(rec, req)
+		ch <- result{code: rec.Code}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.code != http.StatusInternalServerError {
+			t.Errorf("expected 500 from backend error path, got %d", r.code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler deadlocked — LimitReader cap or CloseWithError may be missing")
+	}
+}

--- a/internal/app/handlers/server.go
+++ b/internal/app/handlers/server.go
@@ -1,65 +1,11 @@
 package handlers
 
 import (
-	"errors"
 	"net/http"
-	"strings"
 
 	"github.com/thushan/olla/internal/core/constants"
-
-	"github.com/docker/go-units"
 )
 
-func (a *Application) startWebServer() {
-	configServer := a.Config.Server
-
-	a.logger.Info("Starting Olla Server...", "host", configServer.Host, "port", configServer.Port,
-		"read_timeout", configServer.ReadTimeout, "write_timeout", configServer.WriteTimeout)
-
-	if configServer.WriteTimeout > 0 {
-		a.logger.Warn("Write timeout is set, this may cause issues with long-running requests. (default: 0s)", "write_timeout", configServer.WriteTimeout)
-	}
-
-	if configServer.RequestLimits.MaxBodySize > 0 || configServer.RequestLimits.MaxHeaderSize > 0 {
-		a.logger.Info("Request size limits enabled",
-			"max_body_size", units.HumanSize(float64(configServer.RequestLimits.MaxBodySize)),
-			"max_header_size", units.HumanSize(float64(configServer.RequestLimits.MaxHeaderSize)))
-	}
-
-	if configServer.RateLimits.GlobalRequestsPerMinute > 0 || configServer.RateLimits.PerIPRequestsPerMinute > 0 {
-		a.logger.Info("Rate limiting enabled",
-			"global_limit", configServer.RateLimits.GlobalRequestsPerMinute,
-			"per_ip_limit", configServer.RateLimits.PerIPRequestsPerMinute,
-			"burst_size", configServer.RateLimits.BurstSize,
-			"health_limit", configServer.RateLimits.HealthRequestsPerMinute,
-			"trust_proxy", configServer.RateLimits.TrustProxyHeaders)
-	}
-
-	if configServer.RateLimits.TrustProxyHeaders && len(configServer.RateLimits.TrustedProxyCIDRs) > 0 {
-		cidrsStr := strings.Join(configServer.RateLimits.TrustedProxyCIDRs, ", ")
-		a.logger.Info("Configured Trusted Proxy CIDRS", "cidrs", cidrsStr)
-	}
-
-	mux := http.NewServeMux()
-
-	a.registerRoutes()
-	a.routeRegistry.WireUpWithSecurityChain(mux, a.securityAdapters)
-
-	go func() {
-		if err := a.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			a.logger.Error("HTTP server error", "error", err)
-			a.errCh <- err
-		}
-	}()
-
-	if configServer.RequestLogging {
-		a.server.Handler = a.loggingMiddleware(mux)
-	} else {
-		a.server.Handler = mux
-	}
-
-	a.logger.Info("Started Olla Server", "bind", a.server.Addr)
-}
 func (a *Application) loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		a.logger.Info("HTTP request",

--- a/internal/app/middleware/logging.go
+++ b/internal/app/middleware/logging.go
@@ -24,6 +24,32 @@ const (
 	LoggerKey    contextKey = "logger"
 )
 
+const (
+	// maxRequestIDLength caps the inbound X-Request-ID length. Values beyond this
+	// are most likely probing attempts or misconfigured clients; generating a fresh
+	// ID is cheaper than propagating an unbounded string into every log line.
+	maxRequestIDLength = 128
+)
+
+// sanitiseRequestID validates a client-supplied request ID and returns it
+// unchanged if it passes. An empty string signals the caller to generate a
+// fresh ID instead. Rejected when: longer than maxRequestIDLength, or contains
+// any character that is not a printable ASCII non-space (CR, LF, NUL, tabs and
+// other control characters are log-injection vectors).
+func sanitiseRequestID(id string) string {
+	if len(id) > maxRequestIDLength {
+		return ""
+	}
+	for _, c := range id {
+		// Only allow printable ASCII (0x21–0x7E). Space (0x20) is technically
+		// printable but rarely intentional in IDs and trips some log parsers.
+		if c < 0x21 || c > 0x7E {
+			return ""
+		}
+	}
+	return id
+}
+
 // IsProxyRequest determines if a request is for the proxy endpoints
 // Used to decide logging levels to avoid redundancy with proxy handler logging
 func IsProxyRequest(path string) bool {
@@ -84,8 +110,10 @@ func EnhancedLoggingMiddleware(styledLogger logger.StyledLogger) func(http.Handl
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 
-			// Get or create request ID
-			requestID := r.Header.Get(constants.HeaderXRequestID)
+			// Get or create request ID. Validate the inbound value to prevent
+			// log injection via CR/LF or non-printable characters, and to cap
+			// the length so structured log fields stay bounded.
+			requestID := sanitiseRequestID(r.Header.Get(constants.HeaderXRequestID))
 			if requestID == "" {
 				requestID = util.GenerateRequestID()
 			}

--- a/internal/app/middleware/logging_test.go
+++ b/internal/app/middleware/logging_test.go
@@ -258,6 +258,152 @@ func TestRedactQuery(t *testing.T) {
 	}
 }
 
+// TestSanitiseRequestID verifies that inbound X-Request-ID values containing
+// log-injection characters or exceeding the length cap are rejected, while
+// well-formed IDs pass through unchanged.
+func TestSanitiseRequestID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantOut string // empty means a fresh ID should be generated (input rejected)
+	}{
+		{
+			name:    "valid alphanumeric ID passes through",
+			input:   "abc-def-1234",
+			wantOut: "abc-def-1234",
+		},
+		{
+			name:    "valid ID with printable ASCII passes through",
+			input:   "req_!@#$%^&*()_+[]{}|;:,.<>?",
+			wantOut: "req_!@#$%^&*()_+[]{}|;:,.<>?",
+		},
+		{
+			name:    "CR injection rejected",
+			input:   "valid\rmalicious",
+			wantOut: "",
+		},
+		{
+			name:    "LF injection rejected",
+			input:   "valid\nmalicious",
+			wantOut: "",
+		},
+		{
+			name:    "CRLF injection rejected",
+			input:   "valid\r\nX-Injected-Header: evil",
+			wantOut: "",
+		},
+		{
+			name:    "NUL byte rejected",
+			input:   "valid\x00nul",
+			wantOut: "",
+		},
+		{
+			name:    "tab rejected",
+			input:   "valid\tvalue",
+			wantOut: "",
+		},
+		{
+			name:    "space rejected",
+			input:   "valid value",
+			wantOut: "",
+		},
+		{
+			name:    "DEL (0x7F) rejected",
+			input:   "valid\x7Fvalue",
+			wantOut: "",
+		},
+		{
+			name:    "exactly maxRequestIDLength accepted",
+			input:   strings.Repeat("a", maxRequestIDLength),
+			wantOut: strings.Repeat("a", maxRequestIDLength),
+		},
+		{
+			name:    "maxRequestIDLength+1 rejected",
+			input:   strings.Repeat("a", maxRequestIDLength+1),
+			wantOut: "",
+		},
+		{
+			name:    "empty string returned as-is (caller generates fresh ID)",
+			input:   "",
+			wantOut: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitiseRequestID(tt.input)
+			if got != tt.wantOut {
+				t.Errorf("sanitiseRequestID(%q) = %q, want %q", tt.input, got, tt.wantOut)
+			}
+		})
+	}
+}
+
+// TestEnhancedLoggingMiddleware_InvalidRequestIDReplacedWithGenerated verifies
+// that a request carrying an X-Request-ID containing CRLF does not propagate the
+// injected value into the response or context; instead a fresh ID is generated.
+func TestEnhancedLoggingMiddleware_InvalidRequestIDReplacedWithGenerated(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := &mockStyledLogger{}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The context request ID must not contain the injected header value.
+		ctxID := GetRequestID(r.Context())
+		if strings.Contains(ctxID, "injected") {
+			t.Errorf("log-injection payload leaked into context request ID: %q", ctxID)
+		}
+		if strings.ContainsAny(ctxID, "\r\n") {
+			t.Errorf("context request ID contains CRLF: %q", ctxID)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := EnhancedLoggingMiddleware(mockLogger)(handler)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/health", nil)
+	req.Header.Set("X-Request-ID", "ok\r\nX-Injected: evil")
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	responseID := rr.Header().Get("X-Olla-Request-ID")
+	if strings.ContainsAny(responseID, "\r\n") {
+		t.Errorf("response X-Olla-Request-ID contains CRLF: %q", responseID)
+	}
+	if responseID == "" {
+		t.Error("response X-Olla-Request-ID must be non-empty even when the inbound ID is rejected")
+	}
+}
+
+// TestEnhancedLoggingMiddleware_ValidRequestIDPreserved verifies that a clean
+// inbound X-Request-ID is echoed in the response header unchanged.
+func TestEnhancedLoggingMiddleware_ValidRequestIDPreserved(t *testing.T) {
+	t.Parallel()
+
+	mockLogger := &mockStyledLogger{}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := EnhancedLoggingMiddleware(mockLogger)(handler)
+
+	const cleanID = "my-clean-request-id-abc123"
+	req := httptest.NewRequest(http.MethodGet, "/internal/health", nil)
+	req.Header.Set("X-Request-ID", cleanID)
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("X-Olla-Request-ID"); got != cleanID {
+		t.Errorf("X-Olla-Request-ID = %q, want %q", got, cleanID)
+	}
+}
+
 // Mock styled logger for testing
 type mockStyledLogger struct{}
 

--- a/internal/app/services/http.go
+++ b/internal/app/services/http.go
@@ -142,6 +142,15 @@ func (s *HTTPService) Start(ctx context.Context) error {
 		s.application.SetStickyStatsFn(s.proxySvc.StickyStats)
 	}
 
+	// Wire real security adapters so non-proxy routes get size validation.
+	// This is separate from the security chain (which handles proxy routes) so
+	// non-proxy routes are protected without requiring full chain enforcement.
+	if s.securitySvc != nil {
+		if realAdapters, err := s.securitySvc.GetAdapters(); err == nil && realAdapters != nil {
+			s.application.SetSecurityAdapters(realAdapters)
+		}
+	}
+
 	s.application.RegisterRoutes()
 
 	// Wire routes with security middleware

--- a/internal/core/constants/security.go
+++ b/internal/core/constants/security.go
@@ -3,4 +3,15 @@ package constants
 const (
 	ViolationRateLimit = "rate_limit"
 	ViolationSizeLimit = "size_limit"
+
+	// MaxUpstreamErrorBodyBytes caps how many bytes we read from an upstream error
+	// response before discarding the rest. A misbehaving or compromised backend
+	// could return an arbitrarily large body; reading it all into memory would
+	// exhaust the heap. 1 MiB is enough to capture any reasonable error message.
+	MaxUpstreamErrorBodyBytes = 1 << 20 // 1 MiB
+
+	// HeaderXOllaPrefix is the canonical prefix for all Olla-owned response headers.
+	// Used to strip backend-supplied spoofs from the upstream→client copy path so
+	// Olla is the sole authority for these headers.
+	HeaderXOllaPrefix = "X-Olla-"
 )

--- a/internal/core/domain/endpoint.go
+++ b/internal/core/domain/endpoint.go
@@ -39,7 +39,9 @@ type Endpoint struct {
 	ModelURLString        string
 	// AuthHeaderName is the resolved header name for outbound auth (e.g. "Authorization", "X-Api-Key").
 	// Precomputed at load time so the hot path pays no allocation cost.
-	AuthHeaderName string
+	// Never serialised: exposing the header name through status endpoints would reveal the
+	// auth scheme in use, making credential-guessing attacks cheaper.
+	AuthHeaderName string `json:"-"`
 	// AuthHeaderValue is the fully composed header value (e.g. "Bearer tok", "Basic base64(...)").
 	// Never serialised; leaking credentials through logs or status endpoints would be a security issue.
 	AuthHeaderValue     string `json:"-"`

--- a/internal/core/domain/json_safety_test.go
+++ b/internal/core/domain/json_safety_test.go
@@ -91,6 +91,41 @@ func TestEndpointAuthFieldsNotSerialised(t *testing.T) {
 	}
 }
 
+// TestEndpointAuthHeaderNameNotSerialised asserts that AuthHeaderName is never
+// emitted in JSON. The header name (e.g. "Authorization", "X-Api-Key") reveals
+// the auth scheme in use and makes credential-probing attacks cheaper; it must
+// be treated with the same confidentiality as the value itself.
+func TestEndpointAuthHeaderNameNotSerialised(t *testing.T) {
+	t.Parallel()
+
+	for _, headerName := range []string{"Authorization", "X-Api-Key", "X-Auth-Token"} {
+
+		t.Run(headerName, func(t *testing.T) {
+			t.Parallel()
+
+			ep := domain.Endpoint{
+				Name:            "secure-ep",
+				Type:            "vllm",
+				AuthHeaderName:  headerName,
+				AuthHeaderValue: "Bearer tok",
+			}
+
+			data, err := json.Marshal(ep)
+			if err != nil {
+				t.Fatalf("json.Marshal: %v", err)
+			}
+
+			if strings.Contains(string(data), headerName) {
+				t.Errorf("AuthHeaderName %q leaked into JSON output: %s", headerName, data)
+			}
+			// Sanity: public fields are still emitted.
+			if !strings.Contains(string(data), "secure-ep") {
+				t.Errorf("Endpoint name missing from JSON output: %s", data)
+			}
+		})
+	}
+}
+
 // TestEndpointHeadersNotSerialised asserts that Endpoint.Headers is not included
 // in JSON output. The map may contain API keys or other custom auth values set
 // via the headers: config block; exposing them through status endpoints would

--- a/internal/router/registry.go
+++ b/internal/router/registry.go
@@ -158,12 +158,24 @@ func (r *RouteRegistry) WireUpWithSecurityChain(mux *http.ServeMux, securityAdap
 		CreateRateLimitMiddleware() func(http.Handler) http.Handler
 	}
 
+	// Optional: size validation for non-proxy routes. The full security chain
+	// (proxy routes) already includes size enforcement; this ensures non-proxy
+	// routes (status, health, stats) are also protected against oversized bodies.
+	// Rate limiting on non-proxy routes is intentionally omitted: these endpoints
+	// are internal/observability-only and applying a per-IP token bucket would
+	// complicate operations without meaningful security benefit.
+	type sizeMiddlewareProvider interface {
+		CreateSizeMiddleware() func(http.Handler) http.Handler
+	}
+
 	adapters, hasAdapters := securityAdapters.(securityAdapterProvider)
 
 	if !hasAdapters {
 		r.WireUp(mux)
 		return
 	}
+
+	sizeProvider, hasSizeMiddleware := securityAdapters.(sizeMiddlewareProvider)
 
 	for route, info := range r.routes {
 		var handler http.Handler = info.Handler
@@ -172,7 +184,18 @@ func (r *RouteRegistry) WireUpWithSecurityChain(mux *http.ServeMux, securityAdap
 			handler = adapters.CreateChainMiddleware()(handler)
 			mux.Handle(route, handler)
 		} else {
+			// Non-proxy routes (status, health, stats) get logging via
+			// CreateRateLimitMiddleware. Size validation is added on top when the
+			// adapter supports it, running before the rate-limit/logging wrap so
+			// oversized requests are rejected before consuming any quota or log budget.
+			// Rate limiting itself is intentionally not enforced on these internal
+			// endpoints; they are operational/observability-only and applying a
+			// per-IP token bucket would complicate deployments without meaningful
+			// security gain.
 			handler = adapters.CreateRateLimitMiddleware()(handler)
+			if hasSizeMiddleware {
+				handler = sizeProvider.CreateSizeMiddleware()(handler)
+			}
 			mux.Handle(route, handler)
 		}
 	}

--- a/internal/router/registry_security_test.go
+++ b/internal/router/registry_security_test.go
@@ -1,0 +1,135 @@
+package router
+
+// Regression tests for Phase 3 security hardening item 3:
+// Non-proxy routes must receive request-size validation when a sizeMiddlewareProvider
+// is wired in, so that oversized bodies are rejected on status/health/stats endpoints.
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// capAdapters is a minimal security adapter that applies a 10-byte body cap on
+// non-proxy routes (via CreateSizeMiddleware) and a pass-through chain on proxy
+// routes (to keep the test focused on item 3 only).
+type capAdapters struct{}
+
+func (c *capAdapters) CreateChainMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler { return next }
+}
+
+func (c *capAdapters) CreateRateLimitMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler { return next }
+}
+
+func (c *capAdapters) CreateSizeMiddleware() func(http.Handler) http.Handler {
+	const maxBytes = 10
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ContentLength > maxBytes {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// TestWireUpWithSecurityChain_NonProxyRouteGetsSizeValidation verifies that a
+// non-proxy route rejects an oversized body when a sizeMiddlewareProvider is wired
+// in. Without the fix, the route would receive no size check and return 200.
+func TestWireUpWithSecurityChain_NonProxyRouteGetsSizeValidation(t *testing.T) {
+	t.Parallel()
+
+	reached := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	reg := NewRouteRegistry(&mockRouteLogger{})
+	reg.RegisterWithMethod("/internal/status", handler, "status", http.MethodGet)
+
+	mux := http.NewServeMux()
+	reg.WireUpWithSecurityChain(mux, &capAdapters{})
+
+	// Send a body larger than the 10-byte cap in capAdapters.
+	body := strings.Repeat("x", 50)
+	req := httptest.NewRequest(http.MethodGet, "/internal/status", strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d; size validation is not applied to non-proxy routes", rr.Code)
+	}
+	if reached {
+		t.Error("handler was reached; request should have been rejected by size middleware")
+	}
+}
+
+// TestWireUpWithSecurityChain_NonProxyRouteAllowsSmallBody verifies that a
+// non-proxy route with a body under the size limit is still served normally.
+func TestWireUpWithSecurityChain_NonProxyRouteAllowsSmallBody(t *testing.T) {
+	t.Parallel()
+
+	reached := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	reg := NewRouteRegistry(&mockRouteLogger{})
+	reg.RegisterWithMethod("/internal/status", handler, "status", http.MethodGet)
+
+	mux := http.NewServeMux()
+	reg.WireUpWithSecurityChain(mux, &capAdapters{})
+
+	// 5 bytes is within the 10-byte cap.
+	req := httptest.NewRequest(http.MethodGet, "/internal/status", strings.NewReader("hello"))
+	req.ContentLength = 5
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+	if !reached {
+		t.Error("handler was not reached; small request should pass size validation")
+	}
+}
+
+// mockRouteLogger satisfies logger.StyledLogger for the RouteRegistry.
+type mockRouteLogger struct{}
+
+func (m *mockRouteLogger) Debug(msg string, args ...any)                                {}
+func (m *mockRouteLogger) Info(msg string, args ...any)                                 {}
+func (m *mockRouteLogger) Warn(msg string, args ...any)                                 {}
+func (m *mockRouteLogger) Error(msg string, args ...any)                                {}
+func (m *mockRouteLogger) ResetLine()                                                   {}
+func (m *mockRouteLogger) InfoWithStatus(msg string, status string, args ...any)        {}
+func (m *mockRouteLogger) InfoWithCount(msg string, count int, args ...any)             {}
+func (m *mockRouteLogger) InfoWithEndpoint(msg string, endpoint string, args ...any)    {}
+func (m *mockRouteLogger) InfoWithHealthCheck(msg string, endpoint string, args ...any) {}
+func (m *mockRouteLogger) InfoWithNumbers(msg string, numbers ...int64)                 {}
+func (m *mockRouteLogger) WarnWithEndpoint(msg string, endpoint string, args ...any)    {}
+func (m *mockRouteLogger) ErrorWithEndpoint(msg string, endpoint string, args ...any)   {}
+func (m *mockRouteLogger) InfoHealthy(msg string, endpoint string, args ...any)         {}
+func (m *mockRouteLogger) InfoHealthStatus(msg string, name string, status domain.EndpointStatus, args ...any) {
+}
+func (m *mockRouteLogger) GetUnderlying() *slog.Logger                                         { return slog.Default() }
+func (m *mockRouteLogger) WithRequestID(requestID string) logger.StyledLogger                  { return m }
+func (m *mockRouteLogger) InfoConfigChange(oldName, newName string)                            {}
+func (m *mockRouteLogger) WithAttrs(attrs ...slog.Attr) logger.StyledLogger                    { return m }
+func (m *mockRouteLogger) With(args ...any) logger.StyledLogger                                { return m }
+func (m *mockRouteLogger) InfoWithContext(msg string, endpoint string, ctx logger.LogContext)  {}
+func (m *mockRouteLogger) WarnWithContext(msg string, endpoint string, ctx logger.LogContext)  {}
+func (m *mockRouteLogger) ErrorWithContext(msg string, endpoint string, ctx logger.LogContext) {}


### PR DESCRIPTION
Some hardening  of Olla based on reviews, and todo's from  last couple of months + using [Fable 5](https://www.anthropic.com/news/claude-fable-5-mythos-5) - though quite a number were not  actual issues.

Fixes
- Status handlers (/internal/status, /internal/status/models) allocated per request
- Olla config pointer is now an atomic.Pointer, snapshotted once per request/stream, so a hot-reload can't hand an in-flight request a torn config
- Endpoint pools and circuit breakers use LoadOrCompute, so racing goroutines stop building and throwing away an http.Transport on first use
- Capped upstream error bodies at 1 MiB and close the pipe after, so a misbehaving backend can't exhaust the heap or hang the proxy goroutine.
- Non-proxy routes now reject oversized chunked bodies instead of waving them through (the old check only looked at Content-Length).

Security
- AuthHeaderName no longer serialises into status JSON (was leaking the auth scheme).
- Strip X-Olla-* headers off upstream responses so a backend can't spoof routing or session headers.
- Sanitise inbound X-Request-ID (printable ASCII, 128 cap) before it hits the logs to close a log-injection vector.

Cleanup
- Deleted a pile of dead code in the Olla engine: five unused methods, the unused request/error pools, a dead recordStateTransition carrying a latent panic, dead startWebServer, a forced runtime.GC(), and a request counter that was written but never
read.

Important changes of existing behaviour and user awareness:
- /internal/status/models endpoints now returns endpoint names for every entry. It used to return the backend URL for the first occurrence and names after, which was just inconsistent. Anyone reading endpoints[0] as a URL needs to switch to names.
- Chunked requests to non-proxy and translator endpoints now honour max_body_size.
- X-Olla-* response headers from upstream are dropped, so a chained Olla-in-front-of-Olla setup loses the inner instance's headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request body size validation enforced for non-proxy routes; configurable middleware available.
  * Sanitised inbound request IDs to prevent log injection.

* **Bug Fixes**
  * Prevented streaming deadlocks by capping upstream error-body reads.
  * Improved concurrency and configuration consistency for proxy handling.

* **Security**
  * Blocked upstream injection of platform-owned response headers.
  * Endpoint auth header no longer exposed in JSON status responses.

* **Tests**
  * Added regression and concurrency tests covering size limits, header handling and config races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->