### PR TITLE
fix: config/models.yaml parsing failures

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -9,17 +9,17 @@ model_extraction:
       variant_group: 2
       description: "Mistral and Mixtral models"
       
-    - pattern: "^(llama|gemma|phi|qwen)[-_]?(\d+(?:\.\d+)?)"
+    - pattern: '^(llama|gemma|phi|qwen)[-_]?(\d+(?:\.\d+)?)'
       family_group: 1
       variant_group: 2
       description: "Common families with version numbers"
-      
-    - pattern: "^[^/]+/(phi|llama|gemma|qwen|mistral)[-_]?(\d+(?:\.\d+)?)"
+
+    - pattern: '^[^/]+/(phi|llama|gemma|qwen|mistral)[-_]?(\d+(?:\.\d+)?)'
       family_group: 1
       variant_group: 2
       description: "Models with publisher prefix"
-      
-    - pattern: "^(codellama|starcoder|vicuna|falcon|yi)[-_]?(\d+[bB]?)"
+
+    - pattern: '^(codellama|starcoder|vicuna|falcon|yi)[-_]?(\d+[bB]?)'
       family_group: 1
       variant_group: 2
       description: "Code and specialised models"
@@ -45,6 +45,7 @@ model_extraction:
     "llama3.1": llama
     "llama3.2": llama
     "llama3.3": llama
+    llama4: llama
     gemma: gemma
     gemma2: gemma
     gemma3: gemma

--- a/internal/adapter/unifier/factory.go
+++ b/internal/adapter/unifier/factory.go
@@ -27,6 +27,11 @@ func NewFactory(log logger.StyledLogger) *Factory {
 		logger:   log,
 	}
 
