### PR TITLE
bugfix: issue-191 strict model routing bypass

### DIFF
--- a/docs/content/concepts/model-aliases.md
+++ b/docs/content/concepts/model-aliases.md
@@ -119,7 +119,12 @@ In this case:
 
 When a model name matches both a configured alias **and** a real model known to the registry, the alias takes priority. This ensures consistent cross-backend routing.
 
-If the alias resolves to zero endpoints (none of the actual model names are available), Olla falls back to standard model routing using the alias name as a regular model name.
+If the alias resolves to zero endpoints (none of the actual model names are available), Olla falls back to standard model routing using the alias name as a regular model name. That fallback honours the configured [routing strategy](model-routing.md), so an alias whose targets are all unavailable behaves exactly like any other unroutable model:
+
+- **`strict`** (default), or **`optimistic`** with `none` / `compatible_only`: the request is rejected. `404` when the alias name matches no model anywhere, `503` when it only resolves to unhealthy endpoints.
+- **`optimistic`** with `all`: the request is routed to any healthy endpoint.
+
+Olla does not silently proxy an unroutable alias to a compatible-but-wrong backend.
 
 ## Interaction with Other Features
 

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -647,7 +647,7 @@ model_aliases:
 ```
 
 !!! note
-    Alias names take priority over standard model routing. If no endpoints are found for the alias, Olla falls back to standard routing using the alias name as a regular model name. See [Model Aliases](../concepts/model-aliases.md) for details.
+    Alias names take priority over standard model routing. If no endpoints are found for the alias, Olla falls back to standard routing using the alias name as a regular model name, honouring the configured routing strategy. Under `strict` (the default) an alias whose targets are all unavailable is rejected (`404`/`503`), not proxied to a compatible-but-wrong backend. See [Model Aliases](../concepts/model-aliases.md) for details.
 
 ## Routing Response Headers
 

--- a/internal/adapter/registry/routing/strict_strategy_test.go
+++ b/internal/adapter/registry/routing/strict_strategy_test.go
@@ -1,0 +1,63 @@
+package routing
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/core/constants"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+)
+
+// TestStrictStrategy_GetRoutableEndpoints covers the three outcomes strict routing
+// can produce (#191): a healthy match routes, a match confined to unhealthy endpoints
+// rejects with 503, and no match anywhere rejects with 404. Handlers rely on these
+// exact status codes to fail fast instead of falling through to the proxy engine.
+func TestStrictStrategy_GetRoutableEndpoints(t *testing.T) {
+	ctx := context.Background()
+	testLogger := createTestLogger()
+	strategy := NewStrictStrategy(testLogger)
+
+	healthyEndpoints := []*domain.Endpoint{
+		{Name: "ep1", URLString: "http://ep1", Status: domain.StatusHealthy},
+		{Name: "ep2", URLString: "http://ep2", Status: domain.StatusHealthy},
+	}
+
+	t.Run("model found on healthy endpoint routes", func(t *testing.T) {
+		modelEndpoints := []string{"http://ep1"}
+
+		result, decision, err := strategy.GetRoutableEndpoints(ctx, "test-model", healthyEndpoints, modelEndpoints)
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "ep1", result[0].Name)
+		assert.Equal(t, ports.RoutingActionRouted, decision.Action)
+		assert.Equal(t, constants.RoutingReasonModelFound, decision.Reason)
+		assert.Equal(t, http.StatusOK, decision.StatusCode)
+	})
+
+	t.Run("model only on unhealthy endpoint rejects with 503", func(t *testing.T) {
+		modelEndpoints := []string{"http://ep3"} // not in healthyEndpoints
+
+		result, decision, err := strategy.GetRoutableEndpoints(ctx, "test-model", healthyEndpoints, modelEndpoints)
+
+		require.Error(t, err)
+		assert.Empty(t, result)
+		assert.Equal(t, ports.RoutingActionRejected, decision.Action)
+		assert.Equal(t, constants.RoutingReasonModelUnavailable, decision.Reason)
+		assert.Equal(t, http.StatusServiceUnavailable, decision.StatusCode)
+	})
+
+	t.Run("model nowhere in the fleet rejects with 404", func(t *testing.T) {
+		result, decision, err := strategy.GetRoutableEndpoints(ctx, "test-model", healthyEndpoints, nil)
+
+		require.Error(t, err)
+		assert.Empty(t, result)
+		assert.Equal(t, ports.RoutingActionRejected, decision.Action)
+		assert.Equal(t, constants.RoutingReasonModelNotFound, decision.Reason)
+		assert.Equal(t, http.StatusNotFound, decision.StatusCode)
+	})
+}

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -104,22 +104,7 @@ func (a *Application) providerProxyHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if len(endpoints) == 0 {
-		http.Error(w, fmt.Sprintf("No %s endpoints available", providerType), http.StatusNotFound)
-		return
-	}
-
-	// Update request path to the target path (strip provider prefix)
-	r.URL.Path = pr.targetPath
-
-	a.logRequestStart(pr, len(endpoints))
-	err = a.executeProxyRequest(ctx, w, r, endpoints, pr)
-	pr.captureStickyOutcome(ctx, r)
-	a.logRequestResult(pr, err)
-
-	if err != nil {
-		a.handleProxyError(w, err)
-	}
+	a.dispatchToEndpoints(ctx, w, r, pr, endpoints, providerType)
 }
 
 // getProviderEndpoints returns only endpoints matching the requested provider type.

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -40,7 +40,7 @@ func (a *Application) createProviderProfile(providerType string) *domain.Request
 				}
 			}
 		} else {
-			// Test/static fallback — must track the openai-compatible types in
+			// Test/static fallback: must track the openai-compatible types in
 			// isProviderSupported (handler_common.go) and getStaticProviders (server_routes.go)
 			profile.AddSupportedProfile(constants.ProviderTypeOpenAI)
 			profile.AddSupportedProfile(constants.ProviderTypeVLLM)
@@ -81,7 +81,7 @@ func (a *Application) providerProxyHandler(w http.ResponseWriter, r *http.Reques
 
 	// The proxy needs to know which prefix to strip before forwarding.
 	// We must use the RAW (pre-normalisation) path segment as the strip prefix so
-	// that alias spellings like /olla/lmstudio/ strip correctly — using the
+	// that alias spellings like /olla/lmstudio/ strip correctly. Using the
 	// normalised name (lm-studio) would produce a non-matching prefix and forward
 	// the full /olla/lmstudio/... path to the backend, causing a 404.
 	providerPrefix := getRawProviderPrefix(r.URL.Path)

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -124,10 +124,12 @@ func (a *Application) writeNoRoutableEndpoints(w http.ResponseWriter, r *http.Re
 	}
 
 	// Preserve normal request telemetry (client_ip, model, duration, routing fields)
-	// even though we're short-circuiting before the proxy engine ever runs.
+	// even though we're short-circuiting before the proxy engine ever runs. Logged as
+	// an explicit rejection rather than logRequestResult's "completed", so a fail-fast
+	// 404/503 is never mistaken for a successful proxy in the logs (#191).
 	a.logRequestStart(pr, 0)
 	pr.captureStickyOutcome(r.Context(), r)
-	a.logRequestResult(pr, nil)
+	a.logRequestRejected(pr, status)
 
 	// Headers must be set before http.Error, which calls WriteHeader.
 	a.setStickyResponseHeadersFromRequest(w, r)
@@ -349,6 +351,40 @@ func (a *Application) logRequestStart(pr *proxyRequest, endpointCount int) {
 	}
 
 	pr.requestLogger.Debug("Request details", debugFields...)
+}
+
+// logRequestRejected records a request that never reached the proxy engine because
+// endpoint selection produced no routable target. Kept distinct from logRequestResult's
+// "completed"/"failed" outcomes so a fail-fast rejection (e.g. strict model_not_found)
+// is surfaced as a rejection rather than a successful completion (#191).
+func (a *Application) logRequestRejected(pr *proxyRequest, status int) {
+	duration := time.Since(pr.stats.StartTime)
+
+	logFields := []any{
+		"client_ip", pr.clientIP,
+		"path", pr.path,
+		"status", status,
+		"duration_ms", duration.Milliseconds(),
+	}
+
+	if pr.model != "" {
+		logFields = append(logFields, "model", pr.model)
+	}
+
+	// routing fields explain why nothing was routable (strategy/action/reason)
+	if rd := pr.stats.RoutingDecision; rd != nil {
+		if rd.Strategy != "" {
+			logFields = append(logFields, "routing_strategy", rd.Strategy)
+		}
+		if rd.Action != "" {
+			logFields = append(logFields, "routing_action", rd.Action)
+		}
+		if rd.Reason != "" {
+			logFields = append(logFields, "routing_reason", rd.Reason)
+		}
+	}
+
+	pr.requestLogger.Warn("Request rejected", logFields...)
 }
 
 func (a *Application) logRequestResult(pr *proxyRequest, err error) {

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -706,6 +706,15 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 		logger.Warn("No healthy endpoints found for model alias",
 			"alias", aliasName,
 			"resolved_endpoints", len(endpointToModel))
+
+		// The alias resolved to real target models, but none of them are on a healthy/
+		// compatible candidate - equivalent to the strict strategy's "model only available
+		// on unhealthy endpoints" case. Set a routing decision here (mirroring
+		// RoutingReasonModelUnavailable/503) so the rejection carries X-Olla-Routing-*
+		// headers and a decision-aware status instead of falling through to
+		// writeNoRoutableEndpoints' generic default (#191).
+		profile.RoutingDecision = ports.NewRoutingDecision("alias", ports.RoutingActionRejected,
+			constants.RoutingReasonModelUnavailable)
 		return []*domain.Endpoint{}
 	}
 

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -576,6 +576,14 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 		if decision != nil {
 			profile.RoutingDecision = decision
 		}
+
+		// A rejection (strict model_not_found, or optimistic none/compatible_only) must
+		// fail fast exactly like the non-alias path below - returning candidates here would
+		// silently proxy to a compatible-but-wrong backend and ignore the routing verdict (#191).
+		if decision != nil && decision.Action == ports.RoutingActionRejected {
+			return []*domain.Endpoint{}
+		}
+
 		if routeErr != nil || len(routableEndpoints) == 0 {
 			return candidates
 		}

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -676,10 +676,15 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 			profile.RoutingDecision = decision
 		}
 
-		// A rejection (strict model_not_found, or optimistic none/compatible_only) must
-		// fail fast exactly like the non-alias path below. Returning candidates here would
-		// silently proxy to a compatible-but-wrong backend and ignore the routing verdict (#191).
-		if decision != nil && decision.Action == ports.RoutingActionRejected {
+		// A rejection must fail fast exactly like the non-alias path below. Returning
+		// candidates here would silently proxy to a compatible-but-wrong backend and
+		// ignore the routing verdict (#191). Keyed on status code rather than the
+		// "rejected" action string because writeNoRoutableEndpoints uses the same
+		// status-code contract, and not every registry implementation reports
+		// rejections as "rejected" - MemoryModelRegistry's base GetRoutableEndpointsForModel
+		// uses "no_model"/"no_healthy" with 404/503. Keying on the action string would
+		// silently miss those and reintroduce the bug this fix closes.
+		if decision != nil && decision.StatusCode >= http.StatusBadRequest {
 			return []*domain.Endpoint{}
 		}
 

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -62,21 +62,84 @@ func (a *Application) proxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.logRequestStart(pr, len(endpoints))
+	a.dispatchToEndpoints(ctx, w, r, pr, endpoints, "")
+}
+
+// dispatchToEndpoints is the shared tail of proxyHandler and providerProxyHandler:
+// forward to the proxy engine when endpoints were selected, or fail fast with the
+// correct status when selection produced none. Consolidating this here means a
+// routing rejection (#191) is honoured identically regardless of which route the
+// request came in on, instead of each handler drifting its own empty-endpoint handling.
+func (a *Application) dispatchToEndpoints(ctx context.Context, w http.ResponseWriter, r *http.Request, pr *proxyRequest, endpoints []*domain.Endpoint, providerType string) {
+	if len(endpoints) == 0 {
+		a.writeNoRoutableEndpoints(w, r, pr, providerType)
+		return
+	}
 
 	// Strip the route prefix before forwarding to the backend.
 	// Without this, BuildTargetURL receives the full /olla/proxy/... path and
 	// GetProxyPrefix() returns "route_prefix" (a context key name, not a URL path),
-	// so its StripPrefix is a no-op. This mirrors providerProxyHandler (line 100).
+	// so its StripPrefix is a no-op.
 	r.URL.Path = pr.targetPath
 
-	err = a.executeProxyRequest(ctx, w, r, endpoints, pr)
+	a.logRequestStart(pr, len(endpoints))
+
+	err := a.executeProxyRequest(ctx, w, r, endpoints, pr)
 	pr.captureStickyOutcome(ctx, r)
 	a.logRequestResult(pr, err)
 
 	if err != nil {
 		a.handleProxyError(w, err)
 	}
+}
+
+// writeNoRoutableEndpoints short-circuits a request when endpoint selection produced
+// zero candidates, instead of letting it fall through to the proxy engine (which would
+// either proxy to a compatible-but-wrong backend, or return a generic 502/404 that hides
+// the actual routing verdict). A rejection routing decision takes priority - it carries
+// the precise status code and reason (e.g. strict "model_not_found" -> 404) - falling
+// back to the historical per-route defaults only when no decision was recorded.
+func (a *Application) writeNoRoutableEndpoints(w http.ResponseWriter, r *http.Request, pr *proxyRequest, providerType string) {
+	var decision *domain.ModelRoutingDecision
+	if pr.profile != nil {
+		decision = pr.profile.RoutingDecision
+	}
+
+	var status int
+	var reason string
+
+	switch {
+	case decision != nil && decision.StatusCode >= http.StatusBadRequest:
+		status = decision.StatusCode
+		reason = decision.Reason
+		pr.stats.RoutingDecision = decision
+	case providerType != "":
+		// no decision was recorded (e.g. modelRegistry unset) - preserve the
+		// precise provider-route message rather than a vague generic one.
+		status = http.StatusNotFound
+		reason = fmt.Sprintf("No %s endpoints available", providerType)
+	default:
+		status = http.StatusServiceUnavailable
+		reason = "no healthy endpoints available"
+	}
+
+	// Preserve normal request telemetry (client_ip, model, duration, routing fields)
+	// even though we're short-circuiting before the proxy engine ever runs.
+	a.logRequestStart(pr, 0)
+	pr.captureStickyOutcome(r.Context(), r)
+	a.logRequestResult(pr, nil)
+
+	// Headers must be set before http.Error, which calls WriteHeader.
+	a.setStickyResponseHeadersFromRequest(w, r)
+	if decision != nil {
+		w.Header().Set(constants.HeaderXOllaRoutingStrategy, decision.Strategy)
+		w.Header().Set(constants.HeaderXOllaRoutingDecision, decision.Action)
+		if decision.Reason != "" {
+			w.Header().Set(constants.HeaderXOllaRoutingReason, decision.Reason)
+		}
+	}
+
+	http.Error(w, reason, status)
 }
 
 func (a *Application) initializeProxyRequest(r *http.Request) *proxyRequest {

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -680,27 +680,7 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 			logFields...)
 
 		// fall through to standard routing in case the alias name itself is a known model
-		routableEndpoints, decision, routeErr := a.modelRegistry.GetRoutableEndpointsForModel(ctx, aliasName, candidates)
-		if decision != nil {
-			profile.RoutingDecision = decision
-		}
-
-		// A rejection must fail fast exactly like the non-alias path below. Returning
-		// candidates here would silently proxy to a compatible-but-wrong backend and
-		// ignore the routing verdict (#191). Keyed on status code rather than the
-		// "rejected" action string because writeNoRoutableEndpoints uses the same
-		// status-code contract, and not every registry implementation reports
-		// rejections as "rejected" - MemoryModelRegistry's base GetRoutableEndpointsForModel
-		// uses "no_model"/"no_healthy" with 404/503. Keying on the action string would
-		// silently miss those and reintroduce the bug this fix closes.
-		if decision != nil && decision.StatusCode >= http.StatusBadRequest {
-			return []*domain.Endpoint{}
-		}
-
-		if routeErr != nil || len(routableEndpoints) == 0 {
-			return candidates
-		}
-		return routableEndpoints
+		return a.routeByAliasName(ctx, aliasName, profile, candidates)
 	}
 
 	// filter candidates to only those that have one of the aliased models
@@ -717,14 +697,16 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 			"resolved_endpoints", len(endpointToModel))
 
 		// The alias resolved to real target models, but none of them are on a healthy/
-		// compatible candidate - equivalent to the strict strategy's "model only available
-		// on unhealthy endpoints" case. Set a routing decision here (mirroring
-		// RoutingReasonModelUnavailable/503) so the rejection carries X-Olla-Routing-*
-		// headers and a decision-aware status instead of falling through to
-		// writeNoRoutableEndpoints' generic default (#191).
-		profile.RoutingDecision = ports.NewRoutingDecision("alias", ports.RoutingActionRejected,
-			constants.RoutingReasonModelUnavailable)
-		return []*domain.Endpoint{}
+		// compatible candidate. Rather than synthesising a rejection here, consult the
+		// routing strategy for the alias name itself, exactly like the "resolved to no
+		// endpoints at all" branch above - this is what lets optimistic routing with
+		// fallback_behavior: all substitute a different endpoint instead of the request
+		// being unconditionally rejected (#191 follow-up). Trade-off accepted: the
+		// resulting rejection reason/status is whatever the registry reports for an
+		// unknown model (typically model_not_found/404) rather than the alias-specific
+		// model_unavailable/503 this branch used to synthesise; consistency with the
+		// policy engine wins over status-code precision.
+		return a.routeByAliasName(ctx, aliasName, profile, candidates)
 	}
 
 	// store the rewrite map in the profile for use during request proxying
@@ -752,6 +734,39 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 		"total_candidates", len(candidates))
 
 	return aliasEndpoints
+}
+
+// routeByAliasName is the shared tail for both resolveAliasEndpoints fallback paths:
+// alias resolution producing no endpoints at all, and alias resolution producing
+// endpoints that don't intersect the healthy/compatible candidate set. Both cases treat
+// the alias name as if it were a plain model name and hand the decision to the configured
+// routing strategy, rather than the handler synthesising its own rejection - this is what
+// lets fallback_behavior: all under optimistic routing substitute a different endpoint
+// instead of always rejecting (#191 follow-up). It does NOT set the alias rewrite map:
+// any endpoints returned here were not confirmed to serve one of the alias's actual
+// target models, so the proxy must forward the original request body unchanged.
+func (a *Application) routeByAliasName(ctx context.Context, aliasName string, profile *domain.RequestProfile, candidates []*domain.Endpoint) []*domain.Endpoint {
+	routableEndpoints, decision, routeErr := a.modelRegistry.GetRoutableEndpointsForModel(ctx, aliasName, candidates)
+	if decision != nil {
+		profile.RoutingDecision = decision
+	}
+
+	// A rejection must fail fast exactly like the non-alias path in filterEndpointsByProfile.
+	// Returning candidates here would silently proxy to a compatible-but-wrong backend and
+	// ignore the routing verdict (#191). Keyed on status code rather than the "rejected"
+	// action string because writeNoRoutableEndpoints uses the same status-code contract,
+	// and not every registry implementation reports rejections as "rejected" -
+	// MemoryModelRegistry's base GetRoutableEndpointsForModel uses "no_model"/"no_healthy"
+	// with 404/503. Keying on the action string would silently miss those and reintroduce
+	// the bug this fix closes.
+	if decision != nil && decision.StatusCode >= http.StatusBadRequest {
+		return []*domain.Endpoint{}
+	}
+
+	if routeErr != nil || len(routableEndpoints) == 0 {
+		return candidates
+	}
+	return routableEndpoints
 }
 
 func (a *Application) filterEndpointsByCapabilities(endpoints []*domain.Endpoint, profile *domain.RequestProfile, logger logger.StyledLogger) []*domain.Endpoint {

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -96,9 +96,9 @@ func (a *Application) dispatchToEndpoints(ctx context.Context, w http.ResponseWr
 // writeNoRoutableEndpoints short-circuits a request when endpoint selection produced
 // zero candidates, instead of letting it fall through to the proxy engine (which would
 // either proxy to a compatible-but-wrong backend, or return a generic 502/404 that hides
-// the actual routing verdict). A rejection routing decision takes priority - it carries
-// the precise status code and reason (e.g. strict "model_not_found" -> 404) - falling
-// back to the historical per-route defaults only when no decision was recorded.
+// the actual routing verdict). A rejection routing decision takes priority: it carries
+// the precise status code and reason (strict model_not_found gives 404). Without a
+// decision we keep the historical per-route defaults.
 func (a *Application) writeNoRoutableEndpoints(w http.ResponseWriter, r *http.Request, pr *proxyRequest, providerType string) {
 	var decision *domain.ModelRoutingDecision
 	if pr.profile != nil {
@@ -114,7 +114,7 @@ func (a *Application) writeNoRoutableEndpoints(w http.ResponseWriter, r *http.Re
 		reason = decision.Reason
 		pr.stats.RoutingDecision = decision
 	case providerType != "":
-		// no decision was recorded (e.g. modelRegistry unset) - preserve the
+		// no decision was recorded (e.g. modelRegistry unset), so preserve the
 		// precise provider-route message rather than a vague generic one.
 		status = http.StatusNotFound
 		reason = fmt.Sprintf("No %s endpoints available", providerType)
@@ -677,7 +677,7 @@ func (a *Application) resolveAliasEndpoints(ctx context.Context, profile *domain
 		}
 
 		// A rejection (strict model_not_found, or optimistic none/compatible_only) must
-		// fail fast exactly like the non-alias path below - returning candidates here would
+		// fail fast exactly like the non-alias path below. Returning candidates here would
 		// silently proxy to a compatible-but-wrong backend and ignore the routing verdict (#191).
 		if decision != nil && decision.Action == ports.RoutingActionRejected {
 			return []*domain.Endpoint{}

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -133,15 +133,24 @@ func (a *Application) writeNoRoutableEndpoints(w http.ResponseWriter, r *http.Re
 
 	// Headers must be set before http.Error, which calls WriteHeader.
 	a.setStickyResponseHeadersFromRequest(w, r)
-	if decision != nil {
-		w.Header().Set(constants.HeaderXOllaRoutingStrategy, decision.Strategy)
-		w.Header().Set(constants.HeaderXOllaRoutingDecision, decision.Action)
-		if decision.Reason != "" {
-			w.Header().Set(constants.HeaderXOllaRoutingReason, decision.Reason)
-		}
-	}
+	a.setRoutingDecisionHeaders(w, decision)
 
 	http.Error(w, reason, status)
+}
+
+// setRoutingDecisionHeaders writes the X-Olla-Routing-* observability headers from
+// a routing decision. Shared by writeNoRoutableEndpoints and the translation route's
+// zero-endpoint rejection so a decision-aware rejection carries the same headers
+// regardless of which route produced it (#191).
+func (a *Application) setRoutingDecisionHeaders(w http.ResponseWriter, decision *domain.ModelRoutingDecision) {
+	if decision == nil {
+		return
+	}
+	w.Header().Set(constants.HeaderXOllaRoutingStrategy, decision.Strategy)
+	w.Header().Set(constants.HeaderXOllaRoutingDecision, decision.Action)
+	if decision.Reason != "" {
+		w.Header().Set(constants.HeaderXOllaRoutingReason, decision.Reason)
+	}
 }
 
 func (a *Application) initializeProxyRequest(r *http.Request) *proxyRequest {

--- a/internal/app/handlers/handler_proxy_alias_strict_test.go
+++ b/internal/app/handlers/handler_proxy_alias_strict_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/adapter/inspector"
+	"github.com/thushan/olla/internal/adapter/registry"
+	"github.com/thushan/olla/internal/adapter/registry/profile"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+	"github.com/thushan/olla/internal/core/domain"
+	"github.com/thushan/olla/internal/core/ports"
+	"github.com/thushan/olla/internal/logger"
+)
+
+// TestAliasRejection_StrictRouting_FailsFastWithoutProxying is the full-handler
+// regression test for #191: a model alias whose real target exists on no endpoint
+// must be rejected before the request ever reaches the proxy engine, on both the
+// provider-scoped route (providerProxyHandler) and the plain proxy route
+// (proxyHandler). Before the fix, resolveAliasEndpoints fell back to returning
+// every compatible endpoint, so the request silently proxied to a backend that
+// couldn't serve the requested model and returned a false 200.
+func TestAliasRejection_StrictRouting_FailsFastWithoutProxying(t *testing.T) {
+	t.Parallel()
+
+	styledLog := &mockStyledLogger{}
+
+	profileFactory, err := profile.NewFactoryWithDefaults()
+	require.NoError(t, err)
+
+	inspectorFactory := inspector.NewFactory(profileFactory, styledLog)
+	pathInspector := inspectorFactory.CreatePathInspector()
+	bodyInspector, err := inspectorFactory.CreateBodyInspector()
+	require.NoError(t, err)
+
+	chain := inspectorFactory.CreateChain()
+	chain.AddInspector(pathInspector)
+	chain.AddInspector(bodyInspector)
+
+	// The alias resolves to a real model name that exists on no endpoint, and the
+	// registry is in strict mode so the standard-routing fallback also rejects.
+	aliases := map[string][]string{
+		"gpt-oss-120b": {"gpt-oss:120b"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{},
+		strict:            true,
+	}
+
+	u, _ := url.Parse("http://ollama-1:11434")
+	discoveryService := &mockDiscoveryServiceWithHealthy{
+		endpoints: []*domain.Endpoint{{
+			Name:      "ollama-1",
+			URL:       u,
+			URLString: u.String(),
+			Type:      domain.ProfileOllama,
+			Status:    domain.StatusHealthy,
+		}},
+	}
+
+	body := `{"model":"gpt-oss-120b","messages":[{"role":"user","content":"hi"}]}`
+
+	newApp := func(called *bool) *Application {
+		return &Application{
+			Config: &config.Config{
+				Server: config.ServerConfig{RateLimits: config.ServerRateLimits{}},
+			},
+			logger:           styledLog,
+			profileFactory:   profileFactory,
+			inspectorChain:   chain,
+			discoveryService: discoveryService,
+			modelRegistry:    modelRegistry,
+			aliasResolver:    aliasResolver,
+			proxyService: &mockProxyService{
+				proxyFunc: func(ctx context.Context, w http.ResponseWriter, r *http.Request, endpoints []*domain.Endpoint, stats *ports.RequestStats, rlog logger.StyledLogger) error {
+					*called = true
+					w.WriteHeader(http.StatusOK)
+					return nil
+				},
+			},
+			StartTime: time.Now(),
+		}
+	}
+
+	t.Run("provider route rejects without proxying", func(t *testing.T) {
+		var called bool
+		app := newApp(&called)
+
+		req := httptest.NewRequest(http.MethodPost, "/olla/ollama/api/chat", strings.NewReader(body))
+		req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
+		w := httptest.NewRecorder()
+
+		app.providerProxyHandler(w, req)
+
+		assert.False(t, called, "request must not reach the proxy engine when the alias target is absent under strict routing")
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, "strict", w.Header().Get(constants.HeaderXOllaRoutingStrategy))
+		assert.Equal(t, "rejected", w.Header().Get(constants.HeaderXOllaRoutingDecision))
+	})
+
+	t.Run("plain proxy route rejects without proxying", func(t *testing.T) {
+		var called bool
+		app := newApp(&called)
+
+		req := httptest.NewRequest(http.MethodPost, "/olla/proxy/api/chat", strings.NewReader(body))
+		req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
+		ctx := context.WithValue(req.Context(), constants.ContextRoutePrefixKey, "/olla/proxy/")
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		app.proxyHandler(w, req)
+
+		assert.False(t, called, "request must not reach the proxy engine when the alias target is absent under strict routing")
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, "strict", w.Header().Get(constants.HeaderXOllaRoutingStrategy))
+		assert.Equal(t, "rejected", w.Header().Get(constants.HeaderXOllaRoutingDecision))
+	})
+}

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -121,6 +121,55 @@ func TestResolveAliasEndpoints_NoMatchingEndpoints(t *testing.T) {
 	assert.Contains(t, result, candidates[0])
 }
 
+// TestResolveAliasEndpoints_RejectedRoutingFailsFast verifies the #191 fix: when
+// an alias resolves to no endpoints and the fallback standard-routing lookup also
+// comes back as a strict rejection (model nowhere in the fleet), resolveAliasEndpoints
+// must return an empty slice - not the full candidate list - so the caller fails fast
+// instead of silently proxying to a backend that doesn't serve the requested model.
+func TestResolveAliasEndpoints_RejectedRoutingFailsFast(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://ollama:11434")
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "ollama",
+			URL:       endpoint1URL,
+			URLString: "http://ollama:11434",
+			Type:      domain.ProfileOllama,
+		},
+	}
+
+	// strict: true means GetRoutableEndpointsForModel returns a genuine rejection
+	// (nil endpoints, Action=Rejected) rather than the misleading fallback-to-all
+	// most other tests in this package rely on.
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{},
+		strict:            true,
+	}
+
+	aliases := map[string][]string{
+		"nonexistent-alias": {"model-not-in-registry"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: modelRegistry,
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "nonexistent-alias"
+	profile.SupportedBy = []string{domain.ProfileOllama}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	assert.Empty(t, result, "a rejected routing decision must fail fast with no endpoints, not fall back to all candidates")
+
+	require.NotNil(t, profile.RoutingDecision, "rejection decision should still be recorded for headers/metrics")
+	assert.Equal(t, "rejected", profile.RoutingDecision.Action)
+}
+
 func TestResolveAliasEndpoints_SelfReferencingAlias(t *testing.T) {
 	styledLog := &mockStyledLogger{}
 

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -193,6 +193,59 @@ func TestResolveAliasEndpoints_ShortCircuitsOnStatusCodeNotActionString(t *testi
 	assert.Equal(t, http.StatusNotFound, profile.RoutingDecision.StatusCode)
 }
 
+// TestResolveAliasEndpoints_NoIntersectionWithCandidates covers fix 4 from the #191
+// follow-up review: the alias resolves to real target models, but none of the endpoints
+// serving those models are in the healthy/compatible candidate list. Before the fix this
+// branch returned an empty slice without a routing decision, so the rejection reached
+// writeNoRoutableEndpoints with no decision - a generic reason, no X-Olla-Routing-*
+// headers, and the fallback default status rather than a decision-aware one.
+func TestResolveAliasEndpoints_NoIntersectionWithCandidates(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://ollama:11434")
+	// Only ollama is a candidate; lmstudio (which actually serves the aliased model) is not.
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "ollama",
+			URL:       endpoint1URL,
+			URLString: "http://ollama:11434",
+			Type:      domain.ProfileOllama,
+		},
+	}
+
+	// The alias resolves to a model that only exists on lmstudio, which isn't a candidate.
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{
+			"gpt-oss-120b-MLX": {"http://lmstudio:1234"},
+		},
+	}
+
+	aliases := map[string][]string{
+		"gpt-oss-120b": {"gpt-oss-120b-MLX"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: modelRegistry,
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "gpt-oss-120b"
+	profile.SupportedBy = []string{domain.ProfileOllama, domain.ProfileLmStudio}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	assert.Empty(t, result, "no candidate serves the aliased model, so nothing is routable")
+
+	require.NotNil(t, profile.RoutingDecision, "a decision must be recorded so headers/status are decision-aware, not generic")
+	assert.Equal(t, "alias", profile.RoutingDecision.Strategy)
+	assert.Equal(t, "rejected", profile.RoutingDecision.Action)
+	assert.Equal(t, constants.RoutingReasonModelUnavailable, profile.RoutingDecision.Reason)
+	assert.Equal(t, http.StatusServiceUnavailable, profile.RoutingDecision.StatusCode)
+}
+
 func TestResolveAliasEndpoints_SelfReferencingAlias(t *testing.T) {
 	styledLog := &mockStyledLogger{}
 

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -193,13 +193,16 @@ func TestResolveAliasEndpoints_ShortCircuitsOnStatusCodeNotActionString(t *testi
 	assert.Equal(t, http.StatusNotFound, profile.RoutingDecision.StatusCode)
 }
 
-// TestResolveAliasEndpoints_NoIntersectionWithCandidates covers fix 4 from the #191
-// follow-up review: the alias resolves to real target models, but none of the endpoints
-// serving those models are in the healthy/compatible candidate list. Before the fix this
-// branch returned an empty slice without a routing decision, so the rejection reached
-// writeNoRoutableEndpoints with no decision - a generic reason, no X-Olla-Routing-*
-// headers, and the fallback default status rather than a decision-aware one.
-func TestResolveAliasEndpoints_NoIntersectionWithCandidates(t *testing.T) {
+// TestResolveAliasEndpoints_NoIntersectionWithCandidates_StrictRejects covers fix 4 from
+// the #191 follow-up review, CodeRabbit round 2: the alias resolves to real target models,
+// but none of the endpoints serving those models are in the healthy/compatible candidate
+// list. Rather than the handler synthesising its own rejection, this must fall through to
+// the configured routing strategy for the alias name itself - exactly like the "resolved to
+// no endpoints at all" branch - so the strategy's decision (not a hardcoded one) governs the
+// outcome. Under a strict/rejecting registry that decision is still a fail-fast rejection,
+// just reported as model_not_found/404 (an unknown model name) rather than the
+// alias-specific model_unavailable/503 the handler used to synthesise.
+func TestResolveAliasEndpoints_NoIntersectionWithCandidates_StrictRejects(t *testing.T) {
 	styledLog := &mockStyledLogger{}
 
 	endpoint1URL, _ := url.Parse("http://ollama:11434")
@@ -214,6 +217,69 @@ func TestResolveAliasEndpoints_NoIntersectionWithCandidates(t *testing.T) {
 	}
 
 	// The alias resolves to a model that only exists on lmstudio, which isn't a candidate.
+	// strict:true means the fallback lookup on the alias name itself also rejects, since
+	// "gpt-oss-120b" isn't a model the registry knows about either.
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{
+			"gpt-oss-120b-MLX": {"http://lmstudio:1234"},
+		},
+		strict: true,
+	}
+
+	aliases := map[string][]string{
+		"gpt-oss-120b": {"gpt-oss-120b-MLX"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: modelRegistry,
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "gpt-oss-120b"
+	profile.SupportedBy = []string{domain.ProfileOllama, domain.ProfileLmStudio}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	assert.Empty(t, result, "strict routing on the alias name also rejects, so nothing is routable")
+
+	require.NotNil(t, profile.RoutingDecision, "a decision must be recorded so headers/status are decision-aware, not generic")
+	assert.Equal(t, "strict", profile.RoutingDecision.Strategy)
+	assert.Equal(t, "rejected", profile.RoutingDecision.Action)
+	assert.Equal(t, http.StatusNotFound, profile.RoutingDecision.StatusCode)
+
+	aliasMapRaw, ok := profile.InspectionMeta.Load(constants.ContextModelAliasMapKey)
+	assert.False(t, ok, "rejected fallback must not carry an alias rewrite map")
+	assert.Nil(t, aliasMapRaw)
+}
+
+// TestResolveAliasEndpoints_NoIntersectionWithCandidates_OptimisticFallsBack covers the
+// other side of the same fix: under a registry that returns a fallback decision with
+// endpoints (optimistic routing, fallback_behavior: all) instead of a rejection, the
+// no-intersection branch must let that fallback through rather than unconditionally
+// returning empty. This is the behaviour CodeRabbit flagged as missing - previously this
+// branch always rejected, so optimistic/all could never recover here. The returned
+// endpoints don't serve the alias's actual target models (they're the routing strategy's
+// substitute, not an alias match), so the alias rewrite map must NOT be set - the proxy
+// has to forward the original request body unchanged.
+func TestResolveAliasEndpoints_NoIntersectionWithCandidates_OptimisticFallsBack(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://ollama:11434")
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "ollama",
+			URL:       endpoint1URL,
+			URLString: "http://ollama:11434",
+			Type:      domain.ProfileOllama,
+		},
+	}
+
+	// The alias resolves to a model that only exists on lmstudio, which isn't a candidate.
+	// strict is left false, so mockSimpleModelRegistry's fallback lookup on the alias name
+	// mirrors an optimistic/all decision: it hands back the candidates rather than rejecting.
 	modelRegistry := &mockSimpleModelRegistry{
 		endpointsForModel: map[string][]string{
 			"gpt-oss-120b-MLX": {"http://lmstudio:1234"},
@@ -237,13 +303,15 @@ func TestResolveAliasEndpoints_NoIntersectionWithCandidates(t *testing.T) {
 
 	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
 
-	assert.Empty(t, result, "no candidate serves the aliased model, so nothing is routable")
+	require.Len(t, result, 1, "the fallback decision hands back the candidate set, so the request still proxies")
+	assert.Equal(t, "http://ollama:11434", result[0].URLString)
 
-	require.NotNil(t, profile.RoutingDecision, "a decision must be recorded so headers/status are decision-aware, not generic")
-	assert.Equal(t, "alias", profile.RoutingDecision.Strategy)
-	assert.Equal(t, "rejected", profile.RoutingDecision.Action)
-	assert.Equal(t, constants.RoutingReasonModelUnavailable, profile.RoutingDecision.Reason)
-	assert.Equal(t, http.StatusServiceUnavailable, profile.RoutingDecision.StatusCode)
+	require.NotNil(t, profile.RoutingDecision)
+	assert.NotEqual(t, "rejected", profile.RoutingDecision.Action)
+
+	aliasMapRaw, ok := profile.InspectionMeta.Load(constants.ContextModelAliasMapKey)
+	assert.False(t, ok, "fallback endpoints weren't confirmed to serve the aliased model, so no rewrite map must be set")
+	assert.Nil(t, aliasMapRaw)
 }
 
 func TestResolveAliasEndpoints_SelfReferencingAlias(t *testing.T) {

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -84,7 +84,7 @@ func TestResolveAliasEndpoints_ResolvesToCorrectEndpoints(t *testing.T) {
 // no endpoints and the standard-routing fallback lookup also rejects (the target model
 // exists nowhere in the fleet), the result must be empty. Returning candidates here would
 // silently proxy the request to a backend that doesn't serve the requested model, defeating
-// strict routing entirely - this is exactly the bug this test used to codify.
+// strict routing entirely. This is exactly the bug this test used to codify.
 func TestResolveAliasEndpoints_NoMatchingEndpoints(t *testing.T) {
 	styledLog := &mockStyledLogger{}
 

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -80,6 +80,11 @@ func TestResolveAliasEndpoints_ResolvesToCorrectEndpoints(t *testing.T) {
 	assert.Equal(t, "gpt-oss-120b-MLX", aliasMap["http://lmstudio:1234"])
 }
 
+// TestResolveAliasEndpoints_NoMatchingEndpoints covers #191: when an alias resolves to
+// no endpoints and the standard-routing fallback lookup also rejects (the target model
+// exists nowhere in the fleet), the result must be empty. Returning candidates here would
+// silently proxy the request to a backend that doesn't serve the requested model, defeating
+// strict routing entirely - this is exactly the bug this test used to codify.
 func TestResolveAliasEndpoints_NoMatchingEndpoints(t *testing.T) {
 	styledLog := &mockStyledLogger{}
 
@@ -93,55 +98,8 @@ func TestResolveAliasEndpoints_NoMatchingEndpoints(t *testing.T) {
 		},
 	}
 
-	// Registry has no models matching the alias
-	modelRegistry := &mockSimpleModelRegistry{
-		endpointsForModel: map[string][]string{},
-	}
-
-	aliases := map[string][]string{
-		"nonexistent-alias": {"model-not-in-registry"},
-	}
-	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
-
-	app := &Application{
-		modelRegistry: modelRegistry,
-		aliasResolver: aliasResolver,
-		logger:        styledLog,
-	}
-
-	profile := domain.NewRequestProfile("/v1/chat/completions")
-	profile.ModelName = "nonexistent-alias"
-	profile.SupportedBy = []string{domain.ProfileOllama}
-
-	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
-
-	// Should fall back to all candidates since alias resolved to no endpoints
-	// and standard routing also finds nothing useful
-	assert.Len(t, result, 1)
-	assert.Contains(t, result, candidates[0])
-}
-
-// TestResolveAliasEndpoints_RejectedRoutingFailsFast verifies the #191 fix: when
-// an alias resolves to no endpoints and the fallback standard-routing lookup also
-// comes back as a strict rejection (model nowhere in the fleet), resolveAliasEndpoints
-// must return an empty slice - not the full candidate list - so the caller fails fast
-// instead of silently proxying to a backend that doesn't serve the requested model.
-func TestResolveAliasEndpoints_RejectedRoutingFailsFast(t *testing.T) {
-	styledLog := &mockStyledLogger{}
-
-	endpoint1URL, _ := url.Parse("http://ollama:11434")
-	candidates := []*domain.Endpoint{
-		{
-			Name:      "ollama",
-			URL:       endpoint1URL,
-			URLString: "http://ollama:11434",
-			Type:      domain.ProfileOllama,
-		},
-	}
-
-	// strict: true means GetRoutableEndpointsForModel returns a genuine rejection
-	// (nil endpoints, Action=Rejected) rather than the misleading fallback-to-all
-	// most other tests in this package rely on.
+	// Registry has no models matching the alias, and strict mode means the standard-routing
+	// fallback lookup rejects rather than handing back all candidates.
 	modelRegistry := &mockSimpleModelRegistry{
 		endpointsForModel: map[string][]string{},
 		strict:            true,
@@ -164,7 +122,7 @@ func TestResolveAliasEndpoints_RejectedRoutingFailsFast(t *testing.T) {
 
 	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
 
-	assert.Empty(t, result, "a rejected routing decision must fail fast with no endpoints, not fall back to all candidates")
+	assert.Empty(t, result, "a rejected fallback lookup must fail fast, not return all candidates")
 
 	require.NotNil(t, profile.RoutingDecision, "rejection decision should still be recorded for headers/metrics")
 	assert.Equal(t, "rejected", profile.RoutingDecision.Action)

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -126,6 +128,69 @@ func TestResolveAliasEndpoints_NoMatchingEndpoints(t *testing.T) {
 
 	require.NotNil(t, profile.RoutingDecision, "rejection decision should still be recorded for headers/metrics")
 	assert.Equal(t, "rejected", profile.RoutingDecision.Action)
+}
+
+// mockBasicActionModelRegistry mimics MemoryModelRegistry's base GetRoutableEndpointsForModel
+// (internal/adapter/registry/memory_registry.go), which reports rejections with action
+// "no_model"/"no_healthy" rather than "rejected", but still sets a 4xx/5xx StatusCode.
+// Used to prove the alias fail-fast short-circuit is keyed on status code, not the
+// "rejected" action string (fix 1 from the #191 follow-up review).
+type mockBasicActionModelRegistry struct {
+	baseMockRegistry
+}
+
+func (m *mockBasicActionModelRegistry) GetRoutableEndpointsForModel(_ context.Context, _ string, _ []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
+	return []*domain.Endpoint{}, &domain.ModelRoutingDecision{
+		Strategy:   "basic",
+		Action:     "no_model",
+		Reason:     "Model not found in any endpoint",
+		StatusCode: http.StatusNotFound,
+	}, nil
+}
+
+// TestResolveAliasEndpoints_ShortCircuitsOnStatusCodeNotActionString covers fix 1 from
+// the #191 follow-up review: the alias fail-fast short-circuit must key on
+// decision.StatusCode (matching writeNoRoutableEndpoints' contract), not on
+// decision.Action == "rejected". A registry that reports a 404 rejection under a
+// different action name (as MemoryModelRegistry's base implementation does) must
+// still short-circuit; keying on the action string alone would silently fall through
+// and reintroduce the #191 bypass.
+func TestResolveAliasEndpoints_ShortCircuitsOnStatusCodeNotActionString(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://ollama:11434")
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "ollama",
+			URL:       endpoint1URL,
+			URLString: "http://ollama:11434",
+			Type:      domain.ProfileOllama,
+		},
+	}
+
+	// Alias resolves to nothing, so resolveAliasEndpoints falls through to the
+	// standard-routing fallback lookup, which is where the short-circuit lives.
+	aliases := map[string][]string{
+		"nonexistent-alias": {"model-not-in-registry"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: &mockBasicActionModelRegistry{},
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "nonexistent-alias"
+	profile.SupportedBy = []string{domain.ProfileOllama}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	assert.Empty(t, result, "a 404/503 decision must fail fast regardless of its action string")
+	require.NotNil(t, profile.RoutingDecision)
+	assert.Equal(t, "no_model", profile.RoutingDecision.Action, "sanity check: this registry deliberately does not use the \"rejected\" action string")
+	assert.Equal(t, http.StatusNotFound, profile.RoutingDecision.StatusCode)
 }
 
 func TestResolveAliasEndpoints_SelfReferencingAlias(t *testing.T) {

--- a/internal/app/handlers/handler_proxy_model_test.go
+++ b/internal/app/handlers/handler_proxy_model_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http/httptest"
@@ -205,6 +206,10 @@ func (m *mockStyledLogger) InfoConfigChange(oldName, newName string)            
 type mockSimpleModelRegistry struct {
 	baseMockRegistry
 	endpointsForModel map[string][]string
+	// strict switches GetRoutableEndpointsForModel to genuine strict-routing
+	// behaviour (reject with nil endpoints) instead of the default fallback-to-all
+	// used by most existing tests. Defaults to false so current callers are unaffected.
+	strict bool
 }
 
 func (m *mockSimpleModelRegistry) GetEndpointsForModel(ctx context.Context, modelName string) ([]string, error) {
@@ -220,11 +225,20 @@ func (m *mockSimpleModelRegistry) IsModelAvailable(ctx context.Context, modelNam
 }
 
 func (m *mockSimpleModelRegistry) GetRoutableEndpointsForModel(ctx context.Context, modelName string, healthyEndpoints []*domain.Endpoint) ([]*domain.Endpoint, *domain.ModelRoutingDecision, error) {
-	// implement strict routing for tests
 	modelEndpoints, _ := m.GetEndpointsForModel(ctx, modelName)
 
 	if len(modelEndpoints) == 0 {
-		// model not found - return all healthy as fallback (for test compatibility)
+		if m.strict {
+			// genuine strict routing: model nowhere in the fleet, reject with no endpoints
+			return nil, &domain.ModelRoutingDecision{
+				Strategy:   "strict",
+				Action:     "rejected",
+				Reason:     "model_not_found",
+				StatusCode: 404,
+			}, fmt.Errorf("model %s not found on any endpoint", modelName)
+		}
+
+		// default (most existing tests): return all healthy as fallback
 		return healthyEndpoints, &domain.ModelRoutingDecision{
 			Strategy: "test",
 			Action:   "fallback",
@@ -246,7 +260,16 @@ func (m *mockSimpleModelRegistry) GetRoutableEndpointsForModel(ctx context.Conte
 	}
 
 	if len(routable) == 0 {
-		// model only on unhealthy endpoints
+		if m.strict {
+			return nil, &domain.ModelRoutingDecision{
+				Strategy:   "strict",
+				Action:     "rejected",
+				Reason:     "model_unavailable",
+				StatusCode: 503,
+			}, fmt.Errorf("model %s only available on unhealthy endpoints", modelName)
+		}
+
+		// model only on unhealthy endpoints - fallback for test compatibility
 		return healthyEndpoints, &domain.ModelRoutingDecision{
 			Strategy: "test",
 			Action:   "fallback",

--- a/internal/app/handlers/handler_proxy_model_test.go
+++ b/internal/app/handlers/handler_proxy_model_test.go
@@ -269,7 +269,7 @@ func (m *mockSimpleModelRegistry) GetRoutableEndpointsForModel(ctx context.Conte
 			}, fmt.Errorf("model %s only available on unhealthy endpoints", modelName)
 		}
 
-		// model only on unhealthy endpoints - fallback for test compatibility
+		// model only on unhealthy endpoints; fallback for test compatibility
 		return healthyEndpoints, &domain.ModelRoutingDecision{
 			Strategy: "test",
 			Action:   "fallback",

--- a/internal/app/handlers/handler_translation.go
+++ b/internal/app/handlers/handler_translation.go
@@ -393,12 +393,33 @@ func (a *Application) translationHandler(trans translator.RequestTranslator) htt
 		// make sure that we have at least one endpoint available
 		// prevents hanging when model routing fails to find compatible backends
 		if len(endpoints) == 0 {
-			pr.requestLogger.Warn("No endpoints available for model",
-				"model", pr.model,
-				"translator", trans.Name())
-			a.writeTranslatorError(w, trans, pr,
-				fmt.Errorf("no healthy endpoints available for model: %s", pr.model),
-				http.StatusNotFound)
+			// A recorded routing decision (e.g. strict model_not_found/model_unavailable)
+			// carries the precise status and reason. Without one, defaulting to 404
+			// preserves the historical behaviour. Falling through to a hardcoded 404
+			// would flatten a strict "model only on unhealthy endpoints" 503 to 404 and
+			// drop the X-Olla-Routing-* headers, which the equivalent proxy-route
+			// rejection (writeNoRoutableEndpoints) always sets (#191).
+			var decision *domain.ModelRoutingDecision
+			if pr.profile != nil {
+				decision = pr.profile.RoutingDecision
+			}
+
+			status := http.StatusNotFound
+			reason := fmt.Sprintf("no healthy endpoints available for model: %s", pr.model)
+			if decision != nil && decision.StatusCode >= http.StatusBadRequest {
+				status = decision.StatusCode
+				reason = decision.Reason
+				pr.stats.RoutingDecision = decision
+				a.setRoutingDecisionHeaders(w, decision)
+			}
+
+			// Headers must be set before writeTranslatorError, which calls WriteHeader.
+			a.setStickyResponseHeadersFromRequest(w, r)
+
+			a.logRequestStart(pr, 0)
+			a.logRequestRejected(pr, status)
+
+			a.writeTranslatorError(w, trans, pr, errors.New(reason), status)
 			a.recordTranslatorMetrics(trans, pr, constants.TranslatorModeTranslation, constants.FallbackReasonNoCompatibleEndpoints)
 			return
 		}

--- a/internal/app/handlers/handler_translation_strict_rejection_test.go
+++ b/internal/app/handlers/handler_translation_strict_rejection_test.go
@@ -1,0 +1,138 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thushan/olla/internal/adapter/inspector"
+	"github.com/thushan/olla/internal/adapter/translator/anthropic"
+	"github.com/thushan/olla/internal/config"
+	"github.com/thushan/olla/internal/core/constants"
+)
+
+// TestTranslationHandler_StrictRejection_DecisionAwareStatusAndHeaders covers fix 3
+// from the #191 follow-up review: the translation route's zero-endpoint branch used to
+// always return a hardcoded 404 via writeTranslatorError, ignoring pr.profile.RoutingDecision
+// entirely. That flattened a strict "model only on unhealthy endpoints" 503 to 404 and never
+// set X-Olla-Routing-* headers, unlike the equivalent proxy-route rejection
+// (writeNoRoutableEndpoints). This proves the translation route now honours the recorded
+// decision's status code and reason, sets the routing headers, and still returns an
+// Anthropic-shaped JSON error body (the Anthropic route must never fall back to the
+// plain-text writeNoRoutableEndpoints format).
+func TestTranslationHandler_StrictRejection_DecisionAwareStatusAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	styledLog := &mockStyledLogger{}
+
+	// Real inspector chain (path + body) so profile.ModelName is populated from the
+	// request body exactly as it is in production, matching the #191 proxy-route tests.
+	chain := inspector.NewChain(styledLog)
+	bodyInspector, err := inspector.NewBodyInspector(styledLog)
+	require.NoError(t, err)
+	chain.AddInspector(bodyInspector)
+
+	trans, err := anthropic.NewTranslator(styledLog, config.AnthropicTranslatorConfig{})
+	require.NoError(t, err)
+
+	// Strict registry: the requested model exists nowhere in the fleet, so
+	// GetRoutableEndpointsForModel rejects with a genuine strict decision
+	// (action "rejected", reason model_not_found, status 404).
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{},
+		strict:            true,
+	}
+
+	app := &Application{
+		Config:           &config.Config{},
+		logger:           styledLog,
+		inspectorChain:   chain,
+		discoveryService: &mockDiscoveryServiceForTranslation{},
+		modelRegistry:    modelRegistry,
+		statsCollector:   &mockStatsCollector{},
+		proxyService: &mockProxyService{
+			proxyFunc: nil, // must never be reached
+		},
+	}
+
+	body := `{"model":"claude-not-registered","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/olla/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
+	w := httptest.NewRecorder()
+
+	app.translationHandler(trans).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "must use the decision's status code, not a hardcoded default")
+	assert.Equal(t, "strict", w.Header().Get(constants.HeaderXOllaRoutingStrategy))
+	assert.Equal(t, "rejected", w.Header().Get(constants.HeaderXOllaRoutingDecision))
+	assert.Equal(t, "model_not_found", w.Header().Get(constants.HeaderXOllaRoutingReason))
+
+	// Anthropic-shaped JSON error body must be preserved - the route must never
+	// fall back to the plain-text writeNoRoutableEndpoints format.
+	var errResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Equal(t, "error", errResp["type"])
+	errObj, ok := errResp["error"].(map[string]interface{})
+	require.True(t, ok, "response must carry an Anthropic-shaped error object")
+	assert.Equal(t, "not_found_error", errObj["type"], "404 must map to Anthropic's not_found_error type")
+}
+
+// TestTranslationHandler_StrictRejection_ModelUnavailableMaps503 proves the 503 case
+// (model exists but only on unhealthy endpoints) also survives to the translation route,
+// where it previously would have been flattened to 404.
+func TestTranslationHandler_StrictRejection_ModelUnavailableMaps503(t *testing.T) {
+	t.Parallel()
+
+	styledLog := &mockStyledLogger{}
+
+	chain := inspector.NewChain(styledLog)
+	bodyInspector, err := inspector.NewBodyInspector(styledLog)
+	require.NoError(t, err)
+	chain.AddInspector(bodyInspector)
+
+	trans, err := anthropic.NewTranslator(styledLog, config.AnthropicTranslatorConfig{})
+	require.NoError(t, err)
+
+	// Model is known to the fleet but not present on the one healthy candidate returned
+	// by mockDiscoveryServiceForTranslation, so the strict registry rejects with 503.
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{
+			"claude-somewhere-else": {"http://some-other-host:9999"},
+		},
+		strict: true,
+	}
+
+	app := &Application{
+		Config:           &config.Config{},
+		logger:           styledLog,
+		inspectorChain:   chain,
+		discoveryService: &mockDiscoveryServiceForTranslation{},
+		modelRegistry:    modelRegistry,
+		statsCollector:   &mockStatsCollector{},
+		proxyService: &mockProxyService{
+			proxyFunc: nil,
+		},
+	}
+
+	body := `{"model":"claude-somewhere-else","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/olla/anthropic/v1/messages", strings.NewReader(body))
+	req.Header.Set(constants.HeaderContentType, constants.ContentTypeJSON)
+	w := httptest.NewRecorder()
+
+	app.translationHandler(trans).ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "model_unavailable must map to 503, not the hardcoded 404 default")
+	assert.Equal(t, "strict", w.Header().Get(constants.HeaderXOllaRoutingStrategy))
+	assert.Equal(t, "rejected", w.Header().Get(constants.HeaderXOllaRoutingDecision))
+	assert.Equal(t, "model_unavailable", w.Header().Get(constants.HeaderXOllaRoutingReason))
+
+	var errResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	errObj, ok := errResp["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "api_error", errObj["type"], "503 falls back to the generic api_error type per the Anthropic taxonomy")
+}

--- a/test/scripts/logic/test-model-routing-strategy.sh
+++ b/test/scripts/logic/test-model-routing-strategy.sh
@@ -5,6 +5,9 @@ set -e
 
 OLLA_URL=${OLLA_URL:-"http://localhost:8080"}
 MODEL=${MODEL:-"phi3.5:latest"}
+# ALIAS_MODEL must be a `model_aliases` key in the running Olla's config whose
+# listed real model names exist on none of the configured endpoints - see #191.
+ALIAS_MODEL=${ALIAS_MODEL:-"nonexistent-alias-target"}
 
 echo "Testing Model Routing Strategies"
 echo "================================"
@@ -70,5 +73,35 @@ else
 fi
 
 echo ""
+
+# test 4: alias pointing at a model that exists on no endpoint (#191)
+# requires the running Olla's config to have routing_strategy.type: strict and a
+# model_aliases entry:
+#   model_aliases:
+#     nonexistent-alias-target:
+#       - some-model-that-is-not-served-anywhere
+# under strict routing this must reject fast (404, model_not_found) rather than
+# silently proxying to a compatible-but-wrong backend and returning 200.
+echo "=== Test 4: Alias With No Routable Target (strict routing must reject, not proxy) ==="
+response=$(curl -s -i -X POST "$OLLA_URL/olla/proxy/api/generate" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"$ALIAS_MODEL\", \"prompt\": \"test\", \"stream\": false}" \
+    2>&1 || true)
+
+status_code=$(echo "$response" | head -n 1 | awk '{print $2}')
+decision_header=$(echo "$response" | grep -i "X-Olla-Routing-Decision:" | head -n 1 || echo "")
+
+echo "Response Status: $status_code"
+echo "Routing Decision: $decision_header"
+
+if [[ "$status_code" == "404" || "$status_code" == "503" ]]; then
+    echo "✓ Alias with no routable target was rejected (status $status_code), not proxied"
+else
+    echo "✗ Expected a rejection status (404/503) but got $status_code - request may have been proxied to the wrong backend"
+fi
+
+echo "---"
+echo ""
+
 echo "================================"
 echo "Model Routing Strategy Tests Complete"

--- a/test/scripts/logic/test-model-routing-strategy.sh
+++ b/test/scripts/logic/test-model-routing-strategy.sh
@@ -9,6 +9,14 @@ MODEL=${MODEL:-"phi3.5:latest"}
 # listed real model names exist on none of the configured endpoints - see #191.
 ALIAS_MODEL=${ALIAS_MODEL:-"nonexistent-alias-target"}
 
+# FAILED_TESTS follows the same pass/fail convention as the other scripts in
+# test/scripts/logic (test-model-routing.sh, test-provider-models.sh,
+# test-provider-routing.sh): increment on a real assertion failure, exit 1 at
+# the end if non-zero. Most tests in this script are informational only
+# (echo ✓/✗ without affecting the exit code), but Test 4 asserts a concrete
+# regression (#191) and must fail the script when it doesn't hold.
+FAILED_TESTS=0
+
 echo "Testing Model Routing Strategies"
 echo "================================"
 echo ""
@@ -94,10 +102,11 @@ decision_header=$(echo "$response" | grep -i "X-Olla-Routing-Decision:" | head -
 echo "Response Status: $status_code"
 echo "Routing Decision: $decision_header"
 
-if [[ "$status_code" == "404" || "$status_code" == "503" ]]; then
+if [[ ( "$status_code" == "404" || "$status_code" == "503" ) && "$decision_header" == *"rejected"* ]]; then
     echo "✓ Alias with no routable target was rejected (status $status_code), not proxied"
 else
-    echo "✗ Expected a rejection status (404/503) but got $status_code - request may have been proxied to the wrong backend"
+    echo "✗ Expected a rejection status (404/503) with X-Olla-Routing-Decision: rejected but got status $status_code, decision '$decision_header' - request may have been proxied to the wrong backend"
+    FAILED_TESTS=$((FAILED_TESTS + 1))
 fi
 
 echo "---"
@@ -105,3 +114,8 @@ echo ""
 
 echo "================================"
 echo "Model Routing Strategy Tests Complete"
+
+if [[ $FAILED_TESTS -gt 0 ]]; then
+    echo "$FAILED_TESTS test(s) failed"
+    exit 1
+fi


### PR DESCRIPTION
Strict routing could be bypassed when a request used a model_aliases entry whose target model existed on no endpoint: the routing decision was logged as rejected, but the request was still proxied to a compatible backend and returned 200. Requests now fail fast with a decision-aware 404/503 and routing_action: rejected, matching how unknown models are already handled.

This resolves #191 

# Changes

- Alias resolution no longer falls back to all profile-compatible endpoints when the routing decision is a rejection; it returns no endpoints so the request short-circuits before dispatch
- Shared post-selection dispatch tail across /olla/proxy/ and provider-prefixed routes, so rejections behave identically on every route (incl. X-Olla-Routing-* headers)
- Rejection short-circuit keys on the decision's status code rather than the action string, so base-registry rejections (no_model/no_healthy) can't slip through
- Aliases that resolve to real models with no healthy serving candidate now record a routing decision (503 model_unavailable) instead of a generic 404 with no routing headers
- Anthropic translation route honours the recorded routing decision on zero-endpoint rejection (correct 503 vs 404, routing headers, shared rejection log) while keeping Anthropic-shaped JSON error bodies
- Short-circuited rejections are logged as Request rejected (warn) rather than Request completed
- Docs updated: unroutable aliases fail fast under strict routing and non-all fallback behaviours

# Behavioural notes

- `/olla/proxy/` with zero healthy endpoints now returns 503 (previously 502 from the proxy engine); adjust any monitors keyed on 502 which most folks won't have we think.
- Under optimistic routing with fallback_behavior: none or compatible_only, unroutable aliases now also fail fast (consistent with the non-alias path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Model alias requests that resolve to no routable endpoints now fail fast instead of being proxied to an incompatible backend.
  - Responses now use routing-aware status codes (e.g., 404/503) and return consistent routing decision headers and error details across proxy and translation paths.
  - Strict routing enforces correct rejection for both missing and unhealthy-only alias targets.

- **Documentation**
  - Updated alias routing documentation to clarify fallback and rejection behaviour by routing strategy.

- **Tests**
  - Added and expanded regression and strict-routing test coverage, including a routing strategy script check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->