### PR TITLE
feat: wire family aliases

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -353,7 +353,14 @@ special_rules:
   preserve_family:
     - nomic-bert
     - deepseek-coder-v2
-    
+    # Kimi-K2 GGUF files often report general.architecture "deepseek2" or
+    # "deepseek" (Kimi-K2 and DeepSeek-V3 share the same underlying
+    # transformer architecture). Architecture-based lookup runs before
+    # name-pattern matching, so without this the arch string would win and
+    # misclassify a Kimi model as deepseek. Preserving "kimi" makes the name
+    # win instead, whenever the name itself says kimi.
+    - kimi
+
   # Generic names that need architecture info
   generic_names:
     - model

--- a/internal/adapter/unifier/metadata_extractor.go
+++ b/internal/adapter/unifier/metadata_extractor.go
@@ -182,6 +182,12 @@ func extractFamilyAndVariant(modelName string, arch string) (family, variant str
 	modelName = strings.TrimSpace(strings.ToLower(modelName))
 	config := getConfig()
 
+	// Preserved families (e.g. deepseek-coder-v2) must win outright, ahead of
+	// the deepseek pattern that would otherwise split them into a variant.
+	if preserved := matchPreserveFamily(modelName, arch, config); preserved != "" {
+		return preserved, ""
+	}
+
 	// Try architecture-based extraction first
 	if arch != "" {
 		family, variant = extractFromArchitecture(arch, modelName, config)
@@ -197,8 +203,49 @@ func extractFamilyAndVariant(modelName string, arch string) (family, variant str
 	}
 
 	// Fallback to delimiter-based extraction
-	family = extractFromDelimiters(modelName)
+	family = extractFromDelimiters(modelName, config)
 	return family, variant
+}
+
+// matchPreserveFamily checks whether modelName or arch matches a configured
+// preserve_family entry, using exact or token-prefix matching (never a bare
+// substring contains) so that e.g. "deepseek-coder-v2" preserves whole while
+// "deepseek-coder" still falls through to the deepseek pattern below.
+func matchPreserveFamily(modelName, arch string, config *ModelUnificationConfig) string {
+	archLower := strings.ToLower(strings.TrimSpace(arch))
+
+	for _, entry := range config.SpecialRules.PreserveFamily {
+		entryLower := strings.ToLower(entry)
+
+		if archLower == entryLower {
+			return entry
+		}
+		if matchesTokenPrefix(modelName, entryLower) {
+			return entry
+		}
+	}
+
+	return ""
+}
+
+// matchesTokenPrefix reports whether name is exactly entry, or starts with
+// entry followed by a delimiter boundary. This stops "nomic-bert" matching
+// "nomic-bertson" while still matching "nomic-bert-v1.5".
+func matchesTokenPrefix(name, entry string) bool {
+	if name == entry {
+		return true
+	}
+	if !strings.HasPrefix(name, entry) {
+		return false
+	}
+
+	next := name[len(entry)]
+	switch next {
+	case '-', '_', ':', '/', '.':
+		return true
+	default:
+		return false
+	}
 }
 
 // extractFromArchitecture extracts family and variant from architecture info
@@ -206,7 +253,12 @@ func extractFromArchitecture(arch, modelName string, config *ModelUnificationCon
 	archLower := strings.ToLower(arch)
 	mappedFamily, exists := config.ModelExtraction.ArchitectureMappings[archLower]
 	if !exists {
-		return "", ""
+		// Some backends (e.g. Ollama reporting "deepseek2") surface an
+		// architecture string that's an alias rather than a canonical family.
+		mappedFamily, exists = config.ModelExtraction.FamilyAliases[archLower]
+		if !exists {
+			return "", ""
+		}
 	}
 
 	family = mappedFamily
@@ -256,21 +308,35 @@ func extractFromPatterns(modelName string, config *ModelUnificationConfig) (fami
 	return "", ""
 }
 
-// extractFromDelimiters extracts family from first part of delimited name
-func extractFromDelimiters(modelName string) string {
+// knownDelimiterFamilies is the fallback set of bare family names recognised
+// when config doesn't supply an alias for the leading token - kept in sync
+// with the historical hardcoded list so existing behaviour is unaffected.
+var knownDelimiterFamilies = []string{
+	"llama", "gemma", "phi", "qwen", "mistral", "mixtral",
+	"yi", "deepseek", "codellama", "starcoder", "vicuna",
+	"falcon", "gpt2", "gptj", "gptneox", "bloom", "opt", "mpt",
+}
+
+// extractFromDelimiters extracts family from first part of delimited name.
+// Config-driven FamilyAliases are checked first (e.g. "devstral" -> "mistral"),
+// falling back to the known bare family names mapping to themselves.
+func extractFromDelimiters(modelName string, config *ModelUnificationConfig) string {
 	parts := regexp.MustCompile(`[-_:/]`).Split(modelName, -1)
 	if len(parts) == 0 {
 		return ""
 	}
 
 	firstPart := strings.ToLower(parts[0])
-	knownFamilies := []string{
-		"llama", "gemma", "phi", "qwen", "mistral", "mixtral",
-		"yi", "deepseek", "codellama", "starcoder", "vicuna",
-		"falcon", "gpt2", "gptj", "gptneox", "bloom", "opt", "mpt",
+
+	if config != nil {
+		for alias, mapped := range config.ModelExtraction.FamilyAliases {
+			if strings.HasPrefix(firstPart, alias) {
+				return mapped
+			}
+		}
 	}
 
-	for _, known := range knownFamilies {
+	for _, known := range knownDelimiterFamilies {
 		if strings.HasPrefix(firstPart, known) {
 			return known
 		}

--- a/internal/adapter/unifier/metadata_extractor.go
+++ b/internal/adapter/unifier/metadata_extractor.go
@@ -214,13 +214,23 @@ func extractFamilyAndVariant(modelName string, arch string) (family, variant str
 func matchPreserveFamily(modelName, arch string, config *ModelUnificationConfig) string {
 	archLower := strings.ToLower(strings.TrimSpace(arch))
 
+	// Publisher-prefixed names (e.g. "moonshotai/kimi-k2-instruct" from
+	// LM Studio/vLLM backends) must match on the model's own name, not the
+	// publisher segment - strip everything up to and including the last '/'
+	// before applying the token-prefix check. The arch check above stays on
+	// the raw arch string, which is never publisher-prefixed.
+	nameForMatch := modelName
+	if idx := strings.LastIndex(nameForMatch, "/"); idx != -1 {
+		nameForMatch = nameForMatch[idx+1:]
+	}
+
 	for _, entry := range config.SpecialRules.PreserveFamily {
 		entryLower := strings.ToLower(entry)
 
 		if archLower == entryLower {
 			return entry
 		}
-		if matchesTokenPrefix(modelName, entryLower) {
+		if matchesTokenPrefix(nameForMatch, entryLower) {
 			return entry
 		}
 	}

--- a/internal/adapter/unifier/metadata_extractor_test.go
+++ b/internal/adapter/unifier/metadata_extractor_test.go
@@ -323,6 +323,20 @@ func TestExtractFamilyAndVariant(t *testing.T) {
 		{"kimi model with deepseek arch (fixed via preserve_family)", "kimi-k2-instruct", "deepseek", "kimi", ""},
 		{"kimi model with deepseek2 arch (fixed via preserve_family)", "kimi-k2", "deepseek2", "kimi", ""},
 
+		// Publisher-prefixed names (LM Studio/vLLM commonly report these)
+		// used to skip matchPreserveFamily entirely because the token-prefix
+		// check ran against the whole "publisher/model" string, so the arch
+		// stage won regardless of preserve_family. Fixed by stripping up to
+		// the last '/' before the check.
+		{"publisher-prefixed kimi with deepseek arch", "moonshotai/Kimi-K2-Instruct", "deepseek", "kimi", ""},
+		{"publisher-prefixed kimi with deepseek2 arch", "moonshotai/Kimi-K2-Instruct", "deepseek2", "kimi", ""},
+		{"publisher-prefixed deepseek-coder-v2 preserved", "deepseek-ai/DeepSeek-Coder-V2-Instruct", "", "deepseek-coder-v2", ""},
+
+		// A publisher segment that happens to share a preserve entry's name
+		// must not fool the check - the stripped, matched part is the model
+		// name after the last '/', not the publisher.
+		{"publisher segment matching a preserve entry must not match", "kimi/llama-3-8b", "", "llama", "3"},
+
 		// FamilyAliases delimiter-fallback for name-based extraction is covered
 		// separately in TestExtractFromDelimiters_UsesConfiguredAliases: the
 		// 2026 refresh (main) gave devstral its own family_pattern, so
@@ -377,6 +391,12 @@ func TestMatchPreserveFamily_KimiTokenPrefixSemantics(t *testing.T) {
 		{"arch exact match", "unrelated-name", "kimi", "kimi"},
 		{"unrelated name sharing a prefix must not match", "kimichef-70b", "", ""},
 		{"arch that merely contains kimi as a substring must not match", "unrelated", "not-kimi-arch", ""},
+
+		// Publisher-prefixed names strip everything up to and including the
+		// last '/' before the token-prefix check runs.
+		{"publisher-prefixed name matches on the model part", "moonshotai/kimi-k2-instruct", "", "kimi"},
+		{"publisher-prefixed name with deepseek arch still matches on name", "moonshotai/kimi-k2-instruct", "deepseek", "kimi"},
+		{"publisher segment sharing the entry name must not match", "kimi/llama-3-8b", "", ""},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/unifier/metadata_extractor_test.go
+++ b/internal/adapter/unifier/metadata_extractor_test.go
@@ -319,6 +319,25 @@ func TestExtractFamilyAndVariant(t *testing.T) {
 		// ArchitectureMappings is a flat 1:1 table, so this ambiguity is
 		// unavoidable without a redesign - out of scope for this pass.
 		{"kimi model with deepseek arch (known collision)", "kimi-k2-instruct", "deepseek", "deepseek", ""},
+
+		// FamilyAliases delimiter-fallback for name-based extraction is covered
+		// separately in TestExtractFromDelimiters_UsesConfiguredAliases: the
+		// 2026 refresh (main) gave devstral its own family_pattern, so
+		// "devstral-24b" now resolves at the pattern stage as family
+		// "devstral" (see devstral-small-2505 above) and never reaches the
+		// delimiter fallback this alias mechanism exists for.
+
+		// FamilyAliases: architecture fallback for arch strings not in ArchitectureMappings
+		{"arch alias deepseek2", "model", "deepseek2", "deepseek", "2"},
+
+		// PreserveFamily: wins outright, ahead of the deepseek pattern
+		{"deepseek-coder-v2 preserved", "deepseek-coder-v2", "", "deepseek-coder-v2", ""},
+		{"deepseek-coder-v2 with suffix preserved", "deepseek-coder-v2-lite", "", "deepseek-coder-v2", ""},
+		{"nomic-bert preserved", "nomic-bert", "", "nomic-bert", ""},
+		{"nomic-bert with suffix preserved", "nomic-bert-v1.5", "", "nomic-bert", ""},
+
+		// PreserveFamily must NOT affect deepseek-coder (no -v2 suffix)
+		{"deepseek-coder still splits", "deepseek-coder", "", "deepseek", "coder"},
 	}
 
 	for _, tt := range tests {
@@ -328,6 +347,32 @@ func TestExtractFamilyAndVariant(t *testing.T) {
 			assert.Equal(t, tt.expectedVariant, variant, "Variant mismatch")
 		})
 	}
+}
+
+// TestExtractFromDelimiters_UsesConfiguredAliases exercises the FamilyAliases
+// delimiter fallback directly, with a synthetic config, rather than through
+// the full extractFamilyAndVariant path against production config. Every
+// alias in the shipped config now also has its own family_pattern (that's
+// how the 2026 model families were added), so any real model name that
+// starts with an alias key gets resolved at the pattern stage first and
+// never reaches this fallback - a synthetic config keeps the fallback itself
+// under test regardless of how the shipped patterns evolve.
+func TestExtractFromDelimiters_UsesConfiguredAliases(t *testing.T) {
+	config := &ModelUnificationConfig{}
+	config.ModelExtraction.FamilyAliases = map[string]string{
+		"widgetcoder": "widget",
+	}
+
+	family := extractFromDelimiters("widgetcoder-24b", config)
+	assert.Equal(t, "widget", family)
+}
+
+// TestExtractFromDelimiters_NilConfigFallsBackToKnownFamilies confirms the
+// nil-config guard added when this became config-driven: a nil config must
+// not panic, and the hardcoded knownDelimiterFamilies list still resolves.
+func TestExtractFromDelimiters_NilConfigFallsBackToKnownFamilies(t *testing.T) {
+	family := extractFromDelimiters("llama-3.2-1b", nil)
+	assert.Equal(t, "llama", family)
 }
 
 func TestExtractPublisher(t *testing.T) {

--- a/internal/adapter/unifier/metadata_extractor_test.go
+++ b/internal/adapter/unifier/metadata_extractor_test.go
@@ -277,7 +277,11 @@ func TestExtractFamilyAndVariant(t *testing.T) {
 		{"gemma4:12b", "gemma4:12b", "", "gemma", "4"}, // already worked pre-change; regression proof
 		{"glm-4.5-air", "glm-4.5-air", "", "glm", "4.5"},
 		{"gpt-oss:20b", "gpt-oss:20b", "", "gpt-oss", "20b"},
-		{"kimi-k2", "kimi-k2", "", "kimi", "k2"},
+		// "kimi" is in preserve_family (fixes the deepseek arch collision
+		// below), so matchPreserveFamily short-circuits on the name-token
+		// prefix and returns no variant - same trade-off preserve_family
+		// already makes for deepseek-coder-v2 and nomic-bert.
+		{"kimi-k2", "kimi-k2", "", "kimi", ""},
 		{"granite3.3:8b", "granite3.3:8b", "", "granite", "3.3"},
 		{"devstral-small-2505", "devstral-small-2505", "", "devstral", "small-2505"},
 		{"codestral-22b", "codestral-22b", "", "codestral", "22b"},
@@ -309,16 +313,15 @@ func TestExtractFamilyAndVariant(t *testing.T) {
 		{"model with granitemoe arch", "model", "granitemoe", "granite", ""},
 		{"model with qwen3.5 arch", "model", "qwen3.5", "qwen", "3.5"},
 
-		// Known limitation, not a bug to fix here: Kimi-K2 GGUF files often
-		// report general.architecture "deepseek2" (Kimi-K2 and DeepSeek-V3
-		// share the same underlying transformer architecture), so
-		// architecture-based extraction misclassifies a Kimi model as
-		// "deepseek" whenever arch metadata is present - architecture-based
-		// lookup is tried before name-pattern matching in
-		// extractFamilyAndVariant, so it wins over the "kimi" pattern.
-		// ArchitectureMappings is a flat 1:1 table, so this ambiguity is
-		// unavoidable without a redesign - out of scope for this pass.
-		{"kimi model with deepseek arch (known collision)", "kimi-k2-instruct", "deepseek", "deepseek", ""},
+		// Kimi-K2 GGUF files often report general.architecture "deepseek2" or
+		// "deepseek" (Kimi-K2 and DeepSeek-V3 share the same underlying
+		// transformer architecture), which used to misclassify a Kimi model
+		// as "deepseek" since architecture-based lookup ran before
+		// name-pattern matching. Fixed via special_rules.preserve_family:
+		// matchPreserveFamily checks the name-token prefix ahead of the arch
+		// stage, so the name wins whenever it actually says kimi.
+		{"kimi model with deepseek arch (fixed via preserve_family)", "kimi-k2-instruct", "deepseek", "kimi", ""},
+		{"kimi model with deepseek2 arch (fixed via preserve_family)", "kimi-k2", "deepseek2", "kimi", ""},
 
 		// FamilyAliases delimiter-fallback for name-based extraction is covered
 		// separately in TestExtractFromDelimiters_UsesConfiguredAliases: the
@@ -338,6 +341,67 @@ func TestExtractFamilyAndVariant(t *testing.T) {
 
 		// PreserveFamily must NOT affect deepseek-coder (no -v2 suffix)
 		{"deepseek-coder still splits", "deepseek-coder", "", "deepseek", "coder"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			family, variant := extractFamilyAndVariant(tt.modelName, tt.arch)
+			assert.Equal(t, tt.expectedFamily, family, "Family mismatch")
+			assert.Equal(t, tt.expectedVariant, variant, "Variant mismatch")
+		})
+	}
+}
+
+// TestMatchPreserveFamily_KimiTokenPrefixSemantics is a direct, isolated
+// sanity check for the kimi preserve_family fix (issue: PR #207 CodeRabbit
+// finding). matchPreserveFamily uses exact-or-token-prefix matching, not a
+// bare substring contains, so it must not fire for names that merely start
+// with the same letters, or arch strings that merely contain "kimi".
+// Exercised directly against matchPreserveFamily (rather than through
+// extractFamilyAndVariant) because the kimi family_pattern is separately
+// loose enough to match "kimichef" too - testing end-to-end wouldn't isolate
+// which mechanism actually produced the result.
+func TestMatchPreserveFamily_KimiTokenPrefixSemantics(t *testing.T) {
+	config := &ModelUnificationConfig{}
+	config.SpecialRules.PreserveFamily = []string{"kimi"}
+
+	tests := []struct {
+		name      string
+		modelName string
+		arch      string
+		want      string
+	}{
+		{"exact name match", "kimi", "", "kimi"},
+		{"name with hyphen boundary", "kimi-k2-instruct", "", "kimi"},
+		{"name with dot boundary", "kimi.k2", "", "kimi"},
+		{"arch exact match", "unrelated-name", "kimi", "kimi"},
+		{"unrelated name sharing a prefix must not match", "kimichef-70b", "", ""},
+		{"arch that merely contains kimi as a substring must not match", "unrelated", "not-kimi-arch", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchPreserveFamily(tt.modelName, tt.arch, config)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestExtractFamilyAndVariant_PlainDeepseekUnaffectedByKimiPreserve confirms
+// adding "kimi" to preserve_family didn't collaterally change plain
+// deepseek model classification - the two entries are independent.
+func TestExtractFamilyAndVariant_PlainDeepseekUnaffectedByKimiPreserve(t *testing.T) {
+	tests := []struct {
+		name            string
+		modelName       string
+		arch            string
+		expectedFamily  string
+		expectedVariant string
+	}{
+		{"deepseek-v3", "deepseek-v3", "", "deepseek", "v3"},
+		{"deepseek-r1-distill-qwen-7b", "deepseek-r1-distill-qwen-7b", "", "deepseek", "r1-distill-qwen-7b"},
+		{"arch deepseek", "model", "deepseek", "deepseek", ""},
+		{"arch deepseek2 via alias fallback", "model", "deepseek2", "deepseek", "2"},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/unifier/metadata_integration_test.go
+++ b/internal/adapter/unifier/metadata_integration_test.go
@@ -172,6 +172,21 @@ func TestDefaultUnifier_MetadataExtraction(t *testing.T) {
 			},
 		},
 		{
+			name: "PreserveFamily wins over the deepseek pattern",
+			models: []*domain.ModelInfo{
+				{
+					Name: "deepseek-coder-v2:16b",
+					// No Details.Family - forces the extractor to run rather
+					// than short-circuiting on a provider-supplied family.
+				},
+			},
+			endpoint: createTestEndpoint("http://localhost:11434", "Ollama"),
+			expectedModel: func(t *testing.T, model *domain.UnifiedModel) {
+				assert.Equal(t, "deepseek-coder-v2", model.Family)
+				assert.Empty(t, model.Variant)
+			},
+		},
+		{
 			name: "Model with metadata confidence",
 			models: []*domain.ModelInfo{
 				{

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -600,7 +600,12 @@ func getDefaultConfig() *ModelUnificationConfig {
 		"ultra_long_context": 1000000,
 	}
 
-	config.SpecialRules.PreserveFamily = []string{"nomic-bert", "deepseek-coder-v2"}
+	// "kimi" fixes the Kimi-K2/deepseek architecture-string collision: Kimi-K2
+	// GGUF files often report general.architecture "deepseek2" or "deepseek"
+	// (they share the same underlying transformer architecture as DeepSeek-V3),
+	// and architecture-based lookup runs before name-pattern matching, so
+	// without this the arch string wins and misclassifies the model.
+	config.SpecialRules.PreserveFamily = []string{"nomic-bert", "deepseek-coder-v2", "kimi"}
 	config.SpecialRules.GenericNames = []string{"model", "unknown", "test", "temp", "default"}
 
 	return config


### PR DESCRIPTION
Follow-up to #206/#207. The model unification config carried two fields that were parsed but never consumed: `model_extraction.family_aliases` and `special_rules.preserve_family`. This wires both into the family-extraction pipeline, and uses the new mechanism to fix the Kimi-K2 misclassification flagged by review on #207.

### Changes

- **`preserve_family` guard**: runs before all extraction stages with exact-token/prefix matching (never bare substring). Listed models keep their full family name instead of being collapsed by architecture mappings or patterns:
- `deepseek-coder-v2` stays `deepseek-coder-v2` rather than collapsing to `deepseek`
- `nomic-bert` gains a family (previously extracted as `""`)
- **`family_aliases` consumption**, in two places:
- fallback when an architecture string misses `architecture_mappings` (e.g. arch  `deepseek2` reported by some GGUFs)
- the delimiter-based fallback stage, replacing behaviour previously driven by a  hardcoded family list with config-driven lookup (existing families unchanged)
- **Kimi-K2 fix**: `kimi` added to `preserve_family`. Kimi-K2 GGUFs report architecture `deepseek`/`deepseek2` (shared lineage), so arch-based extraction misclassified them; they now resolve to family `kimi` regardless of arch metadata. Chosen over inverting name-vs-arch precedence globally, which would affect every model where the two disagree.

### Scope

Family feeds only the `/olla/models` `family` field and its `?family=` filter. Unified model IDs, sticky-session keys, routing and the status/dashboard grouping (which uses the provider-reported `details.family`) are unaffected.

### Notes

- `kimi-k2` now extracts variant `""` (preserve short-circuits pattern matching) - the same trade-off `deepseek-coder-v2` and `nomic-bert` make.
- `devstral` resolves via its explicit pattern from #207 (family `devstral`), not the `devstral -> mistral` alias; the alias remains reachable only through the arch-miss and delimiter fallbacks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model family detection for Kimi models, preserving correct identification when architecture metadata differs.
  * Improved recognition of DeepSeek models when provider metadata is unavailable.
  * Added more reliable handling of model-name aliases, publisher prefixes and delimiters.
  * Prevented partial name matches from incorrectly changing a model’s family classification.
  * Improved consistency when identifying model families across different naming formats and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->