### PR TITLE
fix: config log level

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -287,6 +287,19 @@ func parseLevel(level string) slog.Level {
 	}
 }
 
+// IsValidLevel reports whether level is a recognised log level string
+// (case-insensitive). Callers that source a level from config or an env var
+// use this to warn and fall back rather than silently defaulting to info,
+// which is what parseLevel does for any unrecognised value.
+func IsValidLevel(level string) bool {
+	switch strings.ToLower(level) {
+	case LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelWarning, LogLevelError:
+		return true
+	default:
+		return false
+	}
+}
+
 // convertToPTermLevel converts slog level to pterm level
 func convertToPTermLevel(level slog.Level) pterm.LogLevel {
 	switch level {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,30 @@
+package logger
+
+import "testing"
+
+func TestIsValidLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		level string
+		want  bool
+	}{
+		{"debug", true},
+		{"info", true},
+		{"warn", true},
+		{"warning", true},
+		{"error", true},
+		{"DEBUG", true},
+		{"Info", true},
+		{"", false},
+		{"trace", false},
+		{"verbose", false},
+		{"fatal", false}, // recognised by the level constants but not a slog handler level
+	}
+
+	for _, tc := range cases {
+		if got := IsValidLevel(tc.level); got != tc.want {
+			t.Errorf("IsValidLevel(%q) = %v, want %v", tc.level, got, tc.want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,7 +49,11 @@ func init() {
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.StringVar(&configFile, "c", "", "Config file path")
 	flag.StringVar(&configFile, "config", "", "Config file path")
-
+}
+func main() {
+	// flag.Parse must run here, not in init(): init() runs under `go test` too,
+	// and parsing the test binary's own flags (-test.*) against our flag set
+	// fails the build. main() only runs for the real binary.
 	flag.Parse()
 
 	if os.Getenv("OLLA_ENABLE_PROFILER") == "true" {
@@ -59,8 +63,7 @@ func init() {
 	if os.Getenv("OLLA_SHOW_VERSION") == "true" {
 		showVersion = true
 	}
-}
-func main() {
+
 	startTime := time.Now()
 	vlog := log.New(log.Writer(), "", 0)
 	profileAddress := "localhost:19841"
@@ -77,14 +80,18 @@ func main() {
 		vlog.Printf(theme.ColourProfiler("Profiling server started at http://%s/debug/pprof/\n"), profileAddress)
 	}
 
-	// Setup logging
+	// Setup logging. This is a bootstrap logger only: OLLA_LOG_LEVEL controls it,
+	// and it exists purely so pre-config messages (version banner, config load
+	// errors) have somewhere to go. Once the config file is loaded below, we
+	// rebuild the logger against logging.level so the file's setting actually
+	// takes effect instead of being silently ignored.
 	lcfg := buildLoggerConfig()
-	logInstance, styledLogger, cleanup, err := logger.NewWithTheme(lcfg)
+	logInstance, styledLogger, loggerCleanup, err := logger.NewWithTheme(lcfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialise logger: %v\n", err)
 		os.Exit(1)
 	}
-	defer cleanup()
+	defer func() { loggerCleanup() }()
 
 	slog.SetDefault(logInstance)
 
@@ -118,6 +125,25 @@ func main() {
 	}
 
 	styledLogger.Info("Loaded configuration", "config", cfg.Filename)
+
+	// Now that the config file (and any OLLA_LOGGING_LEVEL override, applied
+	// inside config.Load) is known, swap the bootstrap logger for one running
+	// at the configured level. Only rebuild when the level actually changes,
+	// so a default-vs-default startup doesn't pay for a second handler/file init.
+	runtimeLevel := resolveRuntimeLogLevel(cfg.Logging.Level, styledLogger.Warn)
+	if runtimeLevel != lcfg.Level {
+		runtimeCfg := *lcfg
+		runtimeCfg.Level = runtimeLevel
+
+		newLogInstance, newStyledLogger, newCleanup, rebuildErr := logger.NewWithTheme(&runtimeCfg)
+		if rebuildErr != nil {
+			styledLogger.Warn("Failed to apply configured logging.level, keeping bootstrap logger", "level", runtimeLevel, "error", rebuildErr)
+		} else {
+			loggerCleanup()
+			logInstance, styledLogger, loggerCleanup = newLogInstance, newStyledLogger, newCleanup
+			slog.SetDefault(logInstance)
+		}
+	}
 
 	// Create and start service manager
 	serviceManager, err := app.CreateAndStartServiceManager(ctx, cfg, styledLogger)
@@ -200,6 +226,21 @@ func reportProcessStats(logger logger.StyledLogger, startTime time.Time) {
 		"uptime", format.Duration(stats.Uptime),
 		"avg_gc_pause", nerdstats.CalculateAverageGCPause(stats),
 	)
+}
+
+// resolveRuntimeLogLevel decides the level for the post-config logger. An
+// empty value (no logging.level in the file) keeps the built-in default.
+// An unrecognised value is a config mistake, not a reason to crash - warn
+// via the bootstrap logger and fall back so startup still succeeds.
+func resolveRuntimeLogLevel(configuredLevel string, warn func(msg string, args ...any)) string {
+	if configuredLevel == "" {
+		return DefaultLoggerLevel
+	}
+	if !logger.IsValidLevel(configuredLevel) {
+		warn("Invalid logging.level in config, falling back to default", "configured", configuredLevel, "default", DefaultLoggerLevel)
+		return DefaultLoggerLevel
+	}
+	return configuredLevel
 }
 
 func buildLoggerConfig() *logger.Config {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestResolveRuntimeLogLevel_UsesConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	warned := false
+	got := resolveRuntimeLogLevel("debug", func(string, ...any) { warned = true })
+
+	if got != "debug" {
+		t.Errorf("expected configured level 'debug', got %q", got)
+	}
+	if warned {
+		t.Error("did not expect a warning for a valid level")
+	}
+}
+
+func TestResolveRuntimeLogLevel_EmptyFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	warned := false
+	got := resolveRuntimeLogLevel("", func(string, ...any) { warned = true })
+
+	if got != DefaultLoggerLevel {
+		t.Errorf("expected default level %q for unset config, got %q", DefaultLoggerLevel, got)
+	}
+	if warned {
+		t.Error("an unset logging.level is not an error, so no warning should fire")
+	}
+}
+
+func TestResolveRuntimeLogLevel_InvalidFallsBackAndWarns(t *testing.T) {
+	t.Parallel()
+
+	var gotMsg string
+	got := resolveRuntimeLogLevel("verbose", func(msg string, args ...any) { gotMsg = msg })
+
+	if got != DefaultLoggerLevel {
+		t.Errorf("expected fallback to default level %q, got %q", DefaultLoggerLevel, got)
+	}
+	if gotMsg == "" {
+		t.Error("expected a warning to be raised for an invalid level")
+	}
+}


### PR DESCRIPTION
wires logging.level from config.yaml to the runtime logger (previously parsed but ignored); precedence is OLLA_LOGGING_LEVEL env > config file > default, invalid values warn and fall back rather than crash; also moves flag.Parse() out of init(), fixing go test on the main package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logging levels can now be configured and applied at runtime.
  * Supported log levels are validated case-insensitively.

* **Bug Fixes**
  * Invalid or empty logging settings now safely fall back to the default level.
  * Test commands no longer process application command-line flags unexpectedly.
  * Logging remains available if applying a configured level fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->