### PR TITLE
Add native `GET /internal/metrics`

### DIFF
--- a/docs/content/api-reference/overview.md
+++ b/docs/content/api-reference/overview.md
@@ -23,6 +23,7 @@ Internal endpoints for health monitoring, system status, and statistics.
 
 - `/internal/health` - Health check endpoint
 - `/internal/status` - System status and statistics
+- `/internal/metrics` - Prometheus metrics (same data as `/internal/status` and `/internal/stats/models`)
 - `/internal/status/endpoints` - Endpoint status details
 - `/internal/status/models` - Model registry status
 - `/internal/stats/models` - Model usage statistics

--- a/docs/content/api-reference/system.md
+++ b/docs/content/api-reference/system.md
@@ -9,6 +9,7 @@ Internal endpoints for health monitoring, system status, and process information
 | GET | `/version` | Get Olla version information |
 | GET | `/internal/health` | Health check endpoint |
 | GET | `/internal/status` | System status and statistics |
+| GET | `/internal/metrics` | Prometheus metrics (same data as `/internal/status` and `/internal/stats/models`) |
 | GET | `/internal/status/endpoints` | Detailed endpoint status |
 | GET | `/internal/status/models` | Model registry status |
 | GET | `/internal/stats/models` | Model usage statistics |
@@ -49,6 +50,7 @@ curl -X GET http://localhost:40114/version
     "version": "v1",
     "endpoints": {
       "health": "/internal/health",
+      "metrics": "/internal/metrics",
       "status": "/internal/status",
       "process": "/internal/process",
       "version": "/version"
@@ -184,6 +186,85 @@ curl -X GET http://localhost:40114/internal/status
 **`endpoints[]` fields**: `name`, `status`, `success_rate`, `avg_latency`, `traffic`, `last_check`, `next_check`, `issues`, `models.{last_updated, count}`, `priority`, `connections`, `requests`. The `last_check` and `next_check` values are human-readable relative strings (e.g. `"2 seconds ago"`, `"in 3 seconds"`), not RFC3339 timestamps.
 
 **`system` fields**: `status` (healthy/degraded/critical), `endpoints_up`, `success_rate`, `avg_latency`, `total_traffic`, `uptime`, `version`, `commit`, `active_connections`, `security_violations`, `total_requests`, `total_failures`.
+
+---
+
+## GET /internal/metrics
+
+Prometheus text exposition of the same operational data as [`/internal/status`](#get-internalstatus) and [`/internal/stats/models`](#get-internalstatsmodels). Use this endpoint for Prometheus, Grafana Agent, or VictoriaMetrics scraping.
+
+### Request
+
+```bash
+curl -X GET http://localhost:40114/internal/metrics
+```
+
+### Response
+
+Content-Type: `text/plain; version=0.0.4; charset=utf-8`
+
+```text
+# HELP olla_requests_total Total proxy requests processed
+# TYPE olla_requests_total counter
+olla_requests_total 1523
+# HELP olla_endpoints_healthy Number of healthy endpoints
+# TYPE olla_endpoints_healthy gauge
+olla_endpoints_healthy 2
+# HELP olla_model_requests_total Total requests for a model
+# TYPE olla_model_requests_total counter
+olla_model_requests_total{model="llama3.2"} 1200
+```
+
+### Metrics exposed
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `olla_info` | gauge | Build and proxy config (`version`, `commit`, `engine`, `profile`, `balancer` labels) |
+| `olla_system_status` | gauge | Overall status: `2`=healthy, `1`=degraded, `0`=critical |
+| `olla_endpoints_total` | gauge | Total configured endpoints |
+| `olla_endpoints_healthy` | gauge | Healthy endpoint count |
+| `olla_success_rate_percent` | gauge | Proxy success rate |
+| `olla_avg_latency_ms` | gauge | Average proxy latency (ms) |
+| `olla_total_traffic_bytes` | gauge | Total traffic (bytes) |
+| `olla_uptime_seconds` | gauge | Process uptime |
+| `olla_active_connections` | gauge | Active connections |
+| `olla_requests_total` | counter | Total proxy requests |
+| `olla_failures_total` | counter | Total failed requests |
+| `olla_security_*` | gauge/counter | Security posture and violations |
+| `olla_endpoint_up` | gauge | Endpoint health (`endpoint`, `status` labels; value `1`=up) |
+| `olla_endpoint_*` | gauge/counter | Per-endpoint stats (`endpoint` label only) |
+| `olla_models_*` | gauge/counter | Aggregate model stats (same summary as `/internal/stats/models`) |
+| `olla_model_*` | gauge/counter | Per-model stats (`model` label) |
+| `olla_model_endpoint_*` | gauge/counter | Per-model, per-endpoint stats (`model`, `endpoint` labels) |
+
+> :memo: Translator-specific metrics remain on [`/internal/stats/translators`](#get-internalstatstranslators). Model routing and usage metrics from `/internal/stats/models` are included in `/internal/metrics`; scrape `/internal/stats/translators` separately if you need translation passthrough rates.
+
+### Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: olla
+    static_configs:
+      - targets: ['localhost:40114']
+    metrics_path: /internal/metrics
+```
+
+> :memo: When running Olla in Docker, bind the server to all interfaces (`server.host: "0.0.0.0"` or `OLLA_SERVER_HOST=0.0.0.0`) so published ports are reachable from the host.
+
+---
+
+## GET /internal/stats/models
+
+Model usage statistics including per-model request counts, latency, routing effectiveness, and optional per-endpoint breakdowns. The same data is exposed in Prometheus format on [`/internal/metrics`](#get-internalmetrics) as `olla_models_*`, `olla_model_*`, and `olla_model_endpoint_*` series.
+
+### Request
+
+```bash
+curl -X GET http://localhost:40114/internal/stats/models
+curl -X GET "http://localhost:40114/internal/stats/models?include_endpoints=true&include_summary=true"
+```
+
+Query parameters: `include_endpoints=true` adds per-endpoint breakdown per model; `include_summary=true` adds aggregated endpoint summaries.
 
 ---
 

--- a/docs/content/configuration/practices/monitoring.md
+++ b/docs/content/configuration/practices/monitoring.md
@@ -13,6 +13,7 @@ This guide covers monitoring and observability for Olla deployments.
 > # Built-in endpoints (always enabled)
 > # /internal/health - Basic health check
 > # /internal/status - Detailed status
+> # /internal/metrics - Prometheus metrics (same data as /internal/status)
 > # /internal/status/endpoints - Endpoint details
 > # /internal/stats/models - Model statistics
 > # /internal/stats/translators - Translator statistics
@@ -237,12 +238,34 @@ JSON format enables parsing:
 
 ## Prometheus Metrics
 
-### Exporting Metrics
+### Built-in endpoint
 
-While Olla doesn't have built-in Prometheus support, you can scrape the status endpoint:
+Olla exposes Prometheus text format at `/internal/metrics`, derived from the same snapshot as `/internal/status`:
+
+```bash
+curl http://localhost:40114/internal/metrics
+```
+
+Prometheus scrape configuration:
+
+```yaml
+scrape_configs:
+  - job_name: olla
+    static_configs:
+      - targets: ['localhost:40114']
+    metrics_path: /internal/metrics
+```
+
+Key metrics include `olla_requests_total`, `olla_failures_total`, `olla_endpoints_healthy`, `olla_avg_latency_ms`, per-endpoint series with an `endpoint` label (`olla_endpoint_up` also includes `status`), and model usage series (`olla_models_*`, `olla_model_*`, `olla_model_endpoint_*`) matching [`/internal/stats/models`](../../api-reference/system.md#get-internalstatsmodels). See the [System Endpoints API Reference](../../api-reference/system.md#get-internalmetrics) for the full list.
+
+> :memo: When running in Docker, set `OLLA_SERVER_HOST=0.0.0.0` (or `server.host: "0.0.0.0"`) so the published port is reachable from the host.
+
+### Optional external exporter
+
+For translator-specific metrics or custom dashboards, you can still scrape JSON endpoints alongside `/internal/metrics`:
 
 ```python
-# prometheus_exporter.py
+# prometheus_exporter.py (optional - for /internal/stats/translators etc.)
 import requests
 import time
 from prometheus_client import start_http_server, Gauge, Histogram
@@ -259,7 +282,7 @@ tokens_per_second = Histogram('olla_tokens_per_second', 'Token generation speed'
 prompt_tokens = Histogram('olla_prompt_tokens', 'Prompt token count',
                           ['endpoint', 'model'])
 completion_tokens = Histogram('olla_completion_tokens', 'Completion token count',
-                              ['endpoint', 'model'])
+                          ['endpoint', 'model'])
 
 def collect_metrics():
     while True:
@@ -286,6 +309,8 @@ if __name__ == '__main__':
     start_http_server(8000)
     collect_metrics()
 ```
+
+Prefer `/internal/metrics` for proxy, endpoint, and model stats; use `/internal/stats/translators` when you need translation passthrough rates.
 
 ### Grafana Dashboard
 

--- a/docs/content/configuration/practices/monitoring.md
+++ b/docs/content/configuration/practices/monitoring.md
@@ -13,7 +13,7 @@ This guide covers monitoring and observability for Olla deployments.
 > # Built-in endpoints (always enabled)
 > # /internal/health - Basic health check
 > # /internal/status - Detailed status
-> # /internal/metrics - Prometheus metrics (same data as /internal/status)
+> # /internal/metrics - Prometheus metrics (same data as /internal/status and /internal/stats/models)
 > # /internal/status/endpoints - Endpoint details
 > # /internal/stats/models - Model statistics
 > # /internal/stats/translators - Translator statistics

--- a/internal/app/handlers/handler_metrics.go
+++ b/internal/app/handlers/handler_metrics.go
@@ -106,8 +106,49 @@ func writePrometheusMetrics(w http.ResponseWriter, response StatusResponse, snap
 	_, _ = w.Write([]byte(b.String()))
 }
 
+type endpointMetricSample struct {
+	name        string
+	status      string
+	up          float64
+	requests    float64
+	connections float64
+	successRate float64
+	avgLatency  float64
+	traffic     float64
+	priority    float64
+	modelCount  float64
+}
+
 func writeEndpointPrometheusMetrics(b *strings.Builder, all []*domain.Endpoint, statsMap map[string]ports.EndpointStats,
 	connectionStats map[string]int64, modelMap map[string]*domain.EndpointModels) {
+	samples := make([]endpointMetricSample, 0, len(all))
+	for _, endpoint := range all {
+		url := endpoint.GetURLString()
+		stats, hasStats := statsMap[url]
+
+		sample := endpointMetricSample{
+			name:        endpoint.Name,
+			status:      endpoint.Status.String(),
+			connections: float64(connectionStats[url]),
+			priority:    float64(endpoint.Priority),
+		}
+		if endpoint.Status == domain.StatusHealthy {
+			sample.up = 1
+		}
+		if hasStats {
+			sample.requests = float64(stats.TotalRequests)
+			sample.avgLatency = float64(stats.AverageLatency)
+			sample.traffic = float64(stats.TotalBytes)
+			if stats.TotalRequests > 0 {
+				sample.successRate = float64(stats.SuccessfulRequests) / float64(stats.TotalRequests) * 100.0
+			}
+		}
+		if endpointModels := modelMap[url]; endpointModels != nil {
+			sample.modelCount = float64(len(endpointModels.Models))
+		}
+		samples = append(samples, sample)
+	}
+
 	writePrometheusHelpType(b, "olla_endpoint_up", "gauge", "Whether the endpoint is healthy (1) or not (0)")
 	writePrometheusHelpType(b, "olla_endpoint_requests_total", "counter", "Total requests handled by endpoint")
 	writePrometheusHelpType(b, "olla_endpoint_connections", "gauge", "Active connections for endpoint")
@@ -117,50 +158,95 @@ func writeEndpointPrometheusMetrics(b *strings.Builder, all []*domain.Endpoint, 
 	writePrometheusHelpType(b, "olla_endpoint_priority", "gauge", "Endpoint routing priority")
 	writePrometheusHelpType(b, "olla_endpoint_models_count", "gauge", "Number of models discovered on endpoint")
 
-	for _, endpoint := range all {
-		url := endpoint.GetURLString()
-		stats, hasStats := statsMap[url]
-		status := endpoint.Status.String()
-
-		var successRate float64
-		requests := int64(0)
-		avgLatency := int64(0)
-		trafficBytes := int64(0)
-		if hasStats {
-			requests = stats.TotalRequests
-			avgLatency = stats.AverageLatency
-			trafficBytes = stats.TotalBytes
-			if stats.TotalRequests > 0 {
-				successRate = float64(stats.SuccessfulRequests) / float64(stats.TotalRequests) * 100.0
-			}
-		}
-
-		modelCount := int64(0)
-		if endpointModels := modelMap[url]; endpointModels != nil {
-			modelCount = int64(len(endpointModels.Models))
-		}
-
-		up := float64(0)
-		if endpoint.Status == domain.StatusHealthy {
-			up = 1
-		}
-
-		writePrometheusLabeledGauge(b, "olla_endpoint_up", up, "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_requests_total", float64(requests), "endpoint", endpoint.Name)
-		writePrometheusLabeledGauge(b, "olla_endpoint_connections", float64(connectionStats[url]), "endpoint", endpoint.Name)
-		writePrometheusLabeledGauge(b, "olla_endpoint_success_rate_percent", successRate, "endpoint", endpoint.Name)
-		writePrometheusLabeledGauge(b, "olla_endpoint_avg_latency_ms", float64(avgLatency), "endpoint", endpoint.Name)
-		writePrometheusLabeledGauge(b, "olla_endpoint_traffic_bytes", float64(trafficBytes), "endpoint", endpoint.Name)
-		writePrometheusLabeledGauge(b, "olla_endpoint_priority", float64(endpoint.Priority), "endpoint", endpoint.Name)
-		writePrometheusLabeledGauge(b, "olla_endpoint_models_count", float64(modelCount), "endpoint", endpoint.Name)
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_up", sample.up, "endpoint", sample.name, "status", sample.status)
 	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_requests_total", sample.requests, "endpoint", sample.name)
+	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_connections", sample.connections, "endpoint", sample.name)
+	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_success_rate_percent", sample.successRate, "endpoint", sample.name)
+	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_avg_latency_ms", sample.avgLatency, "endpoint", sample.name)
+	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_traffic_bytes", sample.traffic, "endpoint", sample.name)
+	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_priority", sample.priority, "endpoint", sample.name)
+	}
+	for _, sample := range samples {
+		writePrometheusLabeledGauge(b, "olla_endpoint_models_count", sample.modelCount, "endpoint", sample.name)
+	}
+}
+
+type modelMetricSample struct {
+	name               string
+	requests           float64
+	successfulRequests float64
+	failedRequests     float64
+	successRate        float64
+	traffic            float64
+	avgLatency         float64
+	p95Latency         float64
+	p99Latency         float64
+	uniqueClients      float64
+	routingHits        float64
+	routingMisses      float64
+	routingFallbacks   float64
+}
+
+type modelEndpointMetricSample struct {
+	modelName         string
+	endpointName      string
+	requests          float64
+	successRate       float64
+	avgLatency        float64
+	consecutiveErrors float64
 }
 
 func writeModelPrometheusMetrics(b *strings.Builder, summary ModelStatsSummary, modelStats map[string]ports.ModelStats,
 	modelEndpointStats map[string]map[string]ports.EndpointModelStats) {
 	var totalTrafficBytes int64
-	for _, stats := range modelStats {
+	modelSamples := make([]modelMetricSample, 0, len(modelStats))
+	for name, stats := range modelStats {
 		totalTrafficBytes += stats.TotalBytes
+		sample := modelMetricSample{
+			name:               name,
+			requests:           float64(stats.TotalRequests),
+			successfulRequests: float64(stats.SuccessfulRequests),
+			failedRequests:     float64(stats.FailedRequests),
+			traffic:            float64(stats.TotalBytes),
+			avgLatency:         float64(stats.AverageLatency),
+			p95Latency:         float64(stats.P95Latency),
+			p99Latency:         float64(stats.P99Latency),
+			uniqueClients:      float64(stats.UniqueClients),
+			routingHits:        float64(stats.RoutingHits),
+			routingMisses:      float64(stats.RoutingMisses),
+			routingFallbacks:   float64(stats.RoutingFallbacks),
+		}
+		if stats.TotalRequests > 0 {
+			sample.successRate = float64(stats.SuccessfulRequests) / float64(stats.TotalRequests) * 100.0
+		}
+		modelSamples = append(modelSamples, sample)
+	}
+
+	endpointSamples := make([]modelEndpointMetricSample, 0)
+	for modelName, endpoints := range modelEndpointStats {
+		for epName, epStats := range endpoints {
+			endpointSamples = append(endpointSamples, modelEndpointMetricSample{
+				modelName:         modelName,
+				endpointName:      epName,
+				requests:          float64(epStats.RequestCount),
+				successRate:       epStats.SuccessRate,
+				avgLatency:        float64(epStats.AverageLatency),
+				consecutiveErrors: float64(epStats.ConsecutiveErrors),
+			})
+		}
 	}
 
 	writePrometheusHelpType(b, "olla_models_total", "gauge", "Total tracked models")
@@ -191,37 +277,58 @@ func writeModelPrometheusMetrics(b *strings.Builder, summary ModelStatsSummary, 
 	writePrometheusGauge(b, "olla_models_success_rate_percent", parsePercentage(summary.OverallSuccessRate))
 	writePrometheusGauge(b, "olla_models_traffic_bytes", float64(totalTrafficBytes))
 
-	for name, stats := range modelStats {
-		successRate := float64(0)
-		if stats.TotalRequests > 0 {
-			successRate = float64(stats.SuccessfulRequests) / float64(stats.TotalRequests) * 100.0
-		}
-
-		writePrometheusLabeledGauge(b, "olla_model_requests_total", float64(stats.TotalRequests), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_successful_requests_total", float64(stats.SuccessfulRequests), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_failed_requests_total", float64(stats.FailedRequests), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_success_rate_percent", successRate, "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_traffic_bytes", float64(stats.TotalBytes), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_avg_latency_ms", float64(stats.AverageLatency), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_p95_latency_ms", float64(stats.P95Latency), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_p99_latency_ms", float64(stats.P99Latency), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_unique_clients", float64(stats.UniqueClients), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_routing_hits_total", float64(stats.RoutingHits), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_routing_misses_total", float64(stats.RoutingMisses), "model", name)
-		writePrometheusLabeledGauge(b, "olla_model_routing_fallbacks_total", float64(stats.RoutingFallbacks), "model", name)
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_requests_total", sample.requests, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_successful_requests_total", sample.successfulRequests, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_failed_requests_total", sample.failedRequests, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_success_rate_percent", sample.successRate, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_traffic_bytes", sample.traffic, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_avg_latency_ms", sample.avgLatency, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_p95_latency_ms", sample.p95Latency, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_p99_latency_ms", sample.p99Latency, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_unique_clients", sample.uniqueClients, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_routing_hits_total", sample.routingHits, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_routing_misses_total", sample.routingMisses, "model", sample.name)
+	}
+	for _, sample := range modelSamples {
+		writePrometheusLabeledGauge(b, "olla_model_routing_fallbacks_total", sample.routingFallbacks, "model", sample.name)
 	}
 
-	for modelName, endpoints := range modelEndpointStats {
-		for epName, epStats := range endpoints {
-			writePrometheusLabeledGauge(b, "olla_model_endpoint_requests_total", float64(epStats.RequestCount),
-				"model", modelName, "endpoint", epName)
-			writePrometheusLabeledGauge(b, "olla_model_endpoint_success_rate_percent", epStats.SuccessRate,
-				"model", modelName, "endpoint", epName)
-			writePrometheusLabeledGauge(b, "olla_model_endpoint_avg_latency_ms", float64(epStats.AverageLatency),
-				"model", modelName, "endpoint", epName)
-			writePrometheusLabeledGauge(b, "olla_model_endpoint_consecutive_errors", float64(epStats.ConsecutiveErrors),
-				"model", modelName, "endpoint", epName)
-		}
+	for _, sample := range endpointSamples {
+		writePrometheusLabeledGauge(b, "olla_model_endpoint_requests_total", sample.requests,
+			"model", sample.modelName, "endpoint", sample.endpointName)
+	}
+	for _, sample := range endpointSamples {
+		writePrometheusLabeledGauge(b, "olla_model_endpoint_success_rate_percent", sample.successRate,
+			"model", sample.modelName, "endpoint", sample.endpointName)
+	}
+	for _, sample := range endpointSamples {
+		writePrometheusLabeledGauge(b, "olla_model_endpoint_avg_latency_ms", sample.avgLatency,
+			"model", sample.modelName, "endpoint", sample.endpointName)
+	}
+	for _, sample := range endpointSamples {
+		writePrometheusLabeledGauge(b, "olla_model_endpoint_consecutive_errors", sample.consecutiveErrors,
+			"model", sample.modelName, "endpoint", sample.endpointName)
 	}
 }
 

--- a/internal/app/handlers/handler_metrics.go
+++ b/internal/app/handlers/handler_metrics.go
@@ -22,12 +22,28 @@ func (a *Application) metricsHandler(w http.ResponseWriter, r *http.Request) {
 
 	response := a.buildStatusResponse(snapshot)
 
+	modelStats := make(map[string]ports.ModelStats)
+	modelEndpointStats := make(map[string]map[string]ports.EndpointModelStats)
+	if a.statsCollector != nil {
+		modelStats = a.statsCollector.GetModelStats()
+		modelEndpointStats = a.statsCollector.GetModelEndpointStats()
+	}
+	if modelStats == nil {
+		modelStats = make(map[string]ports.ModelStats)
+	}
+	if modelEndpointStats == nil {
+		modelEndpointStats = make(map[string]map[string]ports.EndpointModelStats)
+	}
+	models, acc := a.buildModelStats(modelStats, modelEndpointStats, false)
+	summary := a.buildSummary(models, modelStats, acc)
+
 	w.Header().Set(constants.HeaderContentType, constants.ContentTypePrometheus)
 	w.WriteHeader(http.StatusOK)
-	writePrometheusMetrics(w, response, snapshot, a.Config.Proxy, time.Since(a.StartTime))
+	writePrometheusMetrics(w, response, snapshot, a.Config.Proxy, time.Since(a.StartTime), summary, modelStats, modelEndpointStats)
 }
 
-func writePrometheusMetrics(w http.ResponseWriter, response StatusResponse, snapshot *statusSnapshot, proxyConfig config.ProxyConfig, uptime time.Duration) {
+func writePrometheusMetrics(w http.ResponseWriter, response StatusResponse, snapshot *statusSnapshot, proxyConfig config.ProxyConfig, uptime time.Duration,
+	summary ModelStatsSummary, modelStats map[string]ports.ModelStats, modelEndpointStats map[string]map[string]ports.EndpointModelStats) {
 	var b strings.Builder
 
 	writePrometheusHelpType(&b, "olla_info", "gauge", "Olla build and proxy configuration")
@@ -85,6 +101,7 @@ func writePrometheusMetrics(w http.ResponseWriter, response StatusResponse, snap
 	writePrometheusGauge(&b, "olla_security_status", securityStatusValue(response.Security.Status))
 
 	writeEndpointPrometheusMetrics(&b, snapshot.all, snapshot.endpointStats, snapshot.connectionStats, snapshot.endpointModels)
+	writeModelPrometheusMetrics(&b, summary, modelStats, modelEndpointStats)
 
 	_, _ = w.Write([]byte(b.String()))
 }
@@ -129,13 +146,82 @@ func writeEndpointPrometheusMetrics(b *strings.Builder, all []*domain.Endpoint, 
 		}
 
 		writePrometheusLabeledGauge(b, "olla_endpoint_up", up, "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_requests_total", float64(requests), "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_connections", float64(connectionStats[url]), "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_success_rate_percent", successRate, "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_avg_latency_ms", float64(avgLatency), "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_traffic_bytes", float64(trafficBytes), "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_priority", float64(endpoint.Priority), "endpoint", endpoint.Name, "status", status)
-		writePrometheusLabeledGauge(b, "olla_endpoint_models_count", float64(modelCount), "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_requests_total", float64(requests), "endpoint", endpoint.Name)
+		writePrometheusLabeledGauge(b, "olla_endpoint_connections", float64(connectionStats[url]), "endpoint", endpoint.Name)
+		writePrometheusLabeledGauge(b, "olla_endpoint_success_rate_percent", successRate, "endpoint", endpoint.Name)
+		writePrometheusLabeledGauge(b, "olla_endpoint_avg_latency_ms", float64(avgLatency), "endpoint", endpoint.Name)
+		writePrometheusLabeledGauge(b, "olla_endpoint_traffic_bytes", float64(trafficBytes), "endpoint", endpoint.Name)
+		writePrometheusLabeledGauge(b, "olla_endpoint_priority", float64(endpoint.Priority), "endpoint", endpoint.Name)
+		writePrometheusLabeledGauge(b, "olla_endpoint_models_count", float64(modelCount), "endpoint", endpoint.Name)
+	}
+}
+
+func writeModelPrometheusMetrics(b *strings.Builder, summary ModelStatsSummary, modelStats map[string]ports.ModelStats,
+	modelEndpointStats map[string]map[string]ports.EndpointModelStats) {
+	var totalTrafficBytes int64
+	for _, stats := range modelStats {
+		totalTrafficBytes += stats.TotalBytes
+	}
+
+	writePrometheusHelpType(b, "olla_models_total", "gauge", "Total tracked models")
+	writePrometheusHelpType(b, "olla_models_active", "gauge", "Models requested in the last hour")
+	writePrometheusHelpType(b, "olla_models_requests_total", "counter", "Total requests across all models")
+	writePrometheusHelpType(b, "olla_models_success_rate_percent", "gauge", "Overall model request success rate")
+	writePrometheusHelpType(b, "olla_models_traffic_bytes", "counter", "Total model traffic in bytes")
+	writePrometheusHelpType(b, "olla_model_requests_total", "counter", "Total requests for a model")
+	writePrometheusHelpType(b, "olla_model_successful_requests_total", "counter", "Successful requests for a model")
+	writePrometheusHelpType(b, "olla_model_failed_requests_total", "counter", "Failed requests for a model")
+	writePrometheusHelpType(b, "olla_model_success_rate_percent", "gauge", "Model success rate percentage")
+	writePrometheusHelpType(b, "olla_model_traffic_bytes", "counter", "Total traffic for a model in bytes")
+	writePrometheusHelpType(b, "olla_model_avg_latency_ms", "gauge", "Model average latency in milliseconds")
+	writePrometheusHelpType(b, "olla_model_p95_latency_ms", "gauge", "Model P95 latency in milliseconds")
+	writePrometheusHelpType(b, "olla_model_p99_latency_ms", "gauge", "Model P99 latency in milliseconds")
+	writePrometheusHelpType(b, "olla_model_unique_clients", "gauge", "Unique clients per model")
+	writePrometheusHelpType(b, "olla_model_routing_hits_total", "counter", "Model routing hits (first endpoint)")
+	writePrometheusHelpType(b, "olla_model_routing_misses_total", "counter", "Model routing misses (retry required)")
+	writePrometheusHelpType(b, "olla_model_routing_fallbacks_total", "counter", "Model routing fallbacks")
+	writePrometheusHelpType(b, "olla_model_endpoint_requests_total", "counter", "Requests for a model on a specific endpoint")
+	writePrometheusHelpType(b, "olla_model_endpoint_success_rate_percent", "gauge", "Model success rate on a specific endpoint")
+	writePrometheusHelpType(b, "olla_model_endpoint_avg_latency_ms", "gauge", "Model average latency on a specific endpoint")
+	writePrometheusHelpType(b, "olla_model_endpoint_consecutive_errors", "gauge", "Consecutive errors for a model on an endpoint")
+
+	writePrometheusGauge(b, "olla_models_total", float64(summary.TotalModels))
+	writePrometheusGauge(b, "olla_models_active", float64(summary.ActiveModels))
+	writePrometheusGauge(b, "olla_models_requests_total", float64(summary.TotalRequests))
+	writePrometheusGauge(b, "olla_models_success_rate_percent", parsePercentage(summary.OverallSuccessRate))
+	writePrometheusGauge(b, "olla_models_traffic_bytes", float64(totalTrafficBytes))
+
+	for name, stats := range modelStats {
+		successRate := float64(0)
+		if stats.TotalRequests > 0 {
+			successRate = float64(stats.SuccessfulRequests) / float64(stats.TotalRequests) * 100.0
+		}
+
+		writePrometheusLabeledGauge(b, "olla_model_requests_total", float64(stats.TotalRequests), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_successful_requests_total", float64(stats.SuccessfulRequests), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_failed_requests_total", float64(stats.FailedRequests), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_success_rate_percent", successRate, "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_traffic_bytes", float64(stats.TotalBytes), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_avg_latency_ms", float64(stats.AverageLatency), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_p95_latency_ms", float64(stats.P95Latency), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_p99_latency_ms", float64(stats.P99Latency), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_unique_clients", float64(stats.UniqueClients), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_routing_hits_total", float64(stats.RoutingHits), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_routing_misses_total", float64(stats.RoutingMisses), "model", name)
+		writePrometheusLabeledGauge(b, "olla_model_routing_fallbacks_total", float64(stats.RoutingFallbacks), "model", name)
+	}
+
+	for modelName, endpoints := range modelEndpointStats {
+		for epName, epStats := range endpoints {
+			writePrometheusLabeledGauge(b, "olla_model_endpoint_requests_total", float64(epStats.RequestCount),
+				"model", modelName, "endpoint", epName)
+			writePrometheusLabeledGauge(b, "olla_model_endpoint_success_rate_percent", epStats.SuccessRate,
+				"model", modelName, "endpoint", epName)
+			writePrometheusLabeledGauge(b, "olla_model_endpoint_avg_latency_ms", float64(epStats.AverageLatency),
+				"model", modelName, "endpoint", epName)
+			writePrometheusLabeledGauge(b, "olla_model_endpoint_consecutive_errors", float64(epStats.ConsecutiveErrors),
+				"model", modelName, "endpoint", epName)
+		}
 	}
 }
 
@@ -199,7 +285,7 @@ func writePrometheusGauge(b *strings.Builder, name string, value float64) {
 func writePrometheusLabeledGauge(b *strings.Builder, name string, value float64, labels ...string) {
 	b.WriteString(name)
 	b.WriteByte('{')
-	for i := 0; i < len(labels); i += 2 {
+	for i := 0; i+1 < len(labels); i += 2 {
 		if i > 0 {
 			b.WriteByte(',')
 		}

--- a/internal/app/handlers/handler_metrics.go
+++ b/internal/app/handlers/handler_metrics.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/version"
+)
+
+func (a *Application) metricsHandler(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := a.gatherStatusSnapshot(r.Context())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to get endpoint data: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	response := a.buildStatusResponse(snapshot)
+
+	w.Header().Set(constants.HeaderContentType, constants.ContentTypePrometheus)
+	w.WriteHeader(http.StatusOK)
+	writePrometheusMetrics(w, response, snapshot, a.Config.Proxy, time.Since(a.StartTime))
+}
+
+func writePrometheusMetrics(w http.ResponseWriter, response StatusResponse, snapshot *statusSnapshot, proxyConfig config.ProxyConfig, uptime time.Duration) {
+	var b strings.Builder
+
+	writePrometheusHelpType(&b, "olla_info", "gauge", "Olla build and proxy configuration")
+	writePrometheusLabeledGauge(&b, "olla_info", 1,
+		"version", version.Version,
+		"commit", version.Commit,
+		"engine", proxyConfig.Engine,
+		"profile", proxyConfig.Profile,
+		"balancer", proxyConfig.LoadBalancer,
+	)
+
+	writePrometheusHelpType(&b, "olla_system_status", "gauge", "Overall system status (2=healthy, 1=degraded, 0=critical)")
+	writePrometheusGauge(&b, "olla_system_status", systemStatusValue(response.System.Status))
+
+	writePrometheusHelpType(&b, "olla_endpoints_total", "gauge", "Total configured endpoints")
+	writePrometheusGauge(&b, "olla_endpoints_total", float64(len(snapshot.all)))
+
+	writePrometheusHelpType(&b, "olla_endpoints_healthy", "gauge", "Number of healthy endpoints")
+	writePrometheusGauge(&b, "olla_endpoints_healthy", float64(len(snapshot.healthy)))
+
+	writePrometheusHelpType(&b, "olla_success_rate_percent", "gauge", "Proxy success rate percentage")
+	writePrometheusGauge(&b, "olla_success_rate_percent", parsePercentage(response.System.SuccessRate))
+
+	writePrometheusHelpType(&b, "olla_avg_latency_ms", "gauge", "Average proxy latency in milliseconds")
+	writePrometheusGauge(&b, "olla_avg_latency_ms", float64(snapshot.proxyStats.AverageLatency))
+
+	writePrometheusHelpType(&b, "olla_total_traffic_bytes", "gauge", "Total traffic across all endpoints in bytes")
+	writePrometheusGauge(&b, "olla_total_traffic_bytes", float64(totalTrafficBytes(snapshot)))
+
+	writePrometheusHelpType(&b, "olla_uptime_seconds", "gauge", "Olla process uptime in seconds")
+	writePrometheusGauge(&b, "olla_uptime_seconds", uptime.Seconds())
+
+	writePrometheusHelpType(&b, "olla_active_connections", "gauge", "Active connections across all endpoints")
+	writePrometheusGauge(&b, "olla_active_connections", float64(response.System.ActiveConnections))
+
+	writePrometheusHelpType(&b, "olla_security_violations_total", "counter", "Total security violations")
+	writePrometheusGauge(&b, "olla_security_violations_total", float64(response.System.SecurityViolations))
+
+	writePrometheusHelpType(&b, "olla_requests_total", "counter", "Total proxy requests processed")
+	writePrometheusGauge(&b, "olla_requests_total", float64(response.System.TotalRequests))
+
+	writePrometheusHelpType(&b, "olla_failures_total", "counter", "Total failed proxy requests")
+	writePrometheusGauge(&b, "olla_failures_total", float64(response.System.TotalFailures))
+
+	writePrometheusHelpType(&b, "olla_security_blocked_ips", "gauge", "Unique IPs blocked by rate limiting")
+	writePrometheusGauge(&b, "olla_security_blocked_ips", float64(response.Security.BlockedIPs))
+
+	writePrometheusHelpType(&b, "olla_security_rate_limit_violations_total", "counter", "Rate limit violations")
+	writePrometheusGauge(&b, "olla_security_rate_limit_violations_total", float64(response.Security.Violations.RateLimits))
+
+	writePrometheusHelpType(&b, "olla_security_size_limit_violations_total", "counter", "Request size limit violations")
+	writePrometheusGauge(&b, "olla_security_size_limit_violations_total", float64(response.Security.Violations.SizeLimits))
+
+	writePrometheusHelpType(&b, "olla_security_status", "gauge", "Security posture (1=normal, 0=elevated)")
+	writePrometheusGauge(&b, "olla_security_status", securityStatusValue(response.Security.Status))
+
+	writeEndpointPrometheusMetrics(&b, snapshot.all, snapshot.endpointStats, snapshot.connectionStats, snapshot.endpointModels)
+
+	_, _ = w.Write([]byte(b.String()))
+}
+
+func writeEndpointPrometheusMetrics(b *strings.Builder, all []*domain.Endpoint, statsMap map[string]ports.EndpointStats,
+	connectionStats map[string]int64, modelMap map[string]*domain.EndpointModels) {
+	writePrometheusHelpType(b, "olla_endpoint_up", "gauge", "Whether the endpoint is healthy (1) or not (0)")
+	writePrometheusHelpType(b, "olla_endpoint_requests_total", "counter", "Total requests handled by endpoint")
+	writePrometheusHelpType(b, "olla_endpoint_connections", "gauge", "Active connections for endpoint")
+	writePrometheusHelpType(b, "olla_endpoint_success_rate_percent", "gauge", "Endpoint success rate percentage")
+	writePrometheusHelpType(b, "olla_endpoint_avg_latency_ms", "gauge", "Endpoint average latency in milliseconds")
+	writePrometheusHelpType(b, "olla_endpoint_traffic_bytes", "counter", "Total traffic for endpoint in bytes")
+	writePrometheusHelpType(b, "olla_endpoint_priority", "gauge", "Endpoint routing priority")
+	writePrometheusHelpType(b, "olla_endpoint_models_count", "gauge", "Number of models discovered on endpoint")
+
+	for _, endpoint := range all {
+		url := endpoint.GetURLString()
+		stats, hasStats := statsMap[url]
+		status := endpoint.Status.String()
+
+		var successRate float64
+		requests := int64(0)
+		avgLatency := int64(0)
+		trafficBytes := int64(0)
+		if hasStats {
+			requests = stats.TotalRequests
+			avgLatency = stats.AverageLatency
+			trafficBytes = stats.TotalBytes
+			if stats.TotalRequests > 0 {
+				successRate = float64(stats.SuccessfulRequests) / float64(stats.TotalRequests) * 100.0
+			}
+		}
+
+		modelCount := int64(0)
+		if endpointModels := modelMap[url]; endpointModels != nil {
+			modelCount = int64(len(endpointModels.Models))
+		}
+
+		up := float64(0)
+		if endpoint.Status == domain.StatusHealthy {
+			up = 1
+		}
+
+		writePrometheusLabeledGauge(b, "olla_endpoint_up", up, "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_requests_total", float64(requests), "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_connections", float64(connectionStats[url]), "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_success_rate_percent", successRate, "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_avg_latency_ms", float64(avgLatency), "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_traffic_bytes", float64(trafficBytes), "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_priority", float64(endpoint.Priority), "endpoint", endpoint.Name, "status", status)
+		writePrometheusLabeledGauge(b, "olla_endpoint_models_count", float64(modelCount), "endpoint", endpoint.Name, "status", status)
+	}
+}
+
+func totalTrafficBytes(snapshot *statusSnapshot) int64 {
+	var total int64
+	for url, conn := range snapshot.connectionStats {
+		_ = conn
+		if stats, exists := snapshot.endpointStats[url]; exists {
+			total += stats.TotalBytes
+		}
+	}
+	return total
+}
+
+func systemStatusValue(status string) float64 {
+	switch status {
+	case statusHealthy:
+		return 2
+	case statusDegraded:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func securityStatusValue(status string) float64 {
+	if status == statusNormal {
+		return 1
+	}
+	return 0
+}
+
+func parsePercentage(value string) float64 {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSuffix(value, "%")
+	var parsed float64
+	_, _ = fmt.Sscanf(value, "%f", &parsed)
+	return parsed
+}
+
+func writePrometheusHelpType(b *strings.Builder, name, metricType, help string) {
+	b.WriteString("# HELP ")
+	b.WriteString(name)
+	b.WriteByte(' ')
+	b.WriteString(help)
+	b.WriteByte('\n')
+	b.WriteString("# TYPE ")
+	b.WriteString(name)
+	b.WriteByte(' ')
+	b.WriteString(metricType)
+	b.WriteByte('\n')
+}
+
+func writePrometheusGauge(b *strings.Builder, name string, value float64) {
+	b.WriteString(name)
+	b.WriteByte(' ')
+	b.WriteString(formatPrometheusFloat(value))
+	b.WriteByte('\n')
+}
+
+func writePrometheusLabeledGauge(b *strings.Builder, name string, value float64, labels ...string) {
+	b.WriteString(name)
+	b.WriteByte('{')
+	for i := 0; i < len(labels); i += 2 {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(labels[i])
+		b.WriteByte('=')
+		b.WriteByte('"')
+		b.WriteString(escapePrometheusLabel(labels[i+1]))
+		b.WriteByte('"')
+	}
+	b.WriteByte('}')
+	b.WriteByte(' ')
+	b.WriteString(formatPrometheusFloat(value))
+	b.WriteByte('\n')
+}
+
+func escapePrometheusLabel(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	return value
+}
+
+func formatPrometheusFloat(value float64) string {
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", value), "0"), ".")
+}

--- a/internal/app/handlers/handler_metrics_test.go
+++ b/internal/app/handlers/handler_metrics_test.go
@@ -85,6 +85,7 @@ func TestMetricsHandler_BasicFunctionality(t *testing.T) {
 	assert.Contains(t, body, `engine="olla"`)
 	assert.Contains(t, body, `balancer="priority"`)
 	assert.Contains(t, body, "olla_models_total 0")
+	assertPrometheusFamiliesGrouped(t, body)
 }
 
 func TestMetricsHandler_MatchesModelStatsCounts(t *testing.T) {
@@ -154,6 +155,7 @@ func TestMetricsHandler_MatchesModelStatsCounts(t *testing.T) {
 	assert.Contains(t, body, `olla_model_endpoint_requests_total{model="llama3.2",endpoint="local-ollama"} 42`)
 	assert.Contains(t, body, `olla_model_endpoint_success_rate_percent{model="llama3.2",endpoint="local-ollama"} 95.2`)
 	assert.Contains(t, body, `olla_model_endpoint_consecutive_errors{model="llama3.2",endpoint="local-ollama"} 1`)
+	assertPrometheusFamiliesGrouped(t, body)
 }
 
 func TestMetricsHandler_MatchesStatusCounts(t *testing.T) {
@@ -248,4 +250,37 @@ func TestWritePrometheusLabeledGauge(t *testing.T) {
 	writePrometheusLabeledGauge(&b, "olla_info", 1, "version", "0.0.28", "engine", "olla")
 
 	assert.Equal(t, `olla_info{version="0.0.28",engine="olla"} 1`+"\n", b.String())
+}
+
+func assertPrometheusFamiliesGrouped(t *testing.T, body string) {
+	t.Helper()
+
+	finished := make(map[string]struct{})
+	var current string
+
+	for line := range strings.Lines(body) {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		name := prometheusMetricName(line)
+		if current != "" && name != current {
+			finished[current] = struct{}{}
+		}
+		if _, seen := finished[name]; seen {
+			t.Fatalf("metric family %q samples are not contiguous in exposition output", name)
+		}
+		current = name
+	}
+}
+
+func prometheusMetricName(line string) string {
+	if idx := strings.IndexByte(line, '{'); idx >= 0 {
+		return line[:idx]
+	}
+	if idx := strings.IndexByte(line, ' '); idx >= 0 {
+		return line[:idx]
+	}
+	return line
 }

--- a/internal/app/handlers/handler_metrics_test.go
+++ b/internal/app/handlers/handler_metrics_test.go
@@ -1,0 +1,181 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+)
+
+func TestMetricsHandler_BasicFunctionality(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []*domain.Endpoint{
+		{
+			Name:      "test-endpoint-healthy",
+			Type:      "ollama",
+			URLString: "http://localhost:11434",
+			Status:    domain.StatusHealthy,
+			Priority:  100,
+		},
+		{
+			Name:      "test-endpoint-unhealthy",
+			Type:      "openai",
+			URLString: "http://localhost:8080",
+			Status:    domain.StatusUnhealthy,
+			Priority:  50,
+		},
+	}
+
+	stats := &mockStatusStatsCollector{
+		endpointStats: map[string]ports.EndpointStats{
+			"http://localhost:11434": {
+				TotalRequests:      120,
+				SuccessfulRequests: 118,
+				FailedRequests:     2,
+				TotalBytes:         4096,
+				AverageLatency:     125,
+			},
+		},
+		proxyStats: ports.ProxyStats{
+			TotalRequests:      120,
+			SuccessfulRequests: 118,
+			FailedRequests:     2,
+			AverageLatency:     125,
+		},
+	}
+
+	app := &Application{
+		repository:     &mockStatusEndpointRepository{endpoints: endpoints},
+		statsCollector: stats,
+		modelRegistry:  &mockStatusModelRegistry{},
+		StartTime:      time.Now().Add(-2 * time.Hour),
+		Config: &config.Config{
+			Proxy: config.ProxyConfig{
+				Engine:       "olla",
+				Profile:      "auto",
+				LoadBalancer: "priority",
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, constants.DefaultMetricsEndpoint, nil)
+	w := httptest.NewRecorder()
+
+	app.metricsHandler(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, constants.ContentTypePrometheus, w.Header().Get(constants.HeaderContentType))
+
+	body := w.Body.String()
+	assert.Contains(t, body, "olla_requests_total")
+	assert.Contains(t, body, "olla_failures_total")
+	assert.Contains(t, body, "olla_endpoints_total 2")
+	assert.Contains(t, body, "olla_endpoints_healthy 1")
+	assert.Contains(t, body, `olla_endpoint_up{endpoint="test-endpoint-healthy",status="healthy"} 1`)
+	assert.Contains(t, body, `olla_endpoint_up{endpoint="test-endpoint-unhealthy",status="unhealthy"} 0`)
+	assert.Contains(t, body, `engine="olla"`)
+	assert.Contains(t, body, `balancer="priority"`)
+}
+
+func TestMetricsHandler_MatchesStatusCounts(t *testing.T) {
+	t.Parallel()
+
+	endpoints := []*domain.Endpoint{
+		{
+			Name:      "ep-a",
+			URLString: "http://localhost:11434",
+			Status:    domain.StatusHealthy,
+			Priority:  1,
+		},
+	}
+
+	stats := &mockStatusStatsCollector{
+		endpointStats: map[string]ports.EndpointStats{
+			"http://localhost:11434": {
+				TotalRequests:      10,
+				SuccessfulRequests: 9,
+				FailedRequests:     1,
+				TotalBytes:         1000,
+				AverageLatency:     50,
+			},
+		},
+		proxyStats: ports.ProxyStats{
+			TotalRequests:      10,
+			SuccessfulRequests: 9,
+			FailedRequests:     1,
+			AverageLatency:     50,
+		},
+	}
+
+	app := &Application{
+		repository:     &mockStatusEndpointRepository{endpoints: endpoints},
+		statsCollector: stats,
+		modelRegistry:  &mockStatusModelRegistry{},
+		StartTime:      time.Now(),
+		Config:         &config.Config{},
+	}
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/internal/status", nil)
+	statusRec := httptest.NewRecorder()
+	app.statusHandler(statusRec, statusReq)
+	require.Equal(t, http.StatusOK, statusRec.Code)
+
+	metricsReq := httptest.NewRequest(http.MethodGet, constants.DefaultMetricsEndpoint, nil)
+	metricsRec := httptest.NewRecorder()
+	app.metricsHandler(metricsRec, metricsReq)
+	require.Equal(t, http.StatusOK, metricsRec.Code)
+
+	body := metricsRec.Body.String()
+	assert.Contains(t, body, "olla_requests_total 10")
+	assert.Contains(t, body, "olla_failures_total 1")
+	assert.Contains(t, body, "olla_avg_latency_ms 50")
+	assert.Contains(t, body, `olla_endpoint_requests_total{endpoint="ep-a",status="healthy"} 10`)
+}
+
+func TestEscapePrometheusLabel(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, `line1\nline2`, escapePrometheusLabel("line1\nline2"))
+	assert.Equal(t, `say \"hello\"`, escapePrometheusLabel(`say "hello"`))
+	assert.Equal(t, `path\\to`, escapePrometheusLabel(`path\to`))
+}
+
+func TestFormatPrometheusFloat(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "125", formatPrometheusFloat(125))
+	assert.Equal(t, "99.6", formatPrometheusFloat(99.6))
+}
+
+func TestParsePercentage(t *testing.T) {
+	t.Parallel()
+
+	assert.InDelta(t, 99.2, parsePercentage("99.2%"), 0.001)
+	assert.InDelta(t, 0, parsePercentage("0.0%"), 0.001)
+}
+
+func TestSystemStatusValue(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, float64(2), systemStatusValue(statusHealthy))
+	assert.Equal(t, float64(1), systemStatusValue(statusDegraded))
+	assert.Equal(t, float64(0), systemStatusValue(statusCritical))
+}
+
+func TestWritePrometheusLabeledGauge(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	writePrometheusLabeledGauge(&b, "olla_info", 1, "version", "0.0.28", "engine", "olla")
+
+	assert.Equal(t, `olla_info{version="0.0.28",engine="olla"} 1`+"\n", b.String())
+}

