### PR TITLE
feat: add model aliases visibility modes (hidden/append/disabled)

### DIFF
--- a/docs/content/api-reference/models.md
+++ b/docs/content/api-reference/models.md
@@ -20,6 +20,14 @@ Cross-provider model discovery endpoint that aggregates models from all configur
 
 Returns all available models across all configured and healthy endpoints.
 
+!!! note "Model Aliases Visibility"
+    The visibility of configured model aliases in model listings is controlled by the `model_aliases_mode` configuration option:
+    - `disabled` (default): Only actual backend models are shown. Aliases are not listed.
+    - `append`: Aliases are shown alongside their target models.
+    - `hidden`: Aliases are shown, but their target models are hidden from the list.
+    
+    See [Model Aliases Configuration](../configuration/reference.md#model-aliases-mode) and [Model Aliases Concepts](../concepts/model-aliases.md#alias-visibility-in-model-listings) for details.
+
 ### Query Parameters
 
 | Parameter | Type | Default | Description |

--- a/docs/content/concepts/model-aliases.md
+++ b/docs/content/concepts/model-aliases.md
@@ -140,6 +140,48 @@ Aliases are separate from model unification. Unification merges model catalogues
 
 Both the Olla and Sherpa proxy engines support model alias rewriting. The rewrite happens transparently before the request is forwarded to the backend.
 
+## Alias Visibility in Model Listings
+
+By default, configured aliases are **not** shown in model listing endpoints (e.g., `/olla/proxy/v1/models`, `/olla/ollama/v1/models`, `/olla/openai/v1/models`, etc.). Only actual models discovered from backends are returned.
+
+You can change this behavior with the `model_aliases_mode` configuration option:
+
+| Mode | Description |
+|------|-------------|
+| `disabled` (default) | Aliases are hidden from model listings. Only actual backend models are shown. |
+| `append` | Aliases are added to listings alongside their target models. Both alias and actual model names appear. |
+| `hidden` | Aliases are shown in listings, target models are hidden. Clients see only the alias (e.g., `my-llama`), not backend-specific names (e.g., `llama3.1:8b`). Target models remain accessible by direct request. |
+
+Configuration example:
+
+```yaml
+model_aliases:
+  my-llama:
+    - "llama3.1:8b"                          # Ollama
+    - llama-3.1-8b-instruct                  # LM Studio
+model_aliases_mode: "hidden"
+```
+
+With `model_aliases_mode: "hidden"`, a request to `/olla/proxy/v1/models` returns:
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "my-llama",
+      "object": "model",
+      "created": 1705334400,
+      "owned_by": "olla"
+    }
+  ]
+}
+```
+
+The alias `my-llama` appears in the list, but `llama3.1:8b` and `llama-3.1-8b-instruct` are hidden. A client can still request `"model": "llama3.1:8b"` directly and it will work.
+
+When using `hidden` or `append` mode, alias entries include their target models in the `aliases` field (in unified format) or as additional metadata, allowing clients to discover underlying model names if needed.
+
 ## Example Scenario
 
 Consider a home lab with three backends:

--- a/docs/content/concepts/model-aliases.md
+++ b/docs/content/concepts/model-aliases.md
@@ -150,7 +150,7 @@ You can change this behavior with the `model_aliases_mode` configuration option:
 |------|-------------|
 | `disabled` (default) | Aliases are hidden from model listings. Only actual backend models are shown. |
 | `append` | Aliases are added to listings alongside their target models. Both alias and actual model names appear. |
-| `hidden` | Aliases are shown in listings, target models are hidden. Clients see only the alias (e.g., `my-llama`), not backend-specific names (e.g., `llama3.1:8b`). Target models remain accessible by direct request. |
+| `hidden` | Aliases are shown in listings, but their target models are excluded from the top-level listing. Target models remain accessible by direct request and are still visible through alias metadata (e.g., the `aliases` field). |
 
 Configuration example:
 

--- a/docs/content/configuration/reference.md
+++ b/docs/content/configuration/reference.md
@@ -606,6 +606,7 @@ Define virtual model names that map to platform-specific model names across diff
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `model_aliases` | map[string][]string | `nil` | Map of alias name → list of actual model names |
+| `model_aliases_mode` | string | `disabled` | Controls alias visibility in model listings (`disabled`, `append`, `hidden`) |
 
 Each key is the virtual model name clients will use. Each value is a list of actual model names that backends may serve the model under. When a request matches an alias, Olla resolves endpoints for all listed model names and rewrites the request body to the correct name for the selected backend.
 
@@ -621,10 +622,24 @@ model_aliases:
   my-codegen:
     - "qwen2.5-coder:7b"                     # Ollama
     - qwen2.5-coder-7b-instruct              # LM Studio
+
+model_aliases_mode: "hidden"
 ```
 
 !!! note
     Alias names take priority over standard model routing. If no endpoints are found for the alias, Olla falls back to standard routing using the alias name as a regular model name, honouring the configured routing strategy. Under `strict` (the default) an alias whose targets are all unavailable is rejected (`404`/`503`), not proxied to a compatible-but-wrong backend. See [Model Aliases](../concepts/model-aliases.md) for details.
+
+### Model Aliases Mode
+
+The `model_aliases_mode` setting controls how configured aliases appear in model listing endpoints (e.g., `/olla/proxy/v1/models`, `/olla/ollama/v1/models`, `/olla/openai/v1/models`, etc.):
+
+| Mode | Description |
+|------|-------------|
+| `disabled` | Aliases are not shown in model listings. Only actual models discovered from backends are returned. This is the default for backward compatibility. |
+| `append` | Aliases are added to model listings alongside their target models. Both the alias name and the actual model names appear in the response. |
+| `hidden` | Aliases are shown in model listings, but their target models are hidden. Clients see only the alias names (e.g., `my-llama`), not the backend-specific names (e.g., `llama3.1:8b`, `llama-3.1-8b-instruct`). Target models remain accessible by their direct names if requested explicitly. |
+
+When using `hidden` or `append` mode, the alias entries in model listings include their target models in the `aliases` field, allowing clients to discover the underlying model names if needed.
 
 ## Routing Response Headers
 