+	// Force the model unification config to load now, at startup, rather than
+	// lazily on first inference request - a broken models.yaml should show up
+	// in the boot logs, not silently degrade unification quality later.
+	LogConfigStatus(log)
+
 	// Register default unifier
 	factory.Register(DefaultUnifierType, func(l logger.StyledLogger) ports.ModelUnifier {
 		return NewDefaultUnifier()

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -98,23 +98,34 @@ func ConfigSource() string {
 // request.
 func LogConfigStatus(log logger.StyledLogger) {
 	_, err := LoadModelConfig()
+	if log == nil {
+		// still trigger the load above so callers that only care about the
+		// side effect (warming the singleton) work with a nil logger; there's
+		// just nothing to log to
+		return
+	}
 	if err != nil {
 		log.Error("model unification config: failed to compile patterns, using embedded defaults", "error", err)
 		return
 	}
 
-	if configSource != "" {
-		log.Debug("model unification config loaded", "source", configSource)
-		return
-	}
-
+	// Warn about every found-but-unparseable candidate even when a later
+	// candidate loaded successfully - otherwise a broken ./models.yaml next
+	// to a working config/models.yaml goes unmentioned, which is exactly the
+	// silence issue #204 complained about.
 	if len(configParseWarnings) > 0 {
 		log.Warn("model unification config: found models.yaml but could not parse it, falling back to embedded defaults",
 			"details", strings.Join(configParseWarnings, "; "))
+	}
+
+	if configSource != "" {
+		log.Info("model unification config loaded", "source", configSource)
 		return
 	}
 
-	log.Debug("model unification config: no models.yaml found, using embedded defaults")
+	if len(configParseWarnings) == 0 {
+		log.Debug("model unification config: no models.yaml found, using embedded defaults")
+	}
 }
 
 // loadConfigFromFile loads configuration from the YAML file, trying each

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -187,12 +187,20 @@ func loadConfigFromFile() (*ModelUnificationConfig, string, []string) {
 
 // isEffectivelyEmpty reports whether a successfully-parsed config carries no
 // real configuration at all - the signature of an empty or comment-only YAML
-// file, which is valid YAML but not a usable models.yaml.
+// file, which is valid YAML but not a usable models.yaml. Every top-level
+// section counts: a file that only sets family_aliases (say) is a legitimate
+// partial override and must not be discarded as "empty".
 func (c *ModelUnificationConfig) isEffectivelyEmpty() bool {
 	return len(c.ModelExtraction.FamilyPatterns) == 0 &&
+		len(c.ModelExtraction.FamilyAliases) == 0 &&
+		len(c.ModelExtraction.ArchitectureMappings) == 0 &&
+		len(c.ModelExtraction.PublisherMappings) == 0 &&
 		len(c.Capabilities.NamePatterns) == 0 &&
+		len(c.Capabilities.TypeCapabilities) == 0 &&
+		len(c.Capabilities.ContextThresholds) == 0 &&
 		len(c.Quantization.Mappings) == 0 &&
-		len(c.ModelExtraction.ArchitectureMappings) == 0
+		len(c.SpecialRules.PreserveFamily) == 0 &&
+		len(c.SpecialRules.GenericNames) == 0
 }
 
 // compilePatterns compiles all regex patterns in the configuration

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -76,9 +76,30 @@ var (
 func LoadModelConfig() (*ModelUnificationConfig, error) {
 	configOnce.Do(func() {
 		configInstance, configSource, configParseWarnings = loadConfigFromFile()
-		if configInstance != nil {
-			errConfig = configInstance.compilePatterns()
+		if configInstance == nil {
+			return
 		}
+
+		if err := configInstance.compilePatterns(); err != nil {
+			// the candidate parsed as valid YAML but at least one of its
+			// patterns isn't a valid regex. Don't hand back an uncompiled
+			// config - regex-driven extraction nil-guards on that, so it
+			// would silently no-op rather than panic, which is exactly the
+			// #204 class of silent failure. Record why and recover onto the
+			// embedded defaults, which are known-good.
+			if configSource != "" {
+				configParseWarnings = append(configParseWarnings, fmt.Sprintf("%s: %v", configSource, err))
+			}
+			configSource = ""
+			configInstance = getDefaultConfig()
+			// defaults are hardcoded and covered by TestPatternCompilation,
+			// so this should never fail - but never panic on the assumption,
+			// so keep whatever it returns rather than assuming success.
+			errConfig = configInstance.compilePatterns()
+			return
+		}
+
+		errConfig = nil
 	})
 	return configInstance, errConfig
 }

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -1,7 +1,9 @@
 package unifier
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -184,6 +186,14 @@ func loadConfigFromFile() (*ModelUnificationConfig, string, []string) {
 
 		data, err := os.ReadFile(path)
 		if err != nil {
+			// a candidate simply not existing is the overwhelmingly common
+			// case (most of the search path is speculative) and not worth a
+			// warning. Anything else - permission denied, a directory named
+			// models.yaml, and so on - is a real problem the operator should
+			// hear about, not silence.
+			if !errors.Is(err, fs.ErrNotExist) {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", path, err))
+			}
 			continue
 		}
 

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -130,13 +130,18 @@ func LogConfigStatus(log logger.StyledLogger) {
 		return
 	}
 
-	// Warn about every found-but-unparseable candidate even when a later
+	// Warn about every found-but-unusable candidate even when a later
 	// candidate loaded successfully - otherwise a broken ./models.yaml next
 	// to a working config/models.yaml goes unmentioned, which is exactly the
-	// silence issue #204 complained about.
+	// silence issue #204 complained about. The wording must stay truthful to
+	// what actually happened next: only claim "falling back to embedded
+	// defaults" when that's genuinely what's active.
 	if len(configParseWarnings) > 0 {
-		log.Warn("model unification config: found models.yaml but could not parse it, falling back to embedded defaults",
-			"details", strings.Join(configParseWarnings, "; "))
+		msg := "model unification config: found unusable models.yaml candidate(s), falling back to embedded defaults"
+		if configSource != "" {
+			msg = fmt.Sprintf("model unification config: found unusable models.yaml candidate(s), using %s instead", configSource)
+		}
+		log.Warn(msg, "details", strings.Join(configParseWarnings, "; "))
 	}
 
 	if configSource != "" {

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -5,9 +5,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/thushan/olla/internal/logger"
 )
 
 // ModelUnificationConfig represents the model unification configuration.
@@ -59,12 +62,20 @@ var (
 	configInstance *ModelUnificationConfig
 	configOnce     sync.Once
 	errConfig      error
+
+	// configSource is the path models.yaml was loaded from, or "" when
+	// embedded defaults are in use. configParseWarnings records any
+	// candidate paths that were found but failed to parse, so a startup
+	// diagnostic can explain *why* defaults were used rather than leaving
+	// it silent (see issue #204).
+	configSource        string
+	configParseWarnings []string
 )
 
 // LoadModelConfig loads the model unification configuration
 func LoadModelConfig() (*ModelUnificationConfig, error) {
 	configOnce.Do(func() {
-		configInstance = loadConfigFromFile()
+		configInstance, configSource, configParseWarnings = loadConfigFromFile()
 		if configInstance != nil {
 			errConfig = configInstance.compilePatterns()
 		}
@@ -72,8 +83,45 @@ func LoadModelConfig() (*ModelUnificationConfig, error) {
 	return configInstance, errConfig
 }
 
-// loadConfigFromFile loads configuration from the YAML file
-func loadConfigFromFile() *ModelUnificationConfig {
+// ConfigSource returns the path models.yaml was loaded from, triggering the
+// load if it hasn't happened yet. An empty string means embedded defaults
+// are in use - check the returned warnings via LogConfigStatus to see why.
+func ConfigSource() string {
+	_, _ = LoadModelConfig()
+	return configSource
+}
+
+// LogConfigStatus reports where the model unification config came from.
+// Intended to be called once at startup (rather than relying on the lazy
+// first-use load) so a broken config/models.yaml is surfaced immediately
+// instead of silently degrading to embedded defaults on first inference
+// request.
+func LogConfigStatus(log logger.StyledLogger) {
+	_, err := LoadModelConfig()
+	if err != nil {
+		log.Error("model unification config: failed to compile patterns, using embedded defaults", "error", err)
+		return
+	}
+
+	if configSource != "" {
+		log.Debug("model unification config loaded", "source", configSource)
+		return
+	}
+
+	if len(configParseWarnings) > 0 {
+		log.Warn("model unification config: found models.yaml but could not parse it, falling back to embedded defaults",
+			"details", strings.Join(configParseWarnings, "; "))
+		return
+	}
+
+	log.Debug("model unification config: no models.yaml found, using embedded defaults")
+}
+
+// loadConfigFromFile loads configuration from the YAML file, trying each
+// candidate path in turn. Returns the loaded config, the path it came from
+// (empty if falling back to defaults), and any parse failures encountered
+// along the way for diagnostics.
+func loadConfigFromFile() (*ModelUnificationConfig, string, []string) {
 	paths := []string{
 		"models.yaml",
 		"config/models.yaml",
@@ -82,6 +130,8 @@ func loadConfigFromFile() *ModelUnificationConfig {
 		"../../config/models.yaml",
 		filepath.Join(os.Getenv("OLLA_CONFIG_DIR"), "models.yaml"),
 	}
+
+	var warnings []string
 
 	for _, path := range paths {
 		if path == "" {
@@ -95,13 +145,16 @@ func loadConfigFromFile() *ModelUnificationConfig {
 
 		var config ModelUnificationConfig
 		if err := yaml.Unmarshal(data, &config); err != nil {
+			// found the file but it doesn't parse - record why so LogConfigStatus
+			// can tell the operator instead of quietly using defaults
+			warnings = append(warnings, fmt.Sprintf("%s: %v", path, err))
 			continue
 		}
 
-		return &config
+		return &config, path, warnings
 	}
 
-	return getDefaultConfig()
+	return getDefaultConfig(), "", warnings
 }
 
 // compilePatterns compiles all regex patterns in the configuration
@@ -142,19 +195,19 @@ func getDefaultConfig() *ModelUnificationConfig {
 			Pattern:      `^(llama|gemma|phi|qwen)[-_]?(\d+(?:\.\d+)?)`,
 			FamilyGroup:  1,
 			VariantGroup: 2,
-			Description:  "Common families with versions",
+			Description:  "Common families with version numbers",
 		},
 		{
 			Pattern:      `^[^/]+/(phi|llama|gemma|qwen|mistral)[-_]?(\d+(?:\.\d+)?)`,
 			FamilyGroup:  1,
 			VariantGroup: 2,
-			Description:  "Publisher-prefixed models",
+			Description:  "Models with publisher prefix",
 		},
 		{
 			Pattern:      `^(codellama|starcoder|vicuna|falcon|yi)[-_]?(\d+[bB]?)`,
 			FamilyGroup:  1,
 			VariantGroup: 2,
-			Description:  "Code and specialized models",
+			Description:  "Code and specialised models",
 		},
 		{
 			Pattern:      `^(gpt)[-_]?(2|j|neox)?`,
@@ -168,6 +221,23 @@ func getDefaultConfig() *ModelUnificationConfig {
 			VariantGroup: 2,
 			Description:  "DeepSeek models",
 		},
+	}
+
+	config.ModelExtraction.FamilyAliases = map[string]string{
+		"llama3":    "llama",
+		"llama3.2":  "llama",
+		"llama3.3":  "llama",
+		"llama4":    "llama",
+		"gemma2":    "gemma",
+		"gemma3":    "gemma",
+		"phi3":      "phi",
+		"phi3.5":    "phi",
+		"phi4":      "phi",
+		"qwen2":     "qwen",
+		"qwen2.5":   "qwen",
+		"qwen3":     "qwen",
+		"deepseek2": "deepseek",
+		"devstral":  "mistral",
 	}
 
 	config.ModelExtraction.ArchitectureMappings = map[string]string{
@@ -230,6 +300,7 @@ func getDefaultConfig() *ModelUnificationConfig {
 		"AWQ-4BIT":  "awq4",
 		"INT8":      "int8",
 		"INT4":      "int4",
+		"Q4_K_XL":   "q4kxl",
 	}
 
 	config.ModelExtraction.PublisherMappings = map[string]string{
@@ -243,6 +314,13 @@ func getDefaultConfig() *ModelUnificationConfig {
 		"deepseek":  "deepseek",
 		"yi":        "01-ai",
 		"starcoder": "bigcode",
+		"falcon":    "tii",
+		"vicuna":    "lmsys",
+		"bloom":     "bigscience",
+		"opt":       "meta",
+		"gpt2":      "openai",
+		"gptj":      "eleutherai",
+		"gptneox":   "eleutherai",
 	}
 
 	config.Capabilities.TypeCapabilities = map[string][]string{
@@ -281,6 +359,7 @@ func getDefaultConfig() *ModelUnificationConfig {
 		"ultra_long_context": 1000000,
 	}
 
+	config.SpecialRules.PreserveFamily = []string{"nomic-bert", "deepseek-coder-v2"}
 	config.SpecialRules.GenericNames = []string{"model", "unknown", "test", "temp", "default"}
 
 	return config

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -139,15 +139,22 @@ func loadConfigFromFile() (*ModelUnificationConfig, string, []string) {
 		"config-base/models.yaml",
 		"../config/models.yaml",
 		"../../config/models.yaml",
-		filepath.Join(os.Getenv("OLLA_CONFIG_DIR"), "models.yaml"),
+	}
+	// filepath.Join("", "models.yaml") collapses to "models.yaml", which would
+	// silently duplicate the first candidate (and double every warning) when
+	// OLLA_CONFIG_DIR is unset - only add it when it's actually set.
+	if configDir := os.Getenv("OLLA_CONFIG_DIR"); configDir != "" {
+		paths = append(paths, filepath.Join(configDir, "models.yaml"))
 	}
 
 	var warnings []string
+	seen := make(map[string]bool, len(paths))
 
 	for _, path := range paths {
-		if path == "" {
+		if path == "" || seen[path] {
 			continue
 		}
+		seen[path] = true
 
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -162,10 +169,30 @@ func loadConfigFromFile() (*ModelUnificationConfig, string, []string) {
 			continue
 		}
 
+		if config.isEffectivelyEmpty() {
+			// an empty or comment-only file unmarshals without error, but
+			// treating that as "loaded" repeats the #204 silent-failure class:
+			// LogConfigStatus would report success while every lookup against
+			// it returns nothing. Warn and let a later candidate (or defaults)
+			// win instead.
+			warnings = append(warnings, fmt.Sprintf("%s: parsed but contains no configuration", path))
+			continue
+		}
+
 		return &config, path, warnings
 	}
 
 	return getDefaultConfig(), "", warnings
+}
+
+// isEffectivelyEmpty reports whether a successfully-parsed config carries no
+// real configuration at all - the signature of an empty or comment-only YAML
+// file, which is valid YAML but not a usable models.yaml.
+func (c *ModelUnificationConfig) isEffectivelyEmpty() bool {
+	return len(c.ModelExtraction.FamilyPatterns) == 0 &&
+		len(c.Capabilities.NamePatterns) == 0 &&
+		len(c.Quantization.Mappings) == 0 &&
+		len(c.ModelExtraction.ArchitectureMappings) == 0
 }
 
 // compilePatterns compiles all regex patterns in the configuration

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -281,8 +281,48 @@ func TestLogConfigStatus_WarnsOnBrokenShippedFile(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "level=WARN")
-	assert.Contains(t, out, "could not parse")
+	assert.Contains(t, out, "unusable models.yaml candidate")
+	assert.Contains(t, out, "falling back to embedded defaults")
 	assert.Contains(t, out, "models.yaml")
+}
+
+// TestLogConfigStatus_ShadowedBrokenCandidateReportsRealSource is the
+// scenario issue #204's original complaint was about: a broken candidate
+// earlier in the search order (here "models.yaml" in the cwd) sitting next
+// to a working one later in the order (here the OLLA_CONFIG_DIR candidate).
+// The broken one must still be warned about - the earlier "shadowed" bug
+// dropped that warning entirely once a later candidate loaded - but the
+// message must not claim defaults are active when a real file loaded.
+func TestLogConfigStatus_ShadowedBrokenCandidateReportsRealSource(t *testing.T) {
+	cwd := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cwd, "models.yaml"), []byte(brokenModelsYAML), 0644))
+	t.Chdir(cwd)
+
+	configDir := t.TempDir()
+	workingYAML := `
+model_extraction:
+  family_aliases:
+    llama3: llama
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "models.yaml"), []byte(workingYAML), 0644))
+	t.Setenv("OLLA_CONFIG_DIR", configDir)
+
+	resetConfigSingleton()
+	t.Cleanup(resetConfigSingleton)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	LogConfigStatus(logger.NewPlainStyledLogger(log))
+
+	out := buf.String()
+	assert.Contains(t, out, "level=WARN", "the broken cwd candidate must still be reported, not shadowed into silence")
+	assert.Contains(t, out, "unusable models.yaml candidate")
+	assert.Contains(t, out, "using ", "must say which source is active instead of claiming defaults")
+	assert.Contains(t, out, "instead")
+	assert.NotContains(t, out, "falling back to embedded defaults", "a real file loaded - defaults are not what's active")
+
+	assert.Contains(t, out, "level=INFO")
+	assert.Equal(t, filepath.Join(configDir, "models.yaml"), ConfigSource())
 }
 
 func TestLoadModelConfig(t *testing.T) {

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -209,6 +209,30 @@ func mustAbs(t *testing.T, path string) string {
 	return abs
 }
 
+// TestLoadConfigFromFile_UnreadableCandidateRecordsWarning covers a candidate
+// path that exists but can't be read as a file - here, a directory named
+// models.yaml. That's not fs.ErrNotExist, so it must be recorded as a
+// warning rather than silently skipped like a genuinely absent candidate.
+// The exact OS error text isn't asserted since it differs by platform.
+func TestLoadConfigFromFile_UnreadableCandidateRecordsWarning(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "models.yaml"), 0755))
+
+	t.Chdir(dir)
+	t.Setenv("OLLA_CONFIG_DIR", "")
+
+	config, source, warnings := loadConfigFromFile()
+
+	require.NotNil(t, config, "must fall back to a usable config, never crash")
+	assert.Equal(t, getDefaultConfig(), config)
+	assert.Empty(t, source)
+
+	require.Len(t, warnings, 1, "a directory named models.yaml is not fs.ErrNotExist and must be recorded")
+	assert.Contains(t, warnings[0], "models.yaml")
+
+	require.NoError(t, config.compilePatterns())
+}
+
 // TestLoadModelConfig_InvalidRegexPatternFallsBackToCompiledDefaults covers a
 // candidate that parses as valid YAML but contains a pattern that isn't a
 // valid regex. Before this fix, LoadModelConfig would hand back the broken

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -113,11 +113,12 @@ func TestLoadConfigFromFile_BrokenYAMLFallsBackWithWarning(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(brokenModelsYAML), 0644))
 
 	// t.Chdir makes the loader's first candidate path ("models.yaml") resolve
-	// into dir; OLLA_CONFIG_DIR is pointed at a second, empty temp dir so the
-	// env-derived candidate doesn't re-read the same file and double the
-	// warning count.
+	// into dir. OLLA_CONFIG_DIR is explicitly unset: filepath.Join("", "models.yaml")
+	// collapses to "models.yaml", which is the same candidate as above - if the
+	// loader didn't skip the env candidate when unset, this would read the same
+	// broken file twice and double the warning count.
 	t.Chdir(dir)
-	t.Setenv("OLLA_CONFIG_DIR", t.TempDir())
+	t.Setenv("OLLA_CONFIG_DIR", "")
 
 	config, source, warnings := loadConfigFromFile()
 
@@ -125,12 +126,49 @@ func TestLoadConfigFromFile_BrokenYAMLFallsBackWithWarning(t *testing.T) {
 	assert.Equal(t, getDefaultConfig(), config, "must fall back to embedded defaults")
 	assert.Empty(t, source, "no path should be reported as successfully loaded")
 
-	require.Len(t, warnings, 1, "expected exactly one parse warning for the broken models.yaml")
+	require.Len(t, warnings, 1, "expected exactly one parse warning for the broken models.yaml, not a duplicate from the OLLA_CONFIG_DIR candidate")
 	assert.Contains(t, warnings[0], "models.yaml")
 	assert.Greater(t, len(warnings[0]), len("models.yaml"), "warning should carry the underlying parse error, not just the path")
 
 	// the fallback config must itself still be usable - no panics downstream
 	require.NoError(t, config.compilePatterns())
+}
+
+// TestLoadConfigFromFile_EmptyFileFallsBackWithWarning covers the other
+// silent-failure shape: an empty (or comment-only) models.yaml is valid YAML
+// and unmarshals without error, so without the isEffectivelyEmpty guard it
+// would be treated as a successful load - configSource set, INFO logged -
+// while every family pattern, mapping and rule is missing.
+func TestLoadConfigFromFile_EmptyFileFallsBackWithWarning(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"zero_byte_file", ""},
+		{"comment_only_file", "# nothing to see here\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(tt.content), 0644))
+
+			t.Chdir(dir)
+			t.Setenv("OLLA_CONFIG_DIR", "")
+
+			config, source, warnings := loadConfigFromFile()
+
+			require.NotNil(t, config, "must fall back to a usable config, never nil")
+			assert.Equal(t, getDefaultConfig(), config, "must fall back to embedded defaults")
+			assert.Empty(t, source, "no path should be reported as successfully loaded")
+
+			require.Len(t, warnings, 1, "expected exactly one warning for the empty models.yaml")
+			assert.Contains(t, warnings[0], "models.yaml")
+			assert.Contains(t, warnings[0], "no configuration")
+
+			require.NoError(t, config.compilePatterns())
+		})
+	}
 }
 
 // TestLogConfigStatus_WarnsOnBrokenShippedFile is the LogConfigStatus

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -171,6 +171,43 @@ func TestLoadConfigFromFile_EmptyFileFallsBackWithWarning(t *testing.T) {
 	}
 }
 
+// TestLoadConfigFromFile_PartialFileWithOnlyFamilyAliasesLoads guards against
+// a regression in isEffectivelyEmpty: a file that only sets one section (here
+// family_aliases) is a legitimate partial override, not an empty file, and
+// must load successfully - no warning, configSource pointing at it, and the
+// aliases present in the returned config.
+func TestLoadConfigFromFile_PartialFileWithOnlyFamilyAliasesLoads(t *testing.T) {
+	dir := t.TempDir()
+	partialYAML := `
+model_extraction:
+  family_aliases:
+    llama3: llama
+    devstral: mistral
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(partialYAML), 0644))
+
+	t.Chdir(dir)
+	t.Setenv("OLLA_CONFIG_DIR", "")
+
+	config, source, warnings := loadConfigFromFile()
+
+	require.NotNil(t, config)
+	assert.Equal(t, filepath.Join(dir, "models.yaml"), mustAbs(t, source), "partial file with only family_aliases must be treated as usable, not empty")
+	assert.Empty(t, warnings)
+
+	assert.Equal(t, "llama", config.ModelExtraction.FamilyAliases["llama3"])
+	assert.Equal(t, "mistral", config.ModelExtraction.FamilyAliases["devstral"])
+}
+
+// mustAbs resolves path against the current (t.Chdir'd) working directory so
+// it can be compared against a path built from t.TempDir() (already absolute).
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+	return abs
+}
+
 // TestLogConfigStatus_WarnsOnBrokenShippedFile is the LogConfigStatus
 // counterpart: a models.yaml that exists but fails to parse must produce a
 // warning-level log line naming the file, not the same silence as the

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -74,18 +74,19 @@ func resetConfigSingleton() {
 // the real path when config/models.yaml loads cleanly, giving operators a
 // startup-log trail rather than the previous total silence.
 func TestLogConfigStatus_ReportsShippedFileSource(t *testing.T) {
-	oldConfigDir := os.Getenv("OLLA_CONFIG_DIR")
 	dir := filepath.Dir(shippedConfigPath)
-	require.NoError(t, os.Setenv("OLLA_CONFIG_DIR", dir))
-	defer os.Setenv("OLLA_CONFIG_DIR", oldConfigDir)
+	t.Setenv("OLLA_CONFIG_DIR", dir)
 
 	resetConfigSingleton()
 	t.Cleanup(resetConfigSingleton)
 
-	log, _, _ := logger.New(&logger.Config{Level: "debug", Theme: "default"})
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	LogConfigStatus(logger.NewPlainStyledLogger(log))
 
 	assert.Equal(t, filepath.Join(dir, "models.yaml"), ConfigSource())
+	assert.Contains(t, buf.String(), "level=INFO")
+	assert.Contains(t, buf.String(), "model unification config loaded")
 }
 
 // brokenModelsYAML reproduces the exact issue #204 construct: a `\d` inside
@@ -126,7 +127,7 @@ func TestLoadConfigFromFile_BrokenYAMLFallsBackWithWarning(t *testing.T) {
 
 	require.Len(t, warnings, 1, "expected exactly one parse warning for the broken models.yaml")
 	assert.Contains(t, warnings[0], "models.yaml")
-	assert.Contains(t, warnings[0], "unknown escape character")
+	assert.Greater(t, len(warnings[0]), len("models.yaml"), "warning should carry the underlying parse error, not just the path")
 
 	// the fallback config must itself still be usable - no panics downstream
 	require.NoError(t, config.compilePatterns())
@@ -201,13 +202,13 @@ capabilities:
 	require.NoError(t, err)
 
 	// Set environment variable to point to our test config
-	oldConfigDir := os.Getenv("OLLA_CONFIG_DIR")
-	os.Setenv("OLLA_CONFIG_DIR", tmpDir)
-	defer os.Setenv("OLLA_CONFIG_DIR", oldConfigDir)
+	t.Setenv("OLLA_CONFIG_DIR", tmpDir)
 
-	// Clear the config cache to force reload
-	configOnce = sync.Once{}
-	configInstance = nil
+	// Clear the config cache to force reload, and restore it afterwards -
+	// otherwise configSource is left pointing at this test's (now-deleted)
+	// tmpDir for whatever test runs next.
+	resetConfigSingleton()
+	t.Cleanup(resetConfigSingleton)
 
 	// Load config
 	config, err := LoadModelConfig()

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -1,6 +1,8 @@
 package unifier
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -58,6 +60,16 @@ func TestShippedConfigMatchesDefaults(t *testing.T) {
 	assert.ElementsMatch(t, defaults.SpecialRules.GenericNames, fromFile.SpecialRules.GenericNames, "generic_names drifted")
 }
 
+// resetConfigSingleton clears the LoadModelConfig sync.Once cache so a test
+// can force a fresh load. Registered via t.Cleanup by every test that
+// touches the singleton, so a broken/mutated state from one test can't leak
+// into the next (LoadModelConfig's whole point is process-lifetime caching,
+// which fights individual test isolation otherwise).
+func resetConfigSingleton() {
+	configOnce = sync.Once{}
+	configInstance, errConfig, configSource, configParseWarnings = nil, nil, "", nil
+}
+
 // TestLogConfigStatus_ReportsShippedFileSource verifies LogConfigStatus surfaces
 // the real path when config/models.yaml loads cleanly, giving operators a
 // startup-log trail rather than the previous total silence.
@@ -67,13 +79,81 @@ func TestLogConfigStatus_ReportsShippedFileSource(t *testing.T) {
 	require.NoError(t, os.Setenv("OLLA_CONFIG_DIR", dir))
 	defer os.Setenv("OLLA_CONFIG_DIR", oldConfigDir)
 
-	configOnce = sync.Once{}
-	configInstance, errConfig, configSource, configParseWarnings = nil, nil, "", nil
+	resetConfigSingleton()
+	t.Cleanup(resetConfigSingleton)
 
 	log, _, _ := logger.New(&logger.Config{Level: "debug", Theme: "default"})
 	LogConfigStatus(logger.NewPlainStyledLogger(log))
 
 	assert.Equal(t, filepath.Join(dir, "models.yaml"), ConfigSource())
+}
+
+// brokenModelsYAML reproduces the exact issue #204 construct: a `\d` inside
+// a double-quoted YAML scalar. yaml.v3's double-quoted scalars only accept a
+// small fixed escape set, so this is invalid YAML, not just an unwanted regex.
+const brokenModelsYAML = `
+model_extraction:
+  family_patterns:
+    - pattern: "^(llama|gemma|phi|qwen)[-_]?(\d+(?:\.\d+)?)"
+      family_group: 1
+      variant_group: 2
+      description: "broken escape, matches issue #204"
+`
+
+// TestLoadConfigFromFile_BrokenYAMLFallsBackWithWarning is the failure-path
+// counterpart to TestShippedConfigParses. loadConfigFromFile() is called
+// directly (bypassing the LoadModelConfig sync.Once singleton) so the
+// behaviour under test is the loader itself, not caching. A directory whose
+// models.yaml has the issue #204 escape bug must still yield a usable
+// config - falling back to getDefaultConfig() without panicking - while
+// recording a parse warning that names the broken path.
+func TestLoadConfigFromFile_BrokenYAMLFallsBackWithWarning(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(brokenModelsYAML), 0644))
+
+	// t.Chdir makes the loader's first candidate path ("models.yaml") resolve
+	// into dir; OLLA_CONFIG_DIR is pointed at a second, empty temp dir so the
+	// env-derived candidate doesn't re-read the same file and double the
+	// warning count.
+	t.Chdir(dir)
+	t.Setenv("OLLA_CONFIG_DIR", t.TempDir())
+
+	config, source, warnings := loadConfigFromFile()
+
+	require.NotNil(t, config, "must fall back to a usable config, never nil")
+	assert.Equal(t, getDefaultConfig(), config, "must fall back to embedded defaults")
+	assert.Empty(t, source, "no path should be reported as successfully loaded")
+
+	require.Len(t, warnings, 1, "expected exactly one parse warning for the broken models.yaml")
+	assert.Contains(t, warnings[0], "models.yaml")
+	assert.Contains(t, warnings[0], "unknown escape character")
+
+	// the fallback config must itself still be usable - no panics downstream
+	require.NoError(t, config.compilePatterns())
+}
+
+// TestLogConfigStatus_WarnsOnBrokenShippedFile is the LogConfigStatus
+// counterpart: a models.yaml that exists but fails to parse must produce a
+// warning-level log line naming the file, not the same silence as the
+// "no file found" case.
+func TestLogConfigStatus_WarnsOnBrokenShippedFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(brokenModelsYAML), 0644))
+
+	t.Chdir(dir)
+	t.Setenv("OLLA_CONFIG_DIR", t.TempDir())
+
+	resetConfigSingleton()
+	t.Cleanup(resetConfigSingleton)
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	LogConfigStatus(logger.NewPlainStyledLogger(log))
+
+	out := buf.String()
+	assert.Contains(t, out, "level=WARN")
+	assert.Contains(t, out, "could not parse")
+	assert.Contains(t, out, "models.yaml")
 }
 
 func TestLoadModelConfig(t *testing.T) {

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -8,7 +8,73 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/thushan/olla/internal/logger"
 )
+
+// shippedConfigPath is config/models.yaml, relative to this package
+// (internal/adapter/unifier -> repo root is three levels up).
+const shippedConfigPath = "../../../config/models.yaml"
+
+// TestShippedConfigParses guards against issue #204: yaml.v3's double-quoted
+// scalars only accept a small fixed escape set, so a stray `\d` inside "..."
+// breaks the shipped file. loadConfigFromFile() swallows unmarshal errors and
+// silently falls back to embedded defaults, so a broken file was never caught
+// until now - this test fails loudly instead.
+func TestShippedConfigParses(t *testing.T) {
+	data, err := os.ReadFile(shippedConfigPath)
+	require.NoError(t, err, "config/models.yaml must exist")
+
+	var fromFile ModelUnificationConfig
+	require.NoError(t, yaml.Unmarshal(data, &fromFile), "config/models.yaml must be valid YAML")
+	require.NoError(t, fromFile.compilePatterns(), "config/models.yaml patterns must compile")
+}
+
+// TestShippedConfigMatchesDefaults is an equivalence guard between
+// config/models.yaml and getDefaultConfig(). Because loadConfigFromFile()
+// silently fell back to defaults on any parse error, the shipped file and
+// the embedded fallback drifted apart for years without anyone noticing
+// (issue #204). If this fails, reconcile the drift in both directions -
+// don't just update one side to make the test pass.
+func TestShippedConfigMatchesDefaults(t *testing.T) {
+	data, err := os.ReadFile(shippedConfigPath)
+	require.NoError(t, err)
+
+	var fromFile ModelUnificationConfig
+	require.NoError(t, yaml.Unmarshal(data, &fromFile))
+
+	defaults := getDefaultConfig()
+
+	assert.Equal(t, defaults.ModelExtraction.FamilyPatterns, fromFile.ModelExtraction.FamilyPatterns, "family_patterns drifted")
+	assert.Equal(t, defaults.ModelExtraction.ArchitectureMappings, fromFile.ModelExtraction.ArchitectureMappings, "architecture_mappings drifted")
+	assert.Equal(t, defaults.ModelExtraction.FamilyAliases, fromFile.ModelExtraction.FamilyAliases, "family_aliases drifted")
+	assert.Equal(t, defaults.ModelExtraction.PublisherMappings, fromFile.ModelExtraction.PublisherMappings, "publisher_mappings drifted")
+	assert.Equal(t, defaults.Quantization.Mappings, fromFile.Quantization.Mappings, "quantization mappings drifted")
+	assert.Equal(t, defaults.Capabilities.TypeCapabilities, fromFile.Capabilities.TypeCapabilities, "type_capabilities drifted")
+	assert.Equal(t, defaults.Capabilities.NamePatterns, fromFile.Capabilities.NamePatterns, "capability name_patterns drifted")
+	assert.Equal(t, defaults.Capabilities.ContextThresholds, fromFile.Capabilities.ContextThresholds, "context_thresholds drifted")
+	assert.ElementsMatch(t, defaults.SpecialRules.PreserveFamily, fromFile.SpecialRules.PreserveFamily, "preserve_family drifted")
+	assert.ElementsMatch(t, defaults.SpecialRules.GenericNames, fromFile.SpecialRules.GenericNames, "generic_names drifted")
+}
+
+// TestLogConfigStatus_ReportsShippedFileSource verifies LogConfigStatus surfaces
+// the real path when config/models.yaml loads cleanly, giving operators a
+// startup-log trail rather than the previous total silence.
+func TestLogConfigStatus_ReportsShippedFileSource(t *testing.T) {
+	oldConfigDir := os.Getenv("OLLA_CONFIG_DIR")
+	dir := filepath.Dir(shippedConfigPath)
+	require.NoError(t, os.Setenv("OLLA_CONFIG_DIR", dir))
+	defer os.Setenv("OLLA_CONFIG_DIR", oldConfigDir)
+
+	configOnce = sync.Once{}
+	configInstance, errConfig, configSource, configParseWarnings = nil, nil, "", nil
+
+	log, _, _ := logger.New(&logger.Config{Level: "debug", Theme: "default"})
+	LogConfigStatus(logger.NewPlainStyledLogger(log))
+
+	assert.Equal(t, filepath.Join(dir, "models.yaml"), ConfigSource())
+}
 
 func TestLoadModelConfig(t *testing.T) {
 	// Test loading default config when file doesn't exist

--- a/internal/adapter/unifier/model_config_test.go
+++ b/internal/adapter/unifier/model_config_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -206,6 +207,58 @@ func mustAbs(t *testing.T, path string) string {
 	abs, err := filepath.Abs(path)
 	require.NoError(t, err)
 	return abs
+}
+
+// TestLoadModelConfig_InvalidRegexPatternFallsBackToCompiledDefaults covers a
+// candidate that parses as valid YAML but contains a pattern that isn't a
+// valid regex. Before this fix, LoadModelConfig would hand back the broken
+// (uncompiled) config with errConfig set, and getConfig() in
+// metadata_extractor.go would swap to getDefaultConfig() - which was never
+// compiled either, so every regex-driven lookup silently no-opped. The fix
+// must produce a *compiled*, *functional* fallback.
+func TestLoadModelConfig_InvalidRegexPatternFallsBackToCompiledDefaults(t *testing.T) {
+	dir := t.TempDir()
+	badRegexYAML := `
+model_extraction:
+  family_patterns:
+    - pattern: '(['
+      family_group: 1
+      variant_group: 2
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(badRegexYAML), 0644))
+
+	t.Chdir(dir)
+	t.Setenv("OLLA_CONFIG_DIR", "")
+
+	resetConfigSingleton()
+	t.Cleanup(resetConfigSingleton)
+
+	config, err := LoadModelConfig()
+	require.NoError(t, err, "must recover onto the embedded defaults, not surface the bad-regex error")
+	require.NotNil(t, config)
+
+	assert.Empty(t, ConfigSource(), "defaults are in use, not the broken candidate")
+
+	requireWarningNaming(t, configParseWarnings, "models.yaml")
+
+	// functional, not just present: a default pattern must be compiled and
+	// actually match, proving the fallback config went through compilePatterns.
+	require.Len(t, config.ModelExtraction.FamilyPatterns, 6)
+	llamaPattern := config.ModelExtraction.FamilyPatterns[1]
+	require.NotNil(t, llamaPattern.regex, "fallback defaults must be compiled, not just assigned")
+	assert.True(t, llamaPattern.regex.MatchString("llama-3"), "compiled default pattern should match a real model name")
+}
+
+// requireWarningNaming fails the test unless one of the warnings mentions
+// substr (typically a candidate path).
+func requireWarningNaming(t *testing.T, warnings []string, substr string) {
+	t.Helper()
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return
+		}
+	}
+	t.Fatalf("expected a warning naming %q, got %v", substr, warnings)
 }
 
 // TestLogConfigStatus_WarnsOnBrokenShippedFile is the LogConfigStatus


### PR DESCRIPTION
The shipped `config/models.yaml` used `\d` inside double-quoted YAML scalars, which is not
a vaalid YAML escape, so the file has never parsed on any install. `loadConfigFromFile()`
swallowed the error and silently fell back to embedded defaults, meaning user customisations
(e.g. capability tagging via `name_patterns`) were discarded with no diagnostic.

### Changes

- **Parse fix**: the three regex patterns containing `\d` are now single-quoted scalars.
- **INFO diagnostics at startup**: config loading is now eager (triggered from
  `unifier.NewFactory()` at boot, not lazily on first request). Olla logs the loaded source
  at `INFO`, and a found-but-unparseable candidate at `WARN` with the path and YAML error -
  including when a later candidate path loads successfully (a broken `./models.yaml` shadowed
  by a valid `config/models.yaml` warns about both).
- **Empty-config guard**: a zero-byte or comment-only `models.yaml` parses "successfully" as
  a config with no rules; it now warns and falls through to the next candidate instead.
- **Candidate dedupe**: with `OLLA_CONFIG_DIR` unset, the env candidate collapsed to a
  duplicate of `./models.yaml`, doubling warnings; the candidate is now only added when the
  env var is set, and the list is deduped.
- **Defaults reconciled**: because the file never loaded, it had drifted from
  `getDefaultConfig()`. Both sides are now identical, guarded by an equivalence test so they
  cannot drift silently again.

### Behaviour changes

- `config/models.yaml` (and user copies of it) now actually take effect.
- New startup log lines: `INFO model unification config loaded source=...` or a `WARN` on
  parse failure.
- Newly effective default mappings that previously only existed in the (never-loaded) file
  or only in code: `Q4_K_XL → q4kxl`, `llama4` architecture mapping, and publisher mappings
  for falcon, vicuna, bloom, opt, gpt2, gptj and gptneox. Unified model IDs are unaffected -
  these change metadata in `/olla/models` only.

### Tests

- Regression: the shipped `config/models.yaml` must unmarshal into the real struct and every
  regex must compile.
- Equivalence guard: shipped file and embedded defaults compared field by field.
- Failure paths: broken file (original `\d` construct), empty file, comment-only file - each
  asserts the warning and clean fallback with no panic.
- Fixed a pre-existing test-order flake (`go test -shuffle`) caused by singleton pollution.

### Not in this PR

Will be subsequent PRs.

- `--validate-config` CLI switch / config hashing.
- `profile.LoadProfiles()` has the same silent-swallow pattern for broken profile YAMLs.
- Exposing the active config source via `/internal/status`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded model recognition with additional family aliases, publisher mappings and `llama4` architecture support.
  - Added support for the `Q4_K_XL` quantisation format.
  - Configuration status and source information are now reported at startup.

- **Bug Fixes**
  - Improved configuration loading when files are empty, invalid or unavailable.
  - The system now continues using valid fallback settings and provides warnings when configuration issues occur.

- **Tests**
  - Added coverage for configuration parsing, fallback behaviour and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->