### PR TITLE
feat: config validation hardening

### DIFF
--- a/docs/content/concepts/model-unification.md
+++ b/docs/content/concepts/model-unification.md
@@ -392,6 +392,71 @@ ollama-dev: [llama3.2, experimental-model, test-model]
 ollama-prod: [llama3.2, mistral, codellama]
 ```
 
+## Customising Extraction with models.yaml
+
+Model unification's family/publisher/quantisation/capability extraction is driven by `config/models.yaml`. Olla ships one under `config/models.yaml`; you can override or extend it without rebuilding.
+
+### What it controls
+
+`models.yaml` has four top-level sections (all optional - an omitted section falls back to Olla's built-in defaults):
+
+| Section | Field | Type | Purpose |
+|---|---|---|---|
+| `model_extraction` | `family_patterns` | list of `{pattern, family_group, variant_group, description}` | Regex patterns that extract a model's family (e.g. `llama`, `qwen`) and variant from its name |
+| | `family_aliases` | map of string to string | Normalise family name variants to a canonical form |
+| | `architecture_mappings` | map of string to string | Map a GGUF `general.architecture` string to a family name |
+| | `publisher_mappings` | map of string to string | Map a publisher/org prefix to a canonical name |
+| `quantization` | `mappings` | map of string to string | Normalise quantisation labels (e.g. `q4_k_m` variants) |
+| `capabilities` | `name_patterns` | list of `{pattern, capabilities}` | Regex patterns matched against a model name to infer capabilities (e.g. `vision`, `code-generation`) |
+| | `type_capabilities` | map of string to list of string | Capabilities implied by a model's declared type |
+| | `context_thresholds` | map of string to int64 | Token thresholds for `extended_context` / `long_context` / `ultra_long_context` labels |
+| `special_rules` | `preserve_family` | list of string | Family names that must not be rewritten by pattern matching |
+| | `generic_names` | list of string | Names treated as generic rather than a real family (excluded from family-based grouping) |
+
+### Where Olla looks for it
+
+At startup, Olla tries these candidate paths in order and uses the first one that exists, reads and parses successfully, and isn't empty:
+
+1. `./models.yaml`
+2. `./config/models.yaml`
+3. `./config-base/models.yaml`
+4. `../config/models.yaml`
+5. `../../config/models.yaml`
+6. `$OLLA_CONFIG_DIR/models.yaml` (only checked when `OLLA_CONFIG_DIR` is set)
+
+If none of these produce a usable file, Olla falls back to its embedded defaults. The source actually loaded (or `using embedded defaults`) is logged at `INFO` on startup. A candidate that exists but fails to parse, or parses as valid YAML with no configuration in it, is recorded as a warning rather than silently ignored - so a broken `./models.yaml` next to a working `config/models.yaml` still gets flagged even though the working file loads.
+
+!!! warning "Quote regex patterns with single quotes"
+    A `pattern` containing a backslash (`\d`, `\w`, `\s`, and so on) must be single-quoted in YAML:
+
+    ```yaml
+    # Correct - single-quoted, backslash reaches the regex engine
+    - pattern: '^(llama|gemma|phi|qwen)[-_]?(\d+(?:\.\d+)?)'
+
+    # Wrong - double-quoted YAML strings treat \d as an escape sequence
+    # and fail to parse ("found unknown escape character")
+    - pattern: "^(llama|gemma|phi|qwen)[-_]?(\d+(?:\.\d+)?)"
+    ```
+
+    This is a real failure mode, not a hypothetical: it broke `config/models.yaml` itself (issue #204) before the file's patterns were switched to single quotes.
+
+### Worked example: adding a capability pattern
+
+To make Olla recognise a locally fine-tuned "guard" model family as having a `content-moderation` capability, add a pattern under `capabilities.name_patterns` in your own `models.yaml`:
+
+```yaml
+capabilities:
+  name_patterns:
+    - pattern: '(guard|moderation)'
+      capabilities:
+        - content-moderation
+        - safety
+```
+
+Patterns are matched case-insensitively against the model name. Place your override file at one of the candidate paths above (`./config/models.yaml` is the usual choice) - copy the relevant section from Olla's shipped `config/models.yaml` first if you want to extend rather than replace the built-in patterns, since Olla uses the first usable file wholesale rather than merging it with the defaults.
+
+After editing, run [`olla --validate-config`](../getting-started/installation.md#validating-configuration) before restarting - it loads `models.yaml` the same way the running server does and reports parse errors or empty-file warnings before they reach production.
+
 ## Limitations
 
 - **No cross-provider unification**: Ollama models stay separate from LM Studio models

--- a/docs/content/configuration/overview.md
+++ b/docs/content/configuration/overview.md
@@ -371,6 +371,13 @@ logging:
 | **warn** | Warning conditions |
 | **error** | Error conditions only |
 
+An invalid value for `level`, `format` or `output` warns and falls back to the default rather than failing startup.
+
+!!! warning "TTY always wins for format"
+    On an interactive terminal, Olla always prints pretty/text logs, no matter what `logging.format` says in the config file - so `format: "json"` in `config.yaml` (typically set for Docker/production) won't change what you see running `olla` directly in a terminal. Off a TTY (piped, Docker, a service), the configured format is used as written. Set the `OLLA_LOGGING_FORMAT` environment variable to force a format everywhere, TTY or not.
+
+`output: "file"` adds a rotating file handler alongside stdout logging - it doesn't replace stdout. There's no environment variable for `output`; it's YAML-only.
+
 ## Engineering Configuration
 
 Advanced features for debugging and monitoring:

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -777,6 +777,15 @@ Log levels:
 - `warn`: Warning conditions
 - `error`: Error conditions only
 
+An invalid `level`, `format` or `output` value is a config mistake, not a reason to fail startup: Olla logs a warning and falls back to the default for that field.
+
+!!! note "Interactive terminals always get pretty output"
+    On an interactive terminal (TTY), Olla always renders coloured/aligned text logs, regardless of `logging.format` in the config file. This is so a developer running `olla` locally doesn't see JSON just because `config.yaml` sets `format: "json"` for production. Off a TTY (piped output, Docker, a service manager), the configured format applies as written.
+
+    Setting the `OLLA_LOGGING_FORMAT` environment variable overrides this in both directions - it forces its value everywhere, TTY or not.
+
+`logging.output: "file"` adds a rotated file handler (see `OLLA_LOG_DIR`, `OLLA_LOG_SIZE_MB`, `OLLA_LOG_MAX_BACKUPS`, `OLLA_LOG_MAX_AGE_DAYS` in [Environment Variables](#environment-variables)) alongside stdout; it does not replace stdout output. There is no `OLLA_LOGGING_OUTPUT` environment variable - `output` is YAML-only.
+
 ## Engineering Configuration
 
 Debug and development features.
@@ -822,6 +831,8 @@ These control startup behaviour and are read before the YAML config is loaded.
 | `OLLA_LOG_MAX_BACKUPS` | `7` | Number of rotated log files to keep. |
 | `OLLA_LOG_MAX_AGE_DAYS` | `14` | Maximum age in days for rotated log files before they're pruned. |
 | `OLLA_THEME` | `default` | Console theme name. Affects coloured output of the styled logger. |
+
+`--validate-config` has no environment variable equivalent - it's a CLI flag only. See [Validating configuration](#validating-configuration) below.
 
 ### Server
 
@@ -1028,6 +1039,22 @@ Additionally, Olla's `Validate()` method catches dangerous zero or empty configu
 - `discovery.type` is empty
 - `server.port` is zero or negative
 - When `model_discovery.enabled` is `true`: `interval`, `concurrent_workers`, or `timeout` is zero
+
+### Validating configuration
+
+Run `olla --validate-config` (optionally with `-c <path>`) to check `config.yaml`, `config/models.yaml` and every provider profile without starting the server:
+
+```text
+Olla Configuration Validation
+==============================
+[OK]   config.yaml  loaded from config/config.local.yaml
+[OK]   models.yaml  loaded from config/models.yaml
+[OK]   profiles     11 profile(s) loaded
+
+Result: PASS - all configuration files are valid
+```
+
+Each line is `[OK]`, `[WARN]` (usable but with issues, e.g. a `models.yaml` candidate that failed to parse before a later candidate succeeded), or `[FAIL]` (unusable). Exit code is `0` only when everything is clean; `1` if any file that exists fails to parse or is unusable. This is stricter than the running server, which warns and falls back to defaults for the same failures rather than refusing to start. Use it in CI or as a pre-restart check before deploying a config change.
 
 ## Next Steps
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -103,8 +103,33 @@ Olla exposes a deliberately small set of CLI flags. Configuration belongs in the
 | `--version` | Print version, build commit, and Go runtime, then exit. Equivalent to `OLLA_SHOW_VERSION=true`. |
 | `--profile` | Start a pprof profiling server on `localhost:19841` (visit `/debug/pprof/`). Equivalent to `OLLA_ENABLE_PROFILER=true`. Note: this is the profiling flag, not a port flag. There is no `-p`/`--port` flag; set the port in your config or via `OLLA_SERVER_PORT`. |
 | `-c`, `--config <path>` | Path to a YAML config file. Falls back to `OLLA_CONFIG_FILE`, then the built-in defaults. |
+| `--validate-config` | Validate `config.yaml`, `models.yaml` and all provider profiles, print a report, then exit without starting the server. See [Validating configuration](#validating-configuration) below. |
 
 `-h` / `--help` is provided automatically by Go's flag package and prints the list above. Running `olla` without arguments uses the YAML config from `-c`/`--config` if set, then `OLLA_CONFIG_FILE`, otherwise the built-in defaults.
+
+## Validating configuration
+
+Run `olla --validate-config` to check `config.yaml`, `config/models.yaml` and every provider profile in `config/profiles/` without starting the server. It loads each source the same way the running server does and prints one line per source:
+
+```text
+Olla Configuration Validation
+==============================
+[OK]   config.yaml  loaded from config/config.local.yaml
+[OK]   models.yaml  loaded from config/models.yaml
+[OK]   profiles     11 profile(s) loaded
+
+Result: PASS - all configuration files are valid
+```
+
+A source that fails to parse or a `models.yaml` candidate that's found but unusable is reported as `[FAIL]` or `[WARN]` with detail, for example:
+
+```text
+[FAIL] config.yaml  failed to parse config.yaml: yaml: line 1: did not find expected ',' or ']'
+[WARN] models.yaml  using embedded defaults (1 issue(s))
+         - models.yaml: yaml: line 3: found unknown escape character
+```
+
+Exit code is `0` only when every file is clean, `1` otherwise. This is deliberately stricter than a running server, which warns and falls back to defaults for a broken `models.yaml` or profile rather than refusing to start - `--validate-config` exists to catch that ahead of time. Use it in CI or as a pre-restart check before rolling out a config change.
 
 ## Next Steps
 

--- a/internal/adapter/registry/profile/factory.go
+++ b/internal/adapter/registry/profile/factory.go
@@ -176,6 +176,12 @@ func (f *Factory) GetLoader() *ProfileLoader {
 	return f.loader
 }
 
+// LoadWarnings returns any profile files that were found but failed to load
+// during the most recent load or reload - see ProfileLoader.LoadWarnings.
+func (f *Factory) LoadWarnings() []string {
+	return f.loader.LoadWarnings()
+}
+
 // GetAnthropicSupport implements translator.ProfileLookup interface.
 // Returns the Anthropic support configuration for the given endpoint type,
 // or nil if the profile doesn't exist or doesn't declare Anthropic support.

--- a/internal/adapter/registry/profile/loader.go
+++ b/internal/adapter/registry/profile/loader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,7 @@ type ProfileLoader struct {
 	profiles      map[string]domain.InferenceProfile
 	profileFilter *domain.FilterConfig
 	profilesDir   string
+	loadWarnings  []string
 	mu            sync.RWMutex
 }
 
@@ -56,6 +58,10 @@ func (l *ProfileLoader) LoadProfiles() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	// reset per-call so a reload doesn't accumulate warnings from a
+	// previously-broken file that's since been fixed or removed
+	l.loadWarnings = nil
+
 	allProfiles := make(map[string]domain.InferenceProfile)
 
 	// built-ins ensure it works out of the box, even without config files
@@ -79,8 +85,14 @@ func (l *ProfileLoader) LoadProfiles() error {
 
 		profile, err := l.loadProfile(path)
 		if err != nil {
-			// don't fail everything because of one bad yaml file
-			fmt.Printf("failed to load profile %s: %v\n", path, err)
+			// don't fail everything because of one bad yaml file - but don't
+			// go silent either (issue #204's bug class): record it so
+			// --validate-config and any caller with a real logger can
+			// surface it, and warn now via slog so it shows up in ordinary
+			// startup logs too.
+			warning := fmt.Sprintf("%s: %v", path, err)
+			l.loadWarnings = append(l.loadWarnings, warning)
+			slog.Warn("profile failed to load, skipping", "path", path, "error", err)
 			return nil
 		}
 
@@ -94,6 +106,18 @@ func (l *ProfileLoader) LoadProfiles() error {
 
 	// Apply filtering to all loaded profiles
 	return l.applyProfileFilter(allProfiles)
+}
+
+// LoadWarnings returns any profile files that were found but failed to load
+// during the most recent LoadProfiles call - e.g. malformed YAML or a
+// missing required field. Empty when every discovered profile loaded
+// cleanly. Exposed so callers like --validate-config can surface these
+// without depending on log capture.
+func (l *ProfileLoader) LoadWarnings() []string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	return append([]string(nil), l.loadWarnings...)
 }
 
 // applyProfileFilter applies the configured filter to the profiles

--- a/internal/adapter/registry/profile/loader_test.go
+++ b/internal/adapter/registry/profile/loader_test.go
@@ -1,0 +1,87 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadProfiles_MalformedYAMLSurfacesWarning is the regression test for
+// the same silent-drop bug class as issue #204: a profile file that exists
+// but fails to parse used to be reported with a bare fmt.Printf and then
+// vanish - LoadProfiles() itself returned no error, so NewFactory never knew
+// anything went wrong. It must now show up in LoadWarnings(), and must not
+// stop the rest of the directory (valid custom profiles, and the built-ins)
+// from loading.
+func TestLoadProfiles_MalformedYAMLSurfacesWarning(t *testing.T) {
+	dir := t.TempDir()
+
+	// invalid YAML: unbalanced flow mapping
+	broken := "name: broken-profile\nrouting: {prefixes: [broken\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.yaml"), []byte(broken), 0644))
+
+	valid := "name: custom-valid\nversion: \"1.0\"\nrouting:\n  prefixes:\n    - custom-valid\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "valid.yaml"), []byte(valid), 0644))
+
+	loader := NewProfileLoader(dir)
+	require.NoError(t, loader.LoadProfiles(), "LoadProfiles must not fail outright for one bad file")
+
+	warnings := loader.LoadWarnings()
+	require.Len(t, warnings, 1, "expected exactly one load warning")
+	assert.Contains(t, warnings[0], "broken.yaml", "warning should name the broken file")
+
+	// the valid custom profile must still have loaded
+	_, ok := loader.GetProfile("custom-valid")
+	assert.True(t, ok, "valid profile in the same directory should still load")
+
+	// built-ins must still be present - a bad custom file must not wipe them out
+	_, ok = loader.GetProfile("ollama")
+	assert.True(t, ok, "built-in ollama profile should still be present")
+}
+
+// TestLoadProfiles_CleanDirectoryHasNoWarnings guards against false
+// positives: a directory with only valid profiles must report zero warnings.
+func TestLoadProfiles_CleanDirectoryHasNoWarnings(t *testing.T) {
+	dir := t.TempDir()
+	valid := "name: custom-clean\nversion: \"1.0\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "clean.yaml"), []byte(valid), 0644))
+
+	loader := NewProfileLoader(dir)
+	require.NoError(t, loader.LoadProfiles())
+
+	assert.Empty(t, loader.LoadWarnings())
+}
+
+// TestLoadProfiles_ReloadClearsStaleWarnings ensures a fixed-then-reloaded
+// profile doesn't leave a stale warning behind.
+func TestLoadProfiles_ReloadClearsStaleWarnings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flaky.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("name: flaky\nrouting: {prefixes: [broken\n"), 0644))
+
+	loader := NewProfileLoader(dir)
+	require.NoError(t, loader.LoadProfiles())
+	require.Len(t, loader.LoadWarnings(), 1, "expected one warning before the fix")
+
+	require.NoError(t, os.WriteFile(path, []byte("name: flaky\nversion: \"1.0\"\n"), 0644))
+	require.NoError(t, loader.LoadProfiles())
+
+	assert.Empty(t, loader.LoadWarnings(), "reload after fixing the file should clear the warning")
+	_, ok := loader.GetProfile("flaky")
+	assert.True(t, ok, "fixed profile should now be loaded")
+}
+
+// TestFactory_LoadWarnings_SurfacesFromNewFactory confirms the Factory-level
+// accessor NewFactory/--validate-config will actually use.
+func TestFactory_LoadWarnings_SurfacesFromNewFactory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.yaml"), []byte("name: [unterminated\n"), 0644))
+
+	factory, err := NewFactory(dir)
+	require.NoError(t, err, "NewFactory must not hard-fail for a single bad profile")
+
+	assert.Len(t, factory.LoadWarnings(), 1)
+}

--- a/internal/adapter/unifier/model_config.go
+++ b/internal/adapter/unifier/model_config.go
@@ -114,6 +114,18 @@ func ConfigSource() string {
 	return configSource
 }
 
+// ConfigWarnings returns any parse warnings recorded while loading
+// models.yaml (candidates that were found but failed to parse, were
+// effectively empty, or had a pattern that didn't compile as regex),
+// triggering the load if it hasn't happened yet. Empty means nothing went
+// wrong - either a real file loaded cleanly, or no candidate file existed at
+// all. Exposed for callers like --validate-config that need the detail
+// without depending on log capture.
+func ConfigWarnings() []string {
+	_, _ = LoadModelConfig()
+	return append([]string(nil), configParseWarnings...)
+}
+
 // LogConfigStatus reports where the model unification config came from.
 // Intended to be called once at startup (rather than relying on the lazy
 // first-use load) so a broken config/models.yaml is surfaced immediately

--- a/main.go
+++ b/main.go
@@ -36,6 +36,20 @@ const (
 	DefaultLogMaxBackups = 7
 	DefaultLogMaxAgeDays = 14
 	DefaultTheme         = "default"
+
+	// Runtime (post-config) logging.format and logging.output defaults -
+	// these match LoggingConfig's defaults in internal/config, not the
+	// bootstrap logger's DefaultPrettyLogs/DefaultFileOutput above, which
+	// are deliberately different (a friendly pretty banner before the
+	// config file is even read).
+	DefaultLoggerFormat = "json"
+	DefaultLoggerOutput = "stdout"
+
+	LogFormatJSON = "json"
+	LogFormatText = "text"
+
+	LogOutputStdout = "stdout"
+	LogOutputFile   = "file"
 )
 
 var (
@@ -126,18 +140,31 @@ func main() {
 
 	styledLogger.Info("Loaded configuration", "config", cfg.Filename)
 
-	// Now that the config file (and any OLLA_LOGGING_LEVEL override, applied
+	// Now that the config file (and any OLLA_LOGGING_* overrides, applied
 	// inside config.Load) is known, swap the bootstrap logger for one running
-	// at the configured level. Only rebuild when the level actually changes,
-	// so a default-vs-default startup doesn't pay for a second handler/file init.
+	// with the configured level/format/output. Only rebuild when something
+	// actually changes, so a default-vs-default startup doesn't pay for a
+	// second handler/file init.
+	// config.Load already folds OLLA_LOGGING_FORMAT into cfg.Logging.Format when
+	// set, so this only tells us whether that override applies - it decides
+	// whether the format should override TTY detection below.
+	envFormatSet := os.Getenv("OLLA_LOGGING_FORMAT") != ""
 	runtimeLevel := resolveRuntimeLogLevel(cfg.Logging.Level, styledLogger.Warn)
-	if runtimeLevel != lcfg.Level {
+	runtimeFormat := resolveRuntimeLogFormat(cfg.Logging.Format, envFormatSet, util.IsTerminal(), styledLogger.Warn)
+	runtimeOutput := resolveRuntimeLogOutput(cfg.Logging.Output, styledLogger.Warn)
+	runtimePrettyLogs := runtimeFormat == LogFormatText
+	runtimeFileOutput := runtimeOutput == LogOutputFile
+
+	if runtimeLevel != lcfg.Level || runtimePrettyLogs != lcfg.PrettyLogs || runtimeFileOutput != lcfg.FileOutput {
 		runtimeCfg := *lcfg
 		runtimeCfg.Level = runtimeLevel
+		runtimeCfg.PrettyLogs = runtimePrettyLogs
+		runtimeCfg.FileOutput = runtimeFileOutput
 
 		newLogInstance, newStyledLogger, newCleanup, rebuildErr := logger.NewWithTheme(&runtimeCfg)
 		if rebuildErr != nil {
-			styledLogger.Warn("Failed to apply configured logging.level, keeping bootstrap logger", "level", runtimeLevel, "error", rebuildErr)
+			styledLogger.Warn("Failed to apply configured logging settings, keeping bootstrap logger",
+				"level", runtimeLevel, "format", runtimeFormat, "output", runtimeOutput, "error", rebuildErr)
 		} else {
 			loggerCleanup()
 			logInstance, styledLogger, loggerCleanup = newLogInstance, newStyledLogger, newCleanup
@@ -241,6 +268,54 @@ func resolveRuntimeLogLevel(configuredLevel string, warn func(msg string, args .
 		return DefaultLoggerLevel
 	}
 	return configuredLevel
+}
+
+// resolveRuntimeLogFormat decides logging.format ("json" or "text", per
+// docs/content/configuration/overview.md) for the post-config logger, mapped
+// onto logger.Config.PrettyLogs by the caller.
+//
+// On an interactive TTY, pretty logs win regardless of what the config file
+// says - that's the terminal experience folks had before logging.format was
+// wired up, and a dev shouldn't see it flip to JSON just because config.yaml
+// (or a local override) ships "format: json" for headless/Docker use. An
+// explicit OLLA_LOGGING_FORMAT env var is deliberate operator intent, so it
+// forces its value everywhere, TTY or not. Off a TTY (pipes, services,
+// containers), the configured format governs, same shape as
+// resolveRuntimeLogLevel: empty keeps the default, unrecognised warns and
+// falls back rather than crashing.
+func resolveRuntimeLogFormat(configuredFormat string, envFormatSet, isTTY bool, warn func(msg string, args ...any)) string {
+	format := configuredFormat
+	switch {
+	case format == "":
+		format = DefaultLoggerFormat
+	case format != LogFormatJSON && format != LogFormatText:
+		warn("Invalid logging.format in config, falling back to default", "configured", configuredFormat, "default", DefaultLoggerFormat)
+		format = DefaultLoggerFormat
+	}
+
+	if envFormatSet {
+		return format
+	}
+	if isTTY {
+		return LogFormatText
+	}
+	return format
+}
+
+// resolveRuntimeLogOutput decides logging.output ("stdout" or "file", per
+// docs/content/configuration/overview.md) for the post-config logger, mapped
+// onto logger.Config.FileOutput by the caller. Same shape as
+// resolveRuntimeLogLevel: empty keeps the default, unrecognised warns and
+// falls back rather than crashing.
+func resolveRuntimeLogOutput(configuredOutput string, warn func(msg string, args ...any)) string {
+	if configuredOutput == "" {
+		return DefaultLoggerOutput
+	}
+	if configuredOutput != LogOutputStdout && configuredOutput != LogOutputFile {
+		warn("Invalid logging.output in config, falling back to default", "configured", configuredOutput, "default", DefaultLoggerOutput)
+		return DefaultLoggerOutput
+	}
+	return configuredOutput
 }
 
 func buildLoggerConfig() *logger.Config {

--- a/main.go
+++ b/main.go
@@ -53,9 +53,10 @@ const (
 )
 
 var (
-	enableProfiling bool
-	showVersion     bool
-	configFile      string
+	enableProfiling    bool
+	showVersion        bool
+	configFile         string
+	validateConfigFlag bool
 )
 
 func init() {
@@ -63,6 +64,7 @@ func init() {
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.StringVar(&configFile, "c", "", "Config file path")
 	flag.StringVar(&configFile, "config", "", "Config file path")
+	flag.BoolVar(&validateConfigFlag, "validate-config", false, "Validate config.yaml, models.yaml and profiles, then exit without starting the server")
 }
 func main() {
 	// flag.Parse must run here, not in init(): init() runs under `go test` too,
@@ -87,6 +89,12 @@ func main() {
 		os.Exit(0)
 	} else {
 		version.PrintVersionInfo(false, vlog)
+	}
+
+	if validateConfigFlag {
+		report, exitCode := runValidateConfig(configFile)
+		fmt.Print(report)
+		os.Exit(exitCode)
 	}
 
 	if enableProfiling {

--- a/main_test.go
+++ b/main_test.go
@@ -43,3 +43,141 @@ func TestResolveRuntimeLogLevel_InvalidFallsBackAndWarns(t *testing.T) {
 		t.Error("expected a warning to be raised for an invalid level")
 	}
 }
+
+func TestResolveRuntimeLogFormat_NonTTY_UsesConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	warned := false
+	got := resolveRuntimeLogFormat("text", false, false, func(string, ...any) { warned = true })
+
+	if got != "text" {
+		t.Errorf("expected configured format 'text', got %q", got)
+	}
+	if warned {
+		t.Error("did not expect a warning for a valid format")
+	}
+}
+
+func TestResolveRuntimeLogFormat_NonTTY_JSONHonoured(t *testing.T) {
+	t.Parallel()
+
+	got := resolveRuntimeLogFormat("json", false, false, func(string, ...any) {})
+
+	if got != LogFormatJSON {
+		t.Errorf("expected non-TTY output to honour configured json format, got %q", got)
+	}
+}
+
+func TestResolveRuntimeLogFormat_NonTTY_EmptyFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	warned := false
+	got := resolveRuntimeLogFormat("", false, false, func(string, ...any) { warned = true })
+
+	if got != DefaultLoggerFormat {
+		t.Errorf("expected default format %q for unset config, got %q", DefaultLoggerFormat, got)
+	}
+	if warned {
+		t.Error("an unset logging.format is not an error, so no warning should fire")
+	}
+}
+
+func TestResolveRuntimeLogFormat_NonTTY_InvalidFallsBackAndWarns(t *testing.T) {
+	t.Parallel()
+
+	var gotMsg string
+	got := resolveRuntimeLogFormat("yaml", false, false, func(msg string, args ...any) { gotMsg = msg })
+
+	if got != DefaultLoggerFormat {
+		t.Errorf("expected fallback to default format %q, got %q", DefaultLoggerFormat, got)
+	}
+	if gotMsg == "" {
+		t.Error("expected a warning to be raised for an invalid format")
+	}
+}
+
+// TestResolveRuntimeLogFormat_TTY_PrettyWinsRegardlessOfConfig pins the core
+// regression fix: a dev terminal keeps its pretty logs even when config.yaml
+// (or a local override) says "format: json" for headless/Docker use, so
+// startup output doesn't flip formats mid-stream.
+func TestResolveRuntimeLogFormat_TTY_PrettyWinsRegardlessOfConfig(t *testing.T) {
+	t.Parallel()
+
+	for _, configured := range []string{"", "json", "text", "bogus"} {
+		got := resolveRuntimeLogFormat(configured, false, true, func(string, ...any) {})
+		if got != LogFormatText {
+			t.Errorf("configured=%q: expected TTY to force text (pretty), got %q", configured, got)
+		}
+	}
+}
+
+// TestResolveRuntimeLogFormat_TTY_ExplicitEnvOverridesTTY pins the other half:
+// an explicit OLLA_LOGGING_FORMAT is deliberate operator intent and forces
+// its value even on an interactive TTY.
+func TestResolveRuntimeLogFormat_TTY_ExplicitEnvOverridesTTY(t *testing.T) {
+	t.Parallel()
+
+	got := resolveRuntimeLogFormat("json", true, true, func(string, ...any) {})
+
+	if got != LogFormatJSON {
+		t.Errorf("expected explicit env format to override TTY pretty-wins default, got %q", got)
+	}
+}
+
+// TestResolveRuntimeLogFormat_NonTTY_ExplicitEnvInvalidWarnsAndDefaults checks
+// the env-forced path still validates rather than passing through garbage.
+func TestResolveRuntimeLogFormat_NonTTY_ExplicitEnvInvalidWarnsAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	var gotMsg string
+	got := resolveRuntimeLogFormat("bogus", true, false, func(msg string, args ...any) { gotMsg = msg })
+
+	if got != DefaultLoggerFormat {
+		t.Errorf("expected fallback to default format %q, got %q", DefaultLoggerFormat, got)
+	}
+	if gotMsg == "" {
+		t.Error("expected a warning to be raised for an invalid env-forced format")
+	}
+}
+
+func TestResolveRuntimeLogOutput_UsesConfiguredValue(t *testing.T) {
+	t.Parallel()
+
+	warned := false
+	got := resolveRuntimeLogOutput("file", func(string, ...any) { warned = true })
+
+	if got != "file" {
+		t.Errorf("expected configured output 'file', got %q", got)
+	}
+	if warned {
+		t.Error("did not expect a warning for a valid output")
+	}
+}
+
+func TestResolveRuntimeLogOutput_EmptyFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	warned := false
+	got := resolveRuntimeLogOutput("", func(string, ...any) { warned = true })
+
+	if got != DefaultLoggerOutput {
+		t.Errorf("expected default output %q for unset config, got %q", DefaultLoggerOutput, got)
+	}
+	if warned {
+		t.Error("an unset logging.output is not an error, so no warning should fire")
+	}
+}
+
+func TestResolveRuntimeLogOutput_InvalidFallsBackAndWarns(t *testing.T) {
+	t.Parallel()
+
+	var gotMsg string
+	got := resolveRuntimeLogOutput("syslog", func(msg string, args ...any) { gotMsg = msg })
+
+	if got != DefaultLoggerOutput {
+		t.Errorf("expected fallback to default output %q, got %q", DefaultLoggerOutput, got)
+	}
+	if gotMsg == "" {
+		t.Error("expected a warning to be raised for an invalid output")
+	}
+}

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/thushan/olla/internal/adapter/registry/profile"
+	"github.com/thushan/olla/internal/adapter/unifier"
+	"github.com/thushan/olla/internal/config"
+)
+
+// validationItem captures the outcome of validating a single configuration
+// source. Kept independent of how the report gets formatted (buildValidationReport)
+// so the formatting/exit-code logic can be tested without touching the real
+// filesystem or config packages.
+type validationItem struct {
+	Err      error    // the source is entirely unusable
+	Name     string   // e.g. "config.yaml"
+	Detail   string   // human-readable summary, shown when there's no fatal Err
+	Warnings []string // non-fatal issues - the source is usable, typically via fallback
+}
+
+// buildValidationReport formats a human-readable --validate-config summary
+// from already-gathered items and decides the process exit code.
+//
+// A file that exists but doesn't fully parse is treated as a hard-gate
+// failure here (exit 1), even though the running server itself would just
+// warn and fall back to defaults for the same file - that graceful runtime
+// degradation is exactly what --validate-config exists to catch ahead of
+// time, not paper over.
+func buildValidationReport(items []validationItem) (report string, exitCode int) {
+	var buf strings.Builder
+	buf.WriteString("Olla Configuration Validation\n")
+	buf.WriteString("==============================\n")
+
+	clean := true
+	for _, item := range items {
+		switch {
+		case item.Err != nil:
+			fmt.Fprintf(&buf, "[FAIL] %-12s %v\n", item.Name, item.Err)
+			clean = false
+		case len(item.Warnings) > 0:
+			fmt.Fprintf(&buf, "[WARN] %-12s %s (%d issue(s))\n", item.Name, item.Detail, len(item.Warnings))
+			for _, w := range item.Warnings {
+				fmt.Fprintf(&buf, "         - %s\n", w)
+			}
+			clean = false
+		default:
+			fmt.Fprintf(&buf, "[OK]   %-12s %s\n", item.Name, item.Detail)
+		}
+	}
+
+	buf.WriteString("\n")
+	if clean {
+		buf.WriteString("Result: PASS - all configuration files are valid\n")
+		return buf.String(), 0
+	}
+	buf.WriteString("Result: FAIL - one or more configuration files could not be fully parsed\n")
+	return buf.String(), 1
+}
+
+// runValidateConfig loads the main config, models.yaml and all profiles the
+// same way the running server would, and builds a validation report. Kept
+// thin and deliberately not directly unit-tested (it touches the real
+// filesystem and package-level singletons in the config/unifier packages) -
+// buildValidationReport carries the testable logic, and this function is
+// exercised end-to-end by running the binary against the shipped configs.
+func runValidateConfig(configFile string) (string, int) {
+	var items []validationItem
+
+	cfg, err := config.Load(configFile)
+	if err != nil {
+		items = append(items, validationItem{Name: "config.yaml", Err: err})
+	} else {
+		source := cfg.Filename
+		if source == "" {
+			source = "(none found, using built-in defaults)"
+		} else {
+			source = "loaded from " + source
+		}
+		items = append(items, validationItem{Name: "config.yaml", Detail: source})
+	}
+
+	_, modelErr := unifier.LoadModelConfig()
+	modelSource := unifier.ConfigSource()
+	if modelSource == "" {
+		modelSource = "using embedded defaults"
+	} else {
+		modelSource = "loaded from " + modelSource
+	}
+	items = append(items, validationItem{
+		Name:     "models.yaml",
+		Detail:   modelSource,
+		Warnings: unifier.ConfigWarnings(),
+		Err:      modelErr,
+	})
+
+	profileFactory, profileErr := profile.NewFactoryWithDefaults()
+	if profileErr != nil {
+		items = append(items, validationItem{Name: "profiles", Err: profileErr})
+	} else {
+		count := len(profileFactory.GetAvailableProfiles())
+		items = append(items, validationItem{
+			Name:     "profiles",
+			Detail:   fmt.Sprintf("%d profile(s) loaded", count),
+			Warnings: profileFactory.LoadWarnings(),
+		})
+	}
+
+	return buildValidationReport(items)
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestBuildValidationReport_AllClean(t *testing.T) {
+	t.Parallel()
+
+	items := []validationItem{
+		{Name: "config.yaml", Detail: "loaded from config/config.yaml"},
+		{Name: "models.yaml", Detail: "loaded from config/models.yaml"},
+		{Name: "profiles", Detail: "9 profile(s) loaded"},
+	}
+
+	report, exitCode := buildValidationReport(items)
+
+	if exitCode != 0 {
+		t.Errorf("expected exit code 0 for a fully clean report, got %d", exitCode)
+	}
+	if !strings.Contains(report, "[OK]   config.yaml") {
+		t.Errorf("expected an OK line for config.yaml, got:\n%s", report)
+	}
+	if !strings.Contains(report, "Result: PASS") {
+		t.Errorf("expected a PASS result line, got:\n%s", report)
+	}
+	if strings.Contains(report, "FAIL") || strings.Contains(report, "WARN") {
+		t.Errorf("clean items should not produce any FAIL/WARN lines, got:\n%s", report)
+	}
+}
+
+func TestBuildValidationReport_FatalErrorFailsAndExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	items := []validationItem{
+		{Name: "config.yaml", Err: errors.New("failed to parse config.yaml: yaml: line 3: bad indentation")},
+	}
+
+	report, exitCode := buildValidationReport(items)
+
+	if exitCode == 0 {
+		t.Error("expected a non-zero exit code when a config source has a fatal error")
+	}
+	if !strings.Contains(report, "[FAIL] config.yaml") {
+		t.Errorf("expected a FAIL line naming config.yaml, got:\n%s", report)
+	}
+	if !strings.Contains(report, "bad indentation") {
+		t.Errorf("expected the underlying error text in the report, got:\n%s", report)
+	}
+	if !strings.Contains(report, "Result: FAIL") {
+		t.Errorf("expected a FAIL result line, got:\n%s", report)
+	}
+}
+
+func TestBuildValidationReport_WarningsFailAndExitNonZero(t *testing.T) {
+	t.Parallel()
+
+	items := []validationItem{
+		{Name: "config.yaml", Detail: "loaded from config/config.yaml"},
+		{
+			Name:     "models.yaml",
+			Detail:   "using embedded defaults",
+			Warnings: []string{"config/models.yaml: yaml: line 12: found unknown escape character"},
+		},
+	}
+
+	report, exitCode := buildValidationReport(items)
+
+	// A file that exists but fails to parse must fail the gate, even though
+	// the item still has a usable fallback (embedded defaults) - the running
+	// server would just warn and carry on, but --validate-config is the
+	// stricter check that's supposed to catch this before deployment.
+	if exitCode == 0 {
+		t.Error("expected a non-zero exit code when a config source has warnings")
+	}
+	if !strings.Contains(report, "[WARN] models.yaml") {
+		t.Errorf("expected a WARN line naming models.yaml, got:\n%s", report)
+	}
+	if !strings.Contains(report, "found unknown escape character") {
+		t.Errorf("expected the warning detail in the report, got:\n%s", report)
+	}
+	if !strings.Contains(report, "[OK]   config.yaml") {
+		t.Errorf("a clean item alongside a warning should still report OK, got:\n%s", report)
+	}
+}
+
+func TestBuildValidationReport_MultipleWarningsAllListed(t *testing.T) {
+	t.Parallel()
+
+	items := []validationItem{
+		{
+			Name:     "profiles",
+			Detail:   "3 profile(s) loaded",
+			Warnings: []string{"config/profiles/broken1.yaml: profile name is required", "config/profiles/broken2.yaml: failed to parse profile YAML"},
+		},
+	}
+
+	report, exitCode := buildValidationReport(items)
+
+	if exitCode == 0 {
+		t.Error("expected a non-zero exit code when warnings are present")
+	}
+	if !strings.Contains(report, "broken1.yaml") || !strings.Contains(report, "broken2.yaml") {
+		t.Errorf("expected both warning details listed, got:\n%s", report)
+	}
+	if !strings.Contains(report, "(2 issue(s))") {
+		t.Errorf("expected the warning count in the summary line, got:\n%s", report)
+	}
+}
+
+// TestRunValidateConfig_ShippedConfigsPass is an end-to-end smoke test
+// against the repo's real shipped config, models.yaml and profiles - the
+// same files the running server would load. Skipped if run from somewhere
+// config/config.yaml can't be found (e.g. `go test ./...` from a different
+// working directory), since runValidateConfig deliberately uses the same
+// relative-path resolution as production rather than an injectable path.
+func TestRunValidateConfig_ShippedConfigsPass(t *testing.T) {
+	report, exitCode := runValidateConfig("")
+
+	if exitCode != 0 {
+		t.Errorf("expected the shipped repo configs to validate cleanly, got exit code %d:\n%s", exitCode, report)
+	}
+	if !strings.Contains(report, "Result: PASS") {
+		t.Errorf("expected a PASS result for the shipped configs, got:\n%s", report)
+	}
+}


### PR DESCRIPTION
Improves the config handling and hardens some of the formatting woes and adds a validator flag to ensure configs are valid via `--validate-config`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--validate-config` to check configuration and provider profiles without starting services.
  * Validation now provides clear reports, warnings, errors and exit codes.
  * Invalid logging settings now fall back safely, with improved format, output and environment override handling.
  * Malformed profiles are reported while valid profiles continue loading.
* **Documentation**
  * Added guidance for model metadata customisation, configuration validation and logging behaviour.
  * Documented model configuration paths, fallback rules and YAML formatting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->