--- a/internal/adapter/balancer/sticky.go
+++ b/internal/adapter/balancer/sticky.go
@@ -96,7 +96,7 @@ func (s *StickySessionWrapper) Select(ctx context.Context, endpoints []*domain.E
 	if key == "" {
 		// No affinity key — pass through transparently.
 		if outcome != nil {
-			outcome.Result = "disabled"
+			outcome.Result = constants.StickyOutcomeResultDisabled
 			outcome.Source = "none"
 		}
 		return s.inner.Select(ctx, endpoints)

--- a/internal/adapter/balancer/sticky_test.go
+++ b/internal/adapter/balancer/sticky_test.go
@@ -152,7 +152,7 @@ func TestStickySessionWrapper_NoKey(t *testing.T) {
 	chosen, err := w.Select(ctx, []*domain.Endpoint{ep1})
 	require.NoError(t, err)
 	assert.Equal(t, ep1.URLString, chosen.URLString)
-	assert.Equal(t, "disabled", outcome.Result)
+	assert.Equal(t, constants.StickyOutcomeResultDisabled, outcome.Result)
 	assert.Equal(t, "none", outcome.Source)
 }
 

--- a/internal/adapter/converter/openai_converter.go
+++ b/internal/adapter/converter/openai_converter.go
@@ -53,11 +53,21 @@ func (c *OpenAIConverter) ConvertToFormat(models []*domain.UnifiedModel, filters
 
 func (c *OpenAIConverter) convertModel(model *domain.UnifiedModel) OpenAIModelData {
 	// OLLA-85: [Unification] Models with different digests fail to unify correctly.
-	// we need to use first alas as ID for routing compatibility
+	// we need to use first alias as ID for routing compatibility
 	// to make sure the returned model ID can be used for requests
+	// Exception: config-sourced aliases (Source="config") use their own ID as the model ID
 	modelID := model.ID
 	if len(model.Aliases) > 0 {
-		modelID = model.Aliases[0].Name
+		isConfigAlias := false
+		for _, alias := range model.Aliases {
+			if alias.Source == "config" {
+				isConfigAlias = true
+				break
+			}
+		}
+		if !isConfigAlias {
+			modelID = model.Aliases[0].Name
+		}
 	}
 
 	return OpenAIModelData{

--- a/internal/adapter/converter/openai_converter_test.go
+++ b/internal/adapter/converter/openai_converter_test.go
@@ -92,3 +92,87 @@ func TestOpenAIConverter_ConvertToFormat(t *testing.T) {
 		assert.Equal(t, "phi4:latest", response.Data[0].ID)
 	})
 }
+
+func TestOpenAIConverter_ConfigAliases(t *testing.T) {
+	converter := NewOpenAIConverter()
+
+	// Model with config-sourced aliases (Source="config")
+	configAliasModel := &domain.UnifiedModel{
+		ID: "my-gpt", // alias name is the ID
+		Aliases: []domain.AliasEntry{
+			{Name: "gpt-3.5-turbo", Source: "config"},
+			{Name: "gpt-4", Source: "config"},
+		},
+		SourceEndpoints: []domain.SourceEndpoint{
+			{
+				EndpointURL: "http://openai:8080",
+				NativeName:  "my-gpt",
+				State:       "available",
+			},
+		},
+		Capabilities: []string{"chat", "completion"},
+	}
+
+	// Model with regular (unification) aliases
+	regularModel := &domain.UnifiedModel{
+		ID: "llama/3:70b-q4km",
+		Aliases: []domain.AliasEntry{
+			{Name: "llama3:latest", Source: "ollama"},
+		},
+		SourceEndpoints: []domain.SourceEndpoint{
+			{
+				EndpointURL: "http://localhost:11434",
+				NativeName:  "llama3:latest",
+				State:       "loaded",
+			},
+		},
+		Capabilities: []string{"chat", "completion"},
+	}
+
+	t.Run("config alias uses alias ID not first target", func(t *testing.T) {
+		filters := ports.ModelFilters{}
+
+		result, err := converter.ConvertToFormat([]*domain.UnifiedModel{configAliasModel}, filters)
+		require.NoError(t, err)
+
+		response, ok := result.(OpenAIModelResponse)
+		require.True(t, ok)
+		assert.Len(t, response.Data, 1)
+		// Config alias should use its own ID (my-gpt), not first target (gpt-3.5-turbo)
+		assert.Equal(t, "my-gpt", response.Data[0].ID)
+	})
+
+	t.Run("regular alias uses first target as ID", func(t *testing.T) {
+		filters := ports.ModelFilters{}
+
+		result, err := converter.ConvertToFormat([]*domain.UnifiedModel{regularModel}, filters)
+		require.NoError(t, err)
+
+		response, ok := result.(OpenAIModelResponse)
+		require.True(t, ok)
+		assert.Len(t, response.Data, 1)
+		// Regular alias uses first alias as ID
+		assert.Equal(t, "llama3:latest", response.Data[0].ID)
+	})
+
+	t.Run("mixed config and regular aliases", func(t *testing.T) {
+		filters := ports.ModelFilters{}
+
+		result, err := converter.ConvertToFormat([]*domain.UnifiedModel{configAliasModel, regularModel}, filters)
+		require.NoError(t, err)
+
+		response, ok := result.(OpenAIModelResponse)
+		require.True(t, ok)
+		assert.Len(t, response.Data, 2)
+
+		modelIDs := make([]string, len(response.Data))
+		for i, m := range response.Data {
+			modelIDs[i] = m.ID
+		}
+
+		assert.Contains(t, modelIDs, "my-gpt")
+		assert.Contains(t, modelIDs, "llama3:latest")
+		assert.NotContains(t, modelIDs, "gpt-3.5-turbo")
+		assert.NotContains(t, modelIDs, "gpt-4")
+	})
+}

--- a/internal/adapter/proxy/core/common_test.go
+++ b/internal/adapter/proxy/core/common_test.go
@@ -731,8 +731,8 @@ func TestSetStickySessionHeaders(t *testing.T) {
 		},
 		{
 			name:          "disabled_source_none_skips_key_source_header",
-			outcome:       &domain.StickyOutcome{Result: "disabled", Source: "none"},
-			expectSession: "disabled",
+			outcome:       &domain.StickyOutcome{Result: constants.StickyOutcomeResultDisabled, Source: "none"},
+			expectSession: constants.StickyOutcomeResultDisabled,
 			expectSource:  "", // "none" must not be written
 		},
 		{

--- a/internal/adapter/registry/alias.go
+++ b/internal/adapter/registry/alias.go
@@ -41,6 +41,15 @@ func (r *AliasResolver) GetActualModels(aliasName string) []string {
 	return r.aliases[aliasName]
 }
 
+// GetAllAliases returns all configured aliases and their target models.
+// Returns nil if no aliases are configured.
+func (r *AliasResolver) GetAllAliases() map[string][]string {
+	if r == nil {
+		return nil
+	}
+	return r.aliases
+}
+
 // EndpointModelMapping maps an endpoint URL to the actual model name it should receive
 type EndpointModelMapping struct {
 	EndpointURL string

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -220,10 +220,7 @@ func (a *Application) getProviderModels(ctx context.Context, providerType string
 	}
 
 	// Inject configured aliases (add alias models, optionally hide targets)
-	modelsWithAliases, err := a.injectConfiguredAliases(ctx, healthyModels)
-	if err != nil {
-		return nil, fmt.Errorf("failed to inject configured aliases: %w", err)
-	}
+	modelsWithAliases := a.injectConfiguredAliases(ctx, healthyModels)
 
 	providerModels, err := a.filterModelsByProvider(ctx, modelsWithAliases, providerType)
 	if err != nil {
@@ -253,9 +250,9 @@ func (a *Application) convertModelsToProviderFormat(models []*domain.UnifiedMode
 // injectConfiguredAliases injects configured model aliases into the model list.
 // If ModelAliasesMode is "hidden" or "append", creates synthetic UnifiedModel entries
 // for each alias. In "hidden" mode, filters out target models that appear in any alias.
-func (a *Application) injectConfiguredAliases(ctx context.Context, models []*domain.UnifiedModel) ([]*domain.UnifiedModel, error) {
+func (a *Application) injectConfiguredAliases(ctx context.Context, models []*domain.UnifiedModel) []*domain.UnifiedModel {
 	if a.aliasResolver == nil || a.Config.ModelAliasesMode == "disabled" {
-		return models, nil
+		return models
 	}
 
 	// Collect all target model names from configured aliases
@@ -310,7 +307,7 @@ func (a *Application) injectConfiguredAliases(ctx context.Context, models []*dom
 	}
 	// "append" mode: keep all models + add aliases
 
-	return append(models, aliasModels...), nil
+	return append(models, aliasModels...)
 }
 
 // getUnifiedModelByName retrieves a unified model by its ID or native name

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -251,7 +251,7 @@ func (a *Application) convertModelsToProviderFormat(models []*domain.UnifiedMode
 // If ModelAliasesMode is "hidden" or "append", creates synthetic UnifiedModel entries
 // for each alias. In "hidden" mode, filters out target models that appear in any alias.
 func (a *Application) injectConfiguredAliases(ctx context.Context, models []*domain.UnifiedModel) []*domain.UnifiedModel {
-	if a.aliasResolver == nil || a.Config.ModelAliasesMode == "disabled" {
+	if a.aliasResolver == nil || a.Config.ModelAliasesMode == constants.StickyOutcomeResultDisabled {
 		return models
 	}
 

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -219,7 +219,13 @@ func (a *Application) getProviderModels(ctx context.Context, providerType string
 		return nil, fmt.Errorf("failed to filter models by health: %w", err)
 	}
 
-	providerModels, err := a.filterModelsByProvider(ctx, healthyModels, providerType)
+	// Inject configured aliases (add alias models, optionally hide targets)
+	modelsWithAliases, err := a.injectConfiguredAliases(ctx, healthyModels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inject configured aliases: %w", err)
+	}
+
+	providerModels, err := a.filterModelsByProvider(ctx, modelsWithAliases, providerType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter models by provider: %w", err)
 	}
@@ -242,4 +248,122 @@ func (a *Application) convertModelsToProviderFormat(models []*domain.UnifiedMode
 	}
 
 	return response, nil
+}
+
+// injectConfiguredAliases injects configured model aliases into the model list.
+// If ModelAliasesMode is "hidden" or "append", creates synthetic UnifiedModel entries
+// for each alias. In "hidden" mode, filters out target models that appear in any alias.
+func (a *Application) injectConfiguredAliases(ctx context.Context, models []*domain.UnifiedModel) ([]*domain.UnifiedModel, error) {
+	if a.aliasResolver == nil || a.Config.ModelAliasesMode == "disabled" {
+		return models, nil
+	}
+
+	// Collect all target model names from configured aliases
+	allAliases := a.aliasResolver.GetAllAliases()
+	targetModels := make(map[string]bool)
+	for _, targets := range allAliases {
+		for _, t := range targets {
+			targetModels[t] = true
+		}
+	}
+
+	// Create synthetic alias models
+	var aliasModels []*domain.UnifiedModel
+	for aliasName, targetNames := range allAliases {
+		var mergedEndpoints []domain.SourceEndpoint
+		var firstTarget *domain.UnifiedModel
+
+		for _, targetName := range targetNames {
+			if um, err := a.getUnifiedModelByName(ctx, targetName); err == nil && um != nil {
+				if firstTarget == nil {
+					firstTarget = um
+				}
+				mergedEndpoints = append(mergedEndpoints, um.SourceEndpoints...)
+			}
+		}
+
+		if len(mergedEndpoints) == 0 || firstTarget == nil {
+			continue // no endpoints for this alias
+		}
+
+		// Deduplicate endpoints by URL, set NativeName to alias name
+		uniqEndpoints := deduplicateEndpointsByURL(mergedEndpoints, aliasName)
+
+		aliasModels = append(aliasModels, &domain.UnifiedModel{
+			ID:               aliasName,
+			Aliases:          toAliasEntries(targetNames, "config"),
+			SourceEndpoints:  uniqEndpoints,
+			Family:           firstTarget.Family,
+			Variant:          firstTarget.Variant,
+			ParameterSize:    firstTarget.ParameterSize,
+			Quantization:     firstTarget.Quantization,
+			Format:           firstTarget.Format,
+			Capabilities:     firstTarget.Capabilities,
+			MaxContextLength: firstTarget.MaxContextLength,
+			ParameterCount:   firstTarget.ParameterCount,
+		})
+	}
+
+	// Filter target models in "hidden" mode
+	if a.Config.ModelAliasesMode == "hidden" {
+		models = filterOutTargetModels(models, targetModels)
+	}
+	// "append" mode: keep all models + add aliases
+
+	return append(models, aliasModels...), nil
+}
+
+// getUnifiedModelByName retrieves a unified model by its ID or native name
+func (a *Application) getUnifiedModelByName(ctx context.Context, name string) (*domain.UnifiedModel, error) {
+	unifiedRegistry, ok := a.modelRegistry.(*registry.UnifiedMemoryModelRegistry)
+	if !ok {
+		return nil, errors.New("unified models not supported")
+	}
+	return unifiedRegistry.GetUnifiedModel(ctx, name)
+}
+
+// deduplicateEndpointsByURL deduplicates source endpoints by URL, keeping the first occurrence
+// and setting NativeName to the provided aliasName for all entries
+func deduplicateEndpointsByURL(endpoints []domain.SourceEndpoint, aliasName string) []domain.SourceEndpoint {
+	seen := make(map[string]bool)
+	var result []domain.SourceEndpoint
+	for _, ep := range endpoints {
+		if !seen[ep.EndpointURL] {
+			seen[ep.EndpointURL] = true
+			ep.NativeName = aliasName
+			result = append(result, ep)
+		}
+	}
+	return result
+}
+
+// filterOutTargetModels removes models whose ID or any native name matches a target model in the alias config
+func filterOutTargetModels(models []*domain.UnifiedModel, targetModels map[string]bool) []*domain.UnifiedModel {
+	var result []*domain.UnifiedModel
+	for _, m := range models {
+		if targetModels[m.ID] {
+			continue
+		}
+		// Also check if any source endpoint's native name is a target model
+		isTarget := false
+		for _, ep := range m.SourceEndpoints {
+			if targetModels[ep.NativeName] {
+				isTarget = true
+				break
+			}
+		}
+		if !isTarget {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// toAliasEntries converts a slice of model names to AliasEntry with the given source
+func toAliasEntries(names []string, source string) []domain.AliasEntry {
+	entries := make([]domain.AliasEntry, len(names))
+	for i, n := range names {
+		entries[i] = domain.AliasEntry{Name: n, Source: source}
+	}
+	return entries
 }

--- a/internal/app/handlers/handler_provider_common.go
+++ b/internal/app/handlers/handler_provider_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/thushan/olla/internal/adapter/registry"
 	"github.com/thushan/olla/internal/core/constants"
@@ -251,7 +252,8 @@ func (a *Application) convertModelsToProviderFormat(models []*domain.UnifiedMode
 // If ModelAliasesMode is "hidden" or "append", creates synthetic UnifiedModel entries
 // for each alias. In "hidden" mode, filters out target models that appear in any alias.
 func (a *Application) injectConfiguredAliases(ctx context.Context, models []*domain.UnifiedModel) []*domain.UnifiedModel {
-	if a.aliasResolver == nil || a.Config.ModelAliasesMode == constants.StickyOutcomeResultDisabled {
+	// An unset mode must behave like "disabled" to keep listings backward compatible.
+	if a.aliasResolver == nil || a.Config.ModelAliasesMode == "" || a.Config.ModelAliasesMode == constants.StickyOutcomeResultDisabled {
 		return models
 	}
 
@@ -264,9 +266,17 @@ func (a *Application) injectConfiguredAliases(ctx context.Context, models []*dom
 		}
 	}
 
+	// Map iteration order is randomised, so sort to keep listings stable across calls.
+	aliasNames := make([]string, 0, len(allAliases))
+	for aliasName := range allAliases {
+		aliasNames = append(aliasNames, aliasName)
+	}
+	sort.Strings(aliasNames)
+
 	// Create synthetic alias models
 	var aliasModels []*domain.UnifiedModel
-	for aliasName, targetNames := range allAliases {
+	for _, aliasName := range aliasNames {
+		targetNames := allAliases[aliasName]
 		var mergedEndpoints []domain.SourceEndpoint
 		var firstTarget *domain.UnifiedModel
 

--- a/internal/app/handlers/handler_provider_models_test.go
+++ b/internal/app/handlers/handler_provider_models_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thushan/olla/internal/adapter/converter"
 	"github.com/thushan/olla/internal/adapter/registry"
+	"github.com/thushan/olla/internal/config"
 	"github.com/thushan/olla/internal/core/constants"
 	"github.com/thushan/olla/internal/core/domain"
 	"github.com/thushan/olla/internal/logger"
@@ -343,6 +344,256 @@ func TestProviderModelFiltering(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &lmstudioResponse))
 	assert.Len(t, lmstudioResponse.Data, 1) // Only TheBloke model
 	assert.Equal(t, "TheBloke/Llama-2-7B-Chat-GGUF", lmstudioResponse.Data[0].ID)
+}
+
+// TestModelAliasesMode tests the model_aliases_mode configuration
+func TestModelAliasesMode(t *testing.T) {
+	// Setup logger
+	loggerCfg := &logger.Config{Level: "error", Theme: "default"}
+	log, _, _ := logger.New(loggerCfg)
+	styledLogger := logger.NewPlainStyledLogger(log)
+
+	// Create test endpoints
+	ollamaURL, _ := url.Parse("http://ollama:11434")
+	openaiURL, _ := url.Parse("http://openai:8080")
+
+	endpoints := []*domain.Endpoint{
+		{
+			Name:      "ollama-1",
+			URL:       ollamaURL,
+			URLString: ollamaURL.String(),
+			Status:    domain.StatusHealthy,
+			Type:      "ollama",
+		},
+		{
+			Name:      "openai-1",
+			URL:       openaiURL,
+			URLString: openaiURL.String(),
+			Status:    domain.StatusHealthy,
+			Type:      "openai",
+		},
+	}
+
+	// Create registry and register models
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
+	ctx := context.Background()
+
+	for _, ep := range endpoints {
+		unifiedRegistry.RegisterEndpoint(ep)
+	}
+
+	// Register models: llama3 on ollama, gpt-3.5-turbo on openai
+	require.NoError(t, unifiedRegistry.RegisterModelsWithEndpoint(ctx, endpoints[0], []*domain.ModelInfo{{Name: "llama3:latest"}}))
+	require.NoError(t, unifiedRegistry.RegisterModelsWithEndpoint(ctx, endpoints[1], []*domain.ModelInfo{{Name: "gpt-3.5-turbo"}}))
+
+	// Wait for async unification to complete
+	require.Eventually(t, func() bool {
+		models, err := unifiedRegistry.GetUnifiedModels(ctx)
+		return err == nil && len(models) >= 2
+	}, 5*time.Second, 10*time.Millisecond, "async unification did not complete")
+
+	// Create converter factory
+	converterFactory := converter.NewConverterFactory()
+
+	tests := []struct {
+		name               string
+		modelAliases       map[string][]string
+		modelAliasesMode   string
+		expectedModelCount int
+		expectedIDs        []string
+		notExpectedIDs     []string
+	}{
+		{
+			name: "disabled_mode_only_targets",
+			modelAliases: map[string][]string{
+				"my-llama": {"llama3:latest"},
+				"my-gpt":   {"gpt-3.5-turbo"},
+			},
+			modelAliasesMode:   "disabled",
+			expectedModelCount: 2, // only llama3:latest and gpt-3.5-turbo
+			expectedIDs:        []string{"llama3:latest", "gpt-3.5-turbo"},
+			notExpectedIDs:     []string{"my-llama", "my-gpt"},
+		},
+		{
+			name: "append_mode_both_aliases_and_targets",
+			modelAliases: map[string][]string{
+				"my-llama": {"llama3:latest"},
+				"my-gpt":   {"gpt-3.5-turbo"},
+			},
+			modelAliasesMode:   "append",
+			expectedModelCount: 4, // 2 targets + 2 aliases
+			expectedIDs:        []string{"llama3:latest", "gpt-3.5-turbo", "my-llama", "my-gpt"},
+			notExpectedIDs:     []string{},
+		},
+		{
+			name: "hidden_mode_only_aliases",
+			modelAliases: map[string][]string{
+				"my-llama": {"llama3:latest"},
+				"my-gpt":   {"gpt-3.5-turbo"},
+			},
+			modelAliasesMode:   "hidden",
+			expectedModelCount: 2, // only my-llama and my-gpt
+			expectedIDs:        []string{"my-llama", "my-gpt"},
+			notExpectedIDs:     []string{"llama3:latest", "gpt-3.5-turbo"},
+		},
+		{
+			name: "hidden_mode_multiple_targets_per_alias",
+			modelAliases: map[string][]string{
+				"my-gpt": {"gpt-3.5-turbo", "gpt-4"}, // gpt-4 not registered, should still work
+			},
+			modelAliasesMode:   "hidden",
+			expectedModelCount: 2, // my-gpt (alias) + llama3:latest (not a target of any alias)
+			expectedIDs:        []string{"my-gpt", "llama3:latest"},
+			notExpectedIDs:     []string{"gpt-3.5-turbo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create application with alias config
+			cfg := config.DefaultConfig()
+			cfg.ModelAliases = tt.modelAliases
+			cfg.ModelAliasesMode = tt.modelAliasesMode
+
+			aliasResolver := registry.NewAliasResolver(cfg.ModelAliases, styledLogger)
+
+			app := &Application{
+				modelRegistry:    unifiedRegistry,
+				repository:       &mockRepository{endpoints: endpoints},
+				converterFactory: converterFactory,
+				logger:           styledLogger,
+				aliasResolver:    aliasResolver,
+				Config:           cfg,
+			}
+
+			// Test /olla/proxy/v1/models (openai format)
+			req := httptest.NewRequest("GET", "/olla/proxy/v1/models", nil)
+			w := httptest.NewRecorder()
+			app.openaiModelsHandler(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, constants.ContentTypeJSON, w.Header().Get(constants.HeaderContentType))
+
+			var response converter.OpenAIModelResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			assert.Equal(t, "list", response.Object)
+
+			modelIDs := make([]string, len(response.Data))
+			for i, model := range response.Data {
+				modelIDs[i] = model.ID
+			}
+
+			// Check expected models are present
+			for _, id := range tt.expectedIDs {
+				assert.Contains(t, modelIDs, id, "expected model %s not found in %v", id, modelIDs)
+			}
+
+			// Check unexpected models are NOT present
+			for _, id := range tt.notExpectedIDs {
+				assert.NotContains(t, modelIDs, id, "unexpected model %s found in %v", id, modelIDs)
+			}
+
+			assert.Len(t, response.Data, tt.expectedModelCount, "model count mismatch for %s: got %d, want %d", tt.name, len(response.Data), tt.expectedModelCount)
+		})
+	}
+}
+
+// TestModelAliasesModeProviderSpecific tests that aliases work with provider-specific endpoints
+func TestModelAliasesModeProviderSpecific(t *testing.T) {
+	loggerCfg := &logger.Config{Level: "error", Theme: "default"}
+	log, _, _ := logger.New(loggerCfg)
+	styledLogger := logger.NewPlainStyledLogger(log)
+
+	ollamaURL, _ := url.Parse("http://ollama:11434")
+	lmstudioURL, _ := url.Parse("http://lmstudio:1234")
+
+	endpoints := []*domain.Endpoint{
+		{
+			Name:      "ollama-1",
+			URL:       ollamaURL,
+			URLString: ollamaURL.String(),
+			Status:    domain.StatusHealthy,
+			Type:      "ollama",
+		},
+		{
+			Name:      "lmstudio-1",
+			URL:       lmstudioURL,
+			URLString: lmstudioURL.String(),
+			Status:    domain.StatusHealthy,
+			Type:      "lm-studio",
+		},
+	}
+
+	unifiedRegistry := registry.NewUnifiedMemoryModelRegistry(styledLogger, nil, nil, nil)
+	ctx := context.Background()
+
+	for _, ep := range endpoints {
+		unifiedRegistry.RegisterEndpoint(ep)
+	}
+
+	// Register different models on different providers
+	require.NoError(t, unifiedRegistry.RegisterModelsWithEndpoint(ctx, endpoints[0], []*domain.ModelInfo{{Name: "llama3:latest"}}))
+	require.NoError(t, unifiedRegistry.RegisterModelsWithEndpoint(ctx, endpoints[1], []*domain.ModelInfo{{Name: "TheBloke/Llama-2-7B-Chat-GGUF"}}))
+
+	require.Eventually(t, func() bool {
+		models, err := unifiedRegistry.GetUnifiedModels(ctx)
+		return err == nil && len(models) >= 2
+	}, 5*time.Second, 10*time.Millisecond, "async unification did not complete")
+
+	converterFactory := converter.NewConverterFactory()
+
+	cfg := config.DefaultConfig()
+	cfg.ModelAliases = map[string][]string{
+		"my-llama": {"llama3:latest", "TheBloke/Llama-2-7B-Chat-GGUF"},
+	}
+	cfg.ModelAliasesMode = "hidden"
+
+	aliasResolver := registry.NewAliasResolver(cfg.ModelAliases, styledLogger)
+
+	app := &Application{
+		modelRegistry:    unifiedRegistry,
+		repository:       &mockRepository{endpoints: endpoints},
+		converterFactory: converterFactory,
+		logger:           styledLogger,
+		aliasResolver:    aliasResolver,
+		Config:           cfg,
+	}
+
+	// Test /olla/ollama/v1/models - should show my-llama since it has targets on ollama
+	req := httptest.NewRequest("GET", "/olla/ollama/v1/models", nil)
+	w := httptest.NewRecorder()
+	app.ollamaOpenAIModelsHandler(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var ollamaResponse converter.OpenAIModelResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ollamaResponse))
+
+	ollamaIDs := make([]string, len(ollamaResponse.Data))
+	for i, m := range ollamaResponse.Data {
+		ollamaIDs[i] = m.ID
+	}
+	assert.Contains(t, ollamaIDs, "my-llama", "alias should appear in ollama endpoint")
+	assert.NotContains(t, ollamaIDs, "llama3:latest", "target should be hidden in hidden mode")
+	assert.NotContains(t, ollamaIDs, "TheBloke/Llama-2-7B-Chat-GGUF", "target should be hidden in hidden mode")
+
+	// Test /olla/lmstudio/v1/models - should show my-llama since it has targets on lmstudio
+	req = httptest.NewRequest("GET", "/olla/lmstudio/v1/models", nil)
+	w = httptest.NewRecorder()
+	app.lmstudioOpenAIModelsHandler(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var lmstudioResponse converter.OpenAIModelResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &lmstudioResponse))
+
+	lmstudioIDs := make([]string, len(lmstudioResponse.Data))
+	for i, m := range lmstudioResponse.Data {
+		lmstudioIDs[i] = m.ID
+	}
+	assert.Contains(t, lmstudioIDs, "my-llama", "alias should appear in lmstudio endpoint")
+	assert.NotContains(t, lmstudioIDs, "llama3:latest", "target should be hidden in hidden mode")
+	assert.NotContains(t, lmstudioIDs, "TheBloke/Llama-2-7B-Chat-GGUF", "target should be hidden in hidden mode")
 }
 
 // TestUnifiedModelsFormatFiltering tests that format parameter filters models by provider

--- a/internal/app/handlers/handler_provider_models_test.go
+++ b/internal/app/handlers/handler_provider_models_test.go
@@ -409,7 +409,7 @@ func TestModelAliasesMode(t *testing.T) {
 				"my-llama": {"llama3:latest"},
 				"my-gpt":   {"gpt-3.5-turbo"},
 			},
-			modelAliasesMode:   "disabled",
+			modelAliasesMode:   constants.StickyOutcomeResultDisabled,
 			expectedModelCount: 2, // only llama3:latest and gpt-3.5-turbo
 			expectedIDs:        []string{"llama3:latest", "gpt-3.5-turbo"},
 			notExpectedIDs:     []string{"my-llama", "my-gpt"},

--- a/internal/app/handlers/handler_proxy.go
+++ b/internal/app/handlers/handler_proxy.go
@@ -469,7 +469,7 @@ func (a *Application) logRequestResult(pr *proxyRequest, err error) {
 		}
 
 		// "disabled" carries no signal; omit it to avoid noise in deployments without sticky sessions
-		if pr.stickyOutcome != "" && pr.stickyOutcome != "disabled" {
+		if pr.stickyOutcome != "" && pr.stickyOutcome != constants.StickyOutcomeResultDisabled {
 			infoFields = append(infoFields, "sticky_outcome", pr.stickyOutcome)
 		}
 

--- a/internal/app/handlers/handler_proxy_alias_test.go
+++ b/internal/app/handlers/handler_proxy_alias_test.go
@@ -516,3 +516,177 @@ func TestResolveAliasEndpoints_IntegrationWithFilterEndpointsByProfile(t *testin
 	require.NotNil(t, profile.RoutingDecision)
 	assert.Equal(t, "alias", profile.RoutingDecision.Strategy)
 }
+
+// TestResolveAliasEndpoints_FallbackToSecondTarget tests that when the first
+// target model in an alias is not available on any healthy endpoint, the
+// second target is tried (config order = priority)
+func TestResolveAliasEndpoints_FallbackToSecondTarget(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://ollama:11434")
+	endpoint2URL, _ := url.Parse("http://lmstudio:1234")
+	endpoint3URL, _ := url.Parse("http://openai:8080")
+
+	// All three endpoints are healthy candidates
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "ollama",
+			URL:       endpoint1URL,
+			URLString: "http://ollama:11434",
+			Type:      domain.ProfileOllama,
+		},
+		{
+			Name:      "lmstudio",
+			URL:       endpoint2URL,
+			URLString: "http://lmstudio:1234",
+			Type:      domain.ProfileLmStudio,
+		},
+		{
+			Name:      "openai",
+			URL:       endpoint3URL,
+			URLString: "http://openai:8080",
+			Type:      domain.ProfileOpenAI,
+		},
+	}
+
+	// Alias has two targets: gpt-3.5-turbo (first priority) and gpt-4 (fallback)
+	// Only gpt-4 is available on any endpoint (openai)
+	// The alias should resolve to openai endpoint with gpt-4
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{
+			"gpt-3.5-turbo": {"http://unhealthy:9999"}, // not in candidates (unhealthy)
+			"gpt-4":         {"http://openai:8080"},
+		},
+	}
+
+	aliases := map[string][]string{
+		"my-gpt": {"gpt-3.5-turbo", "gpt-4"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: modelRegistry,
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "my-gpt"
+	profile.SupportedBy = []string{domain.ProfileOpenAI, domain.ProfileOllama, domain.ProfileLmStudio}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	// Should return only the openai endpoint (which has gpt-4)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "http://openai:8080", result[0].URLString)
+
+	// Verify the rewrite map uses gpt-4 for the openai endpoint
+	aliasMapRaw, ok := profile.InspectionMeta.Load(constants.ContextModelAliasMapKey)
+	require.True(t, ok)
+	aliasMap := aliasMapRaw.(map[string]string)
+	assert.Equal(t, "gpt-4", aliasMap["http://openai:8080"])
+}
+
+// TestResolveAliasEndpoints_FallbackToSecondTargetOnSameEndpoint tests fallback
+// when both targets are on the same endpoint but first is unavailable
+func TestResolveAliasEndpoints_FallbackToSecondTargetOnSameEndpoint(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://openai:8080")
+
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "openai",
+			URL:       endpoint1URL,
+			URLString: "http://openai:8080",
+			Type:      domain.ProfileOpenAI,
+		},
+	}
+
+	// Both targets on the same endpoint, but first is "unavailable"
+	// The mock registry will only return endpoints for gpt-4
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{
+			// gpt-3.5-turbo not listed = not available
+			"gpt-4": {"http://openai:8080"},
+		},
+	}
+
+	aliases := map[string][]string{
+		"my-gpt": {"gpt-3.5-turbo", "gpt-4"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: modelRegistry,
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "my-gpt"
+	profile.SupportedBy = []string{domain.ProfileOpenAI}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	// Should return the openai endpoint with gpt-4
+	assert.Len(t, result, 1)
+	assert.Equal(t, "http://openai:8080", result[0].URLString)
+
+	aliasMapRaw, ok := profile.InspectionMeta.Load(constants.ContextModelAliasMapKey)
+	require.True(t, ok)
+	aliasMap := aliasMapRaw.(map[string]string)
+	assert.Equal(t, "gpt-4", aliasMap["http://openai:8080"])
+}
+
+// TestResolveAliasEndpoints_TargetOrderMatters tests that config order determines
+// priority - first target wins when both are available on the same endpoint
+func TestResolveAliasEndpoints_TargetOrderMatters(t *testing.T) {
+	styledLog := &mockStyledLogger{}
+
+	endpoint1URL, _ := url.Parse("http://openai:8080")
+
+	candidates := []*domain.Endpoint{
+		{
+			Name:      "openai",
+			URL:       endpoint1URL,
+			URLString: "http://openai:8080",
+			Type:      domain.ProfileOpenAI,
+		},
+	}
+
+	// Both targets available on the same endpoint
+	modelRegistry := &mockSimpleModelRegistry{
+		endpointsForModel: map[string][]string{
+			"gpt-3.5-turbo": {"http://openai:8080"},
+			"gpt-4":         {"http://openai:8080"},
+		},
+	}
+
+	// gpt-3.5-turbo is first in config, so it should win for the endpoint
+	aliases := map[string][]string{
+		"my-gpt": {"gpt-3.5-turbo", "gpt-4"},
+	}
+	aliasResolver := registry.NewAliasResolver(aliases, styledLog)
+
+	app := &Application{
+		modelRegistry: modelRegistry,
+		aliasResolver: aliasResolver,
+		logger:        styledLog,
+	}
+
+	profile := domain.NewRequestProfile("/v1/chat/completions")
+	profile.ModelName = "my-gpt"
+	profile.SupportedBy = []string{domain.ProfileOpenAI}
+
+	result := app.resolveAliasEndpoints(t.Context(), profile, candidates, styledLog)
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, "http://openai:8080", result[0].URLString)
+
+	// First target in config should win
+	aliasMapRaw, ok := profile.InspectionMeta.Load(constants.ContextModelAliasMapKey)
+	require.True(t, ok)
+	aliasMap := aliasMapRaw.(map[string]string)
+	assert.Equal(t, "gpt-3.5-turbo", aliasMap["http://openai:8080"])
+}

--- a/internal/app/handlers/handler_proxy_logging_test.go
+++ b/internal/app/handlers/handler_proxy_logging_test.go
@@ -89,7 +89,7 @@ func TestLogRequestResult_StickyOutcome_OmittedWhenDisabled(t *testing.T) {
 
 	cl := &capturingLogger{}
 	pr := makeTestPR(cl)
-	pr.stickyOutcome = "disabled"
+	pr.stickyOutcome = constants.StickyOutcomeResultDisabled
 
 	app := &Application{logger: cl}
 	app.logRequestResult(pr, nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,6 +163,7 @@ func DefaultConfig() *Config {
 			// The field ships now so a later change needs no config migration.
 			GateInternalAPI: false,
 		},
+		ModelAliasesMode: "disabled",
 		Translators: TranslatorsConfig{
 			Anthropic: AnthropicTranslatorConfig{
 				Enabled:            true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1052,6 +1052,37 @@ func TestValidateModelAliases_SelfReferencingAlias(t *testing.T) {
 	}
 }
 
+func TestValidateModelAliasesMode_Invalid(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ModelAliases = map[string][]string{"test": {"model1"}}
+	cfg.ModelAliasesMode = "invalid"
+	err := cfg.ValidateModelAliases()
+	if err == nil {
+		t.Error("expected error for invalid model_aliases_mode")
+	}
+}
+
+func TestValidateModelAliasesMode_Valid(t *testing.T) {
+	for _, mode := range []string{"disabled", "append", "hidden"} {
+		cfg := DefaultConfig()
+		cfg.ModelAliases = map[string][]string{"test": {"model1"}}
+		cfg.ModelAliasesMode = mode
+		err := cfg.ValidateModelAliases()
+		if err != nil {
+			t.Errorf("expected no error for valid mode %q, got: %v", mode, err)
+		}
+	}
+}
+
+func TestValidateModelAliasesMode_EmptyNoAliases(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ModelAliasesMode = "disabled"
+	err := cfg.ValidateModelAliases()
+	if err != nil {
+		t.Errorf("expected no error for empty aliases with mode, got: %v", err)
+	}
+}
+
 // TestDefaultConfig_ModelDiscovery verifies the ModelDiscovery block is
 // populated with safe, non-zero defaults so the ticker and errgroup won't panic
 // on a fresh install.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -26,16 +26,23 @@ type Config struct {
 	//       - gpt-oss:120b
 	//       - gpt-oss-120b-MLX
 	//       - gguf_gpt_oss_120b.gguf
-	ModelAliases  map[string][]string `yaml:"model_aliases,omitempty"`
-	Logging       LoggingConfig       `yaml:"logging"`
-	Filename      string              `yaml:"-"`
-	Dashboard     DashboardConfig     `yaml:"dashboard"`
-	Translators   TranslatorsConfig   `yaml:"translators"`
-	ModelRegistry ModelRegistryConfig `yaml:"model_registry"`
-	Discovery     DiscoveryConfig     `yaml:"discovery"`
-	Proxy         ProxyConfig         `yaml:"proxy"`
-	Server        ServerConfig        `yaml:"server"`
-	Engineering   EngineeringConfig   `yaml:"engineering"`
+	ModelAliases map[string][]string `yaml:"model_aliases,omitempty"`
+
+	// ModelAliasesMode controls whether configured aliases appear in model listings
+	// and whether their target models are hidden. Valid values: "disabled", "append", "hidden".
+	// - "disabled": aliases are not shown in model listings (default, backward compatible)
+	// - "append": aliases are added to listings alongside their target models
+	// - "hidden": aliases are shown in listings, target models are hidden
+	ModelAliasesMode string              `yaml:"model_aliases_mode,omitempty"`
+	Logging          LoggingConfig       `yaml:"logging"`
+	Filename         string              `yaml:"-"`
+	Dashboard        DashboardConfig     `yaml:"dashboard"`
+	Translators      TranslatorsConfig   `yaml:"translators"`
+	ModelRegistry    ModelRegistryConfig `yaml:"model_registry"`
+	Discovery        DiscoveryConfig     `yaml:"discovery"`
+	Proxy            ProxyConfig         `yaml:"proxy"`
+	Server           ServerConfig        `yaml:"server"`
+	Engineering      EngineeringConfig   `yaml:"engineering"`
 }
 
 // CorsConfig controls browser cross-origin access to the Olla API.
@@ -546,8 +553,24 @@ func (c *AnthropicTranslatorConfig) Validate() error {
 // Returns an error for invalid configurations that would cause runtime failures.
 // Logs warnings for non-fatal issues like duplicate model names.
 func (c *Config) ValidateModelAliases() error {
-	if len(c.ModelAliases) == 0 {
+	if len(c.ModelAliases) == 0 && c.ModelAliasesMode == "" {
 		return nil // no aliases configured, nothing to validate
+	}
+
+	// Validate model_aliases_mode if set
+	if c.ModelAliasesMode != "" {
+		validModes := map[string]bool{
+			"disabled": true,
+			"append":   true,
+			"hidden":   true,
+		}
+		if !validModes[c.ModelAliasesMode] {
+			return fmt.Errorf("invalid model_aliases_mode %q: must be one of disabled, append, hidden", c.ModelAliasesMode)
+		}
+	}
+
+	if len(c.ModelAliases) == 0 {
+		return nil
 	}
 
 	for aliasName, actualModels := range c.ModelAliases {

--- a/internal/core/constants/routing.go
+++ b/internal/core/constants/routing.go
@@ -32,6 +32,9 @@ const (
 	RoutingReasonDiscoveryError                = "discovery_error"
 )
 
+// StickyOutcomeResultDisabled indicates sticky sessions are not in use.
+const StickyOutcomeResultDisabled = "disabled"
+
 // Fallback behavior constants for routing strategies
 const (
 	// FallbackBehaviorNone never falls back to other endpoints

--- a/internal/core/constants/routing.go
+++ b/internal/core/constants/routing.go
@@ -32,7 +32,10 @@ const (
 	RoutingReasonDiscoveryError                = "discovery_error"
 )
 
-// StickyOutcomeResultDisabled indicates sticky sessions are not in use.
+// StickyOutcomeResultDisabled is the sentinel StickySessionWrapper.Select sets
+// on the StickyOutcome when no affinity key exists on the context; the value is
+// returned in X-Olla-Sticky-Session but omitted from INFO request logs because
+// it carries no actionable signal.
 const StickyOutcomeResultDisabled = "disabled"
 
 // Fallback behavior constants for routing strategies


### PR DESCRIPTION
## Summary

Add model_aliases_mode configuration to control alias visibility in model listing endpoints with three modes:
- disabled (default): aliases hidden, only target models shown
- append: aliases shown alongside target models
- hidden: aliases shown, target models hidden (accessible by direct request)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Backend / integration support
- [ ] Documentation
- [ ] Refactor / internal (no behaviour change)

## How was this tested?

- Written unit tests for all three model alias modes (disabled/append/hidden) and verified they pass.
- Tested provider-specific alias filtering and endpoint resolution fallback scenarios.
- Built Docker image locally and ran with custom configuration to validate feature works end-to-end.

## Checklist

- [x] `make ready` passes (test-short + test-race + fmt + vet + lint + align)
- [x] Tests added or updated for the change
- [x] Documentation updated (`./docs`) if behaviour or config changed
- [x] No new dependencies added (or called out and justified below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable visibility for model aliases in model listings.
  * Supports `disabled` (default), `append`, and `hidden` modes across general and provider-specific listings.
  * Alias routing now falls back to the next available target while respecting configured target order.

* **Documentation**
  * Added configuration guidance, examples, and API details for model alias visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->