--- a/internal/app/handlers/handler_metrics_test.go
+++ b/internal/app/handlers/handler_metrics_test.go
@@ -84,6 +84,76 @@ func TestMetricsHandler_BasicFunctionality(t *testing.T) {
 	assert.Contains(t, body, `olla_endpoint_up{endpoint="test-endpoint-unhealthy",status="unhealthy"} 0`)
 	assert.Contains(t, body, `engine="olla"`)
 	assert.Contains(t, body, `balancer="priority"`)
+	assert.Contains(t, body, "olla_models_total 0")
+}
+
+func TestMetricsHandler_MatchesModelStatsCounts(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	stats := &mockStatusStatsCollector{
+		modelStats: map[string]ports.ModelStats{
+			"llama3.2": {
+				TotalRequests:      42,
+				SuccessfulRequests: 40,
+				FailedRequests:     2,
+				TotalBytes:         8192,
+				AverageLatency:     110,
+				P95Latency:         200,
+				P99Latency:         350,
+				UniqueClients:      3,
+				RoutingHits:        35,
+				RoutingMisses:      5,
+				RoutingFallbacks:   2,
+				LastRequested:      now,
+			},
+		},
+		modelEndpointStats: map[string]map[string]ports.EndpointModelStats{
+			"llama3.2": {
+				"local-ollama": {
+					EndpointName:      "local-ollama",
+					ModelName:         "llama3.2",
+					RequestCount:      42,
+					SuccessRate:       95.2,
+					AverageLatency:    110,
+					ConsecutiveErrors: 1,
+					LastUsed:          now,
+				},
+			},
+		},
+	}
+
+	app := &Application{
+		repository:     &mockStatusEndpointRepository{endpoints: nil},
+		statsCollector: stats,
+		modelRegistry:  &mockStatusModelRegistry{},
+		StartTime:      time.Now(),
+		Config:         &config.Config{},
+	}
+
+	modelReq := httptest.NewRequest(http.MethodGet, "/internal/stats/models", nil)
+	modelRec := httptest.NewRecorder()
+	app.modelStatsHandler(modelRec, modelReq)
+	require.Equal(t, http.StatusOK, modelRec.Code)
+
+	metricsReq := httptest.NewRequest(http.MethodGet, constants.DefaultMetricsEndpoint, nil)
+	metricsRec := httptest.NewRecorder()
+	app.metricsHandler(metricsRec, metricsReq)
+	require.Equal(t, http.StatusOK, metricsRec.Code)
+
+	body := metricsRec.Body.String()
+	assert.Contains(t, body, "olla_models_total 1")
+	assert.Contains(t, body, "olla_models_active 1")
+	assert.Contains(t, body, "olla_models_requests_total 42")
+	assert.Contains(t, body, "olla_models_traffic_bytes 8192")
+	assert.Contains(t, body, `olla_model_requests_total{model="llama3.2"} 42`)
+	assert.Contains(t, body, `olla_model_successful_requests_total{model="llama3.2"} 40`)
+	assert.Contains(t, body, `olla_model_failed_requests_total{model="llama3.2"} 2`)
+	assert.Contains(t, body, `olla_model_avg_latency_ms{model="llama3.2"} 110`)
+	assert.Contains(t, body, `olla_model_routing_hits_total{model="llama3.2"} 35`)
+	assert.Contains(t, body, `olla_model_endpoint_requests_total{model="llama3.2",endpoint="local-ollama"} 42`)
+	assert.Contains(t, body, `olla_model_endpoint_success_rate_percent{model="llama3.2",endpoint="local-ollama"} 95.2`)
+	assert.Contains(t, body, `olla_model_endpoint_consecutive_errors{model="llama3.2",endpoint="local-ollama"} 1`)
 }
 
 func TestMetricsHandler_MatchesStatusCounts(t *testing.T) {
@@ -138,7 +208,7 @@ func TestMetricsHandler_MatchesStatusCounts(t *testing.T) {
 	assert.Contains(t, body, "olla_requests_total 10")
 	assert.Contains(t, body, "olla_failures_total 1")
 	assert.Contains(t, body, "olla_avg_latency_ms 50")
-	assert.Contains(t, body, `olla_endpoint_requests_total{endpoint="ep-a",status="healthy"} 10`)
+	assert.Contains(t, body, `olla_endpoint_requests_total{endpoint="ep-a"} 10`)
 }
 
 func TestEscapePrometheusLabel(t *testing.T) {

--- a/internal/app/handlers/handler_status.go
+++ b/internal/app/handlers/handler_status.go
@@ -90,13 +90,13 @@ type StatusResponse struct {
 }
 
 type statusSnapshot struct {
-	all             []*domain.Endpoint
-	healthy         []*domain.Endpoint
 	endpointStats   map[string]ports.EndpointStats
-	proxyStats      ports.ProxyStats
-	securityStats   ports.SecurityStats
 	connectionStats map[string]int64
 	endpointModels  map[string]*domain.EndpointModels
+	all             []*domain.Endpoint
+	healthy         []*domain.Endpoint
+	proxyStats      ports.ProxyStats
+	securityStats   ports.SecurityStats
 }
 
 func (a *Application) gatherStatusSnapshot(ctx context.Context) (*statusSnapshot, error) {

--- a/internal/app/handlers/handler_status.go
+++ b/internal/app/handlers/handler_status.go
@@ -89,36 +89,61 @@ type StatusResponse struct {
 	System    SystemSummary      `json:"system"`
 }
 
-func (a *Application) statusHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	now := time.Now()
+type statusSnapshot struct {
+	all             []*domain.Endpoint
+	healthy         []*domain.Endpoint
+	endpointStats   map[string]ports.EndpointStats
+	proxyStats      ports.ProxyStats
+	securityStats   ports.SecurityStats
+	connectionStats map[string]int64
+	endpointModels  map[string]*domain.EndpointModels
+}
 
+func (a *Application) gatherStatusSnapshot(ctx context.Context) (*statusSnapshot, error) {
 	all, healthy, _, err := a.getEndpointCounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	endpointModelsMap, emErr := a.modelRegistry.GetEndpointModelMap(ctx)
+	if emErr != nil {
+		a.logger.Warn("Failed to get model map", "error", emErr)
+		endpointModelsMap = make(map[string]*domain.EndpointModels)
+	}
+
+	return &statusSnapshot{
+		all:             all,
+		healthy:         healthy,
+		endpointStats:   a.statsCollector.GetEndpointStats(),
+		proxyStats:      a.statsCollector.GetProxyStats(),
+		securityStats:   a.statsCollector.GetSecurityStats(),
+		connectionStats: a.statsCollector.GetConnectionStats(),
+		endpointModels:  endpointModelsMap,
+	}, nil
+}
+
+func (a *Application) buildStatusResponse(snapshot *statusSnapshot) StatusResponse {
+	response := StatusResponse{
+		Timestamp: time.Now(),
+		Endpoints: make([]EndpointResponse, len(snapshot.all)),
+	}
+
+	response.Proxy = a.buildProxySummary(a.Config.Proxy)
+	response.System = a.buildSystemSummary(snapshot.all, snapshot.healthy, snapshot.proxyStats, snapshot.securityStats, snapshot.connectionStats, snapshot.endpointStats)
+	a.buildUnifiedEndpoints(snapshot.all, snapshot.endpointStats, snapshot.connectionStats, response.Endpoints, snapshot.endpointModels)
+	response.Security = a.buildSecuritySummary(snapshot.securityStats)
+
+	return response
+}
+
+func (a *Application) statusHandler(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := a.gatherStatusSnapshot(r.Context())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to get endpoint data: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	endpointStatsMap := a.statsCollector.GetEndpointStats()
-	proxyStats := a.statsCollector.GetProxyStats()
-	securityStats := a.statsCollector.GetSecurityStats()
-	connectionStats := a.statsCollector.GetConnectionStats()
-	endpointModelsMap, emErr := a.modelRegistry.GetEndpointModelMap(ctx)
-
-	if emErr != nil {
-		a.logger.Warn("Failed to get model map", "error", err)
-		endpointModelsMap = make(map[string]*domain.EndpointModels)
-	}
-
-	response := StatusResponse{
-		Timestamp: now,
-		Endpoints: make([]EndpointResponse, len(all)),
-	}
-
-	response.Proxy = a.buildProxySummary(a.Config.Proxy)
-	response.System = a.buildSystemSummary(all, healthy, proxyStats, securityStats, connectionStats, endpointStatsMap)
-	a.buildUnifiedEndpoints(all, endpointStatsMap, connectionStats, response.Endpoints, endpointModelsMap)
-	response.Security = a.buildSecuritySummary(securityStats)
+	response := a.buildStatusResponse(snapshot)
 
 	w.Header().Set(constants.HeaderContentType, constants.ContentTypeJSON)
 	w.WriteHeader(http.StatusOK)

--- a/internal/app/handlers/handler_status.go
+++ b/internal/app/handlers/handler_status.go
@@ -111,13 +111,25 @@ func (a *Application) gatherStatusSnapshot(ctx context.Context) (*statusSnapshot
 		endpointModelsMap = make(map[string]*domain.EndpointModels)
 	}
 
+	var endpointStats map[string]ports.EndpointStats
+	var proxyStats ports.ProxyStats
+	var securityStats ports.SecurityStats
+	var connectionStats map[string]int64
+
+	if a.statsCollector != nil {
+		endpointStats = a.statsCollector.GetEndpointStats()
+		proxyStats = a.statsCollector.GetProxyStats()
+		securityStats = a.statsCollector.GetSecurityStats()
+		connectionStats = a.statsCollector.GetConnectionStats()
+	}
+
 	return &statusSnapshot{
 		all:             all,
 		healthy:         healthy,
-		endpointStats:   a.statsCollector.GetEndpointStats(),
-		proxyStats:      a.statsCollector.GetProxyStats(),
-		securityStats:   a.statsCollector.GetSecurityStats(),
-		connectionStats: a.statsCollector.GetConnectionStats(),
+		endpointStats:   endpointStats,
+		proxyStats:      proxyStats,
+		securityStats:   securityStats,
+		connectionStats: connectionStats,
 		endpointModels:  endpointModelsMap,
 	}, nil
 }

--- a/internal/app/handlers/handler_status_endpoints_test.go
+++ b/internal/app/handlers/handler_status_endpoints_test.go
@@ -67,8 +67,10 @@ func (m *mockStatusEndpointRepository) Exists(ctx context.Context, endpointURL *
 
 // mockStatusStatsCollector for status endpoint testing
 type mockStatusStatsCollector struct {
-	endpointStats map[string]ports.EndpointStats
-	proxyStats    ports.ProxyStats
+	endpointStats      map[string]ports.EndpointStats
+	proxyStats         ports.ProxyStats
+	modelStats         map[string]ports.ModelStats
+	modelEndpointStats map[string]map[string]ports.EndpointModelStats
 }
 
 func (m *mockStatusStatsCollector) RecordRequest(endpoint *domain.Endpoint, status string, latency time.Duration, bytes int64) {
@@ -81,9 +83,17 @@ func (m *mockStatusStatsCollector) RecordModelRequest(model string, endpoint *do
 }
 func (m *mockStatusStatsCollector) RecordModelError(model string, endpoint *domain.Endpoint, errorType string) {
 }
-func (m *mockStatusStatsCollector) GetModelStats() map[string]ports.ModelStats { return nil }
+func (m *mockStatusStatsCollector) GetModelStats() map[string]ports.ModelStats {
+	if m.modelStats == nil {
+		return make(map[string]ports.ModelStats)
+	}
+	return m.modelStats
+}
 func (m *mockStatusStatsCollector) GetModelEndpointStats() map[string]map[string]ports.EndpointModelStats {
-	return nil
+	if m.modelEndpointStats == nil {
+		return make(map[string]map[string]ports.EndpointModelStats)
+	}
+	return m.modelEndpointStats
 }
 func (m *mockStatusStatsCollector) RecordTranslatorRequest(event ports.TranslatorRequestEvent) {}
 func (m *mockStatusStatsCollector) GetTranslatorStats() map[string]ports.TranslatorStats {

--- a/internal/app/handlers/handler_status_endpoints_test.go
+++ b/internal/app/handlers/handler_status_endpoints_test.go
@@ -68,6 +68,7 @@ func (m *mockStatusEndpointRepository) Exists(ctx context.Context, endpointURL *
 // mockStatusStatsCollector for status endpoint testing
 type mockStatusStatsCollector struct {
 	endpointStats map[string]ports.EndpointStats
+	proxyStats    ports.ProxyStats
 }
 
 func (m *mockStatusStatsCollector) RecordRequest(endpoint *domain.Endpoint, status string, latency time.Duration, bytes int64) {
@@ -88,7 +89,7 @@ func (m *mockStatusStatsCollector) RecordTranslatorRequest(event ports.Translato
 func (m *mockStatusStatsCollector) GetTranslatorStats() map[string]ports.TranslatorStats {
 	return nil
 }
-func (m *mockStatusStatsCollector) GetProxyStats() ports.ProxyStats { return ports.ProxyStats{} }
+func (m *mockStatusStatsCollector) GetProxyStats() ports.ProxyStats { return m.proxyStats }
 func (m *mockStatusStatsCollector) GetSecurityStats() ports.SecurityStats {
 	return ports.SecurityStats{}
 }

--- a/internal/app/handlers/handler_version.go
+++ b/internal/app/handlers/handler_version.go
@@ -55,6 +55,7 @@ func (a *Application) versionHandler(w http.ResponseWriter, r *http.Request) {
 			Version: "v1",
 			Endpoints: map[string]string{
 				"health":  "/internal/health",
+				"metrics": "/internal/metrics",
 				"status":  "/internal/status",
 				"process": "/internal/process",
 				"version": "/version",

--- a/internal/app/handlers/server_routes.go
+++ b/internal/app/handlers/server_routes.go
@@ -31,6 +31,7 @@ func (a *Application) registerRoutes() {
 	// for operations and shouldn't depend on any provider configuration
 	a.routeRegistry.RegisterWithMethod(constants.DefaultHealthCheckEndpoint, a.healthHandler, "Health check endpoint", "GET")
 	a.routeRegistry.RegisterWithMethod("/internal/status", a.statusHandler, "Endpoint status", "GET")
+	a.routeRegistry.RegisterWithMethod(constants.DefaultMetricsEndpoint, a.metricsHandler, "Prometheus metrics", "GET")
 	a.routeRegistry.RegisterWithMethod("/internal/status/endpoints", a.endpointsStatusHandler, "Endpoints status", "GET")
 	a.routeRegistry.RegisterWithMethod("/internal/status/models", a.modelsStatusHandler, "Models status", "GET")
 	a.routeRegistry.RegisterWithMethod("/internal/stats/models", a.modelStatsHandler, "Model statistics", "GET")

--- a/internal/core/constants/content.go
+++ b/internal/core/constants/content.go
@@ -6,6 +6,7 @@ const (
 	// Standard Content Types
 	ContentTypeJSON           = "application/json"
 	ContentTypeText           = "text/plain"
+	ContentTypePrometheus     = "text/plain; version=0.0.4; charset=utf-8"
 	ContentTypeHTML           = "text/html"
 	ContentTypeXML            = "application/xml"
 	ContentTypeJavaScript     = "application/javascript"

--- a/internal/core/constants/endpoint.go
+++ b/internal/core/constants/endpoint.go
@@ -2,6 +2,7 @@ package constants
 
 const (
 	DefaultHealthCheckEndpoint = "/internal/health"
+	DefaultMetricsEndpoint     = "/internal/metrics"
 	DefaultOllaProxyPathPrefix = "/olla/"
 	DefaultPathPrefix          = "/"
 


### PR DESCRIPTION
## Summary

Add native `GET /internal/metrics` in Prometheus text format, exposing operational
data from the same builders as `/internal/status` (system, endpoint, security) and
`/internal/stats/models` (model usage and routing). No external Python exporter
required for core proxy monitoring.

Status metrics use `gatherStatusSnapshot` / `buildStatusResponse`; model metrics
use `buildModelStats` / `buildSummary`. 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Backend / integration support
- [X] Documentation
- [ ] Refactor / internal (no behaviour change)

## How was this tested?

Built via `make docker-build-local` and tested locally
Added new tests for `/internal/metrics` endpoint and sucessfully passed all tests and lints

## Checklist

- [X] `make ready` passes (test-short + test-race + fmt + vet + lint + align)
- [X] Tests added or updated for the change
- [X] Documentation updated (`./docs`) if behaviour or config changed
- [X] No new dependencies added (or called out and justified below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Prometheus metrics endpoint (`/internal/metrics`) for monitoring app health, requests, models, and routing activity.
  * Exposed the metrics endpoint in the API version response and registered it in system routes.

* **Documentation**
  * Updated the API reference and monitoring guides with `/internal/metrics`, including curl/scrape examples and metric series details (and how it relates to other system endpoints).

* **Bug Fixes**
  * Improved status snapshot assembly and reliability when model/proxy stats are unavailable, and added comprehensive tests for metrics formatting and escